### PR TITLE
Define Phase 1 architecture, skills, and validation strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ Route based on what the user says:
 **They describe a product idea** ("I want to build an app that...", "let's make a tool for...", "I have an idea for..."):
 → They want to USE Prawduct. Read `skills/orchestrator/SKILL.md` and follow its instructions. The Orchestrator handles everything from here — classification, discovery, product definition, artifact generation, and review. **Important:** The Orchestrator will set up a separate project directory for their files. Never write project output into this framework directory.
 
-**They reference framework internals** ("fix the domain analyzer", "update the rubric", "work on Phase 2"):
-→ They want to BUILD Prawduct itself. Follow the framework development instructions below.
+**They reference framework internals or want to work on this project** ("fix the domain analyzer", "update the rubric", "work on Phase 2", "what should I work on next?", "run the eval", "I want to contribute"):
+→ They want to BUILD Prawduct itself. Follow the framework development instructions below. Use the V1 Build Order and current project state to orient.
 
 **Their intent is unclear** ("let's go!", "hello", "what can you do?"):
 → Explain what Prawduct does and ask what they'd like to build. Something like:
@@ -93,7 +93,9 @@ The rest of this file is for building Prawduct itself — the skills, templates,
 1. Read `docs/principles.md` — these are your hard rules. Never violate them.
 2. Read `docs/requirements.md` — focus on [v1] tagged items.
 3. Read `docs/high-level-design.md` — understand the components and their interactions.
-4. Apply the framework to itself. Every decision needs rationale. Every artifact needs tests. Documentation follows the tier system.
+4. Check the V1 Build Order (below) to understand the current phase and what's already been built. Compare it against the actual files in `skills/`, `templates/`, and `tests/scenarios/` to see the current state.
+5. To run an evaluation, see `tests/scenarios/` — each scenario has an Evaluation Procedure section with setup, run, and evaluation steps.
+6. Apply the framework to itself. Every decision needs rationale. Every artifact needs tests. Documentation follows the tier system.
 
 ## Key Principles (read `docs/principles.md` for the full set)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,13 @@ prawduct/
 │       ├── party-experience-spec.md   # Per-party template
 │       ├── party-interaction-model.md
 │       └── migration-adoption-plan.md
+├── tests/                             # Evaluation rubrics for skill validation
+│   └── scenarios/                     # Per-scenario test definitions (Tier 1)
+│       ├── family-utility.md          # Phase 1 vertical slice scenario
+│       ├── consumer-mobile-app.md     # Phase 2
+│       ├── background-data-pipeline.md # Phase 2
+│       ├── b2b-integration-api.md     # Phase 2
+│       └── two-sided-marketplace.md   # Phase 2
 ├── docs/                              # This project's own Tier 1 documentation
 │   ├── vision.md
 │   ├── requirements.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,25 +89,41 @@ These are the ones most likely to be violated under pressure:
 
 ## V1 Build Order
 
-Components, in recommended implementation order:
+Build as a vertical slice, not component-by-component. See `docs/high-level-design.md` § "Bootstrapping: Vertical Slice Approach" for the full rationale.
 
-1. **C2: Domain Analyzer** (`skills/domain-analyzer/SKILL.md`) — The most novel piece. Start here. Test against diverse product ideas.
-2. **C1: Orchestrator** (`skills/orchestrator/SKILL.md`) — Conversation flow, stage management, calibration. Depends on C2.
-3. **C3: Artifact Generator** (`skills/artifact-generator/SKILL.md`) — Templates and generation logic. Start with universal artifacts, add shape-specific ones.
-4. **C5: Project State** (`templates/project-state.yaml`) — Schema design. Define what gets tracked and how.
-5. **C4: Review Lenses** (`skills/review-lenses/SKILL.md`) — May merge into critic skill. Build and evaluate.
-6. **Mechanical tools** (`tools/`) — Test integrity, doc validation, boundary checking. Satisfying because they're deterministic.
-7. **C6: Critic** (`skills/critic/SKILL.md`) — Combines LLM judgment with mechanical tool invocations.
+### Phase 1: Prove the Path (one scenario end-to-end)
+
+Use the **family utility** test scenario (simple UI app, low risk). Build just enough of each component to handle this one case through the full pipeline:
+
+1. **C5: Project State** (`templates/project-state.yaml`) — Define the schema first. Everything else reads/writes this.
+2. **C2: Domain Analyzer** (`skills/domain-analyzer/SKILL.md`) — Classify "UI Application" + "Utility." Generate discovery questions for this combination only.
+3. **C1: Orchestrator** (`skills/orchestrator/SKILL.md`) — Manage stages 0 → 0.5 → 1 → 2 for this one scenario.
+4. **C3: Artifact Generator** (`skills/artifact-generator/SKILL.md`) — Generate universal artifacts only (product brief, data model, security model, test specs, NFRs, operational spec, dependency manifest).
+5. **C4: Review Lenses** (`skills/review-lenses/SKILL.md`) — Apply all four lenses to the generated artifacts.
+
+**Evaluate against the family utility test scenario rubric** (see `docs/high-level-design.md` § "Validation Strategy for Skills"). Phase 1 succeeds when the end-to-end flow produces useful, consistent output from a vague input.
+
+### Phase 2: Widen
+
+- Add product shapes one at a time (automation → API → multi-party), evaluating each against its test scenario rubric.
+- Add shape-specific artifacts and templates as each shape is added.
+- Build mechanical tools (`tools/`).
+- Build the Critic (C6) — start with spec compliance + test integrity.
+- Add Orchestrator sophistication (pacing, expertise calibration, pushback).
+
+### Phase 3: Full V1
+
+All v1 requirements, all five test scenarios passing, framework governing its own development.
 
 C7 (Trajectory Monitor) and C8 (Learning System) are post-v1. Accommodate them architecturally but don't build them yet.
 
 ## Testing Strategy for This Project
 
-Since this project is a framework of skills and tools (not a traditional application), testing looks different:
+Since this project is a framework of skills and tools (not a traditional application), testing looks different. See `docs/high-level-design.md` § "Validation Strategy for Skills" for the full approach.
 
-- **Skills:** Test by running them against diverse product scenarios. Minimum test scenarios: a consumer mobile app, a background automation, a B2B API, a simple family utility, and a multi-party platform. Evaluate whether the skill asks the right questions, produces good artifacts, and catches problems.
+- **Skills:** Test against five defined product scenarios with evaluation rubrics specifying must-do, must-not-do, and quality criteria. "Good" is not a test — specific, observable criteria are. The five scenarios: consumer mobile app, background automation, B2B API, family utility, two-sided marketplace.
 - **Mechanical tools:** Standard unit/integration tests. Feed them known-good and known-bad project states and verify correct detection.
-- **End-to-end:** Take a product idea from raw input through to build plan using the full framework. Evaluate the build plan's quality. This is the compiler-compiles-itself test.
+- **End-to-end:** Take a product idea from raw input through to build plan using the full framework. Evaluate the build plan against its scenario rubric. The compiler-compiles-itself test: run Prawduct through Prawduct.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,24 @@
 
 ## What This Project Is
 
-Prawduct is a framework that turns vague product ideas into well-built software. It does this by guiding structured discovery, producing agent-executable build plans, and enforcing quality throughout development. You (Claude) are both the builder of this framework and its primary runtime.
+Prawduct is a framework that turns vague product ideas into well-built software. It does this by guiding structured discovery, producing agent-executable build plans, and enforcing quality throughout development. You (Claude) are its primary runtime — you read these skills and follow their instructions to help users build products.
 
-Read `docs/vision.md` for the full picture. Read `docs/principles.md` before making any decisions — it contains the hard rules.
+## When Someone Opens This Directory
+
+Route based on what the user says:
+
+**They describe a product idea** ("I want to build an app that...", "let's make a tool for...", "I have an idea for..."):
+→ They want to USE Prawduct. Read `skills/orchestrator/SKILL.md` and follow its instructions. The Orchestrator handles everything from here — classification, discovery, product definition, artifact generation, and review. **Important:** The Orchestrator will set up a separate project directory for their files. Never write project output into this framework directory.
+
+**They reference framework internals** ("fix the domain analyzer", "update the rubric", "work on Phase 2"):
+→ They want to BUILD Prawduct itself. Follow the framework development instructions below.
+
+**Their intent is unclear** ("let's go!", "hello", "what can you do?"):
+→ Explain what Prawduct does and ask what they'd like to build. Something like:
+
+> "Prawduct helps turn a product idea into a clear, detailed build plan. Tell me what you want to build — even a rough idea is fine — and I'll guide you through some questions about who it's for and what matters most. Then I'll produce a set of artifacts (product brief, data model, security model, test specs, and more) that a developer or coding agent can use to start building. What would you like to build?"
+
+If they then describe a product, route to the Orchestrator. If they want to work on the framework, follow the framework development instructions.
 
 ## Project Structure
 
@@ -70,19 +85,15 @@ prawduct/
     └── .gitkeep
 ```
 
-## How to Work on This Project
+## Framework Development
 
-### If you're building Prawduct itself:
+The rest of this file is for building Prawduct itself — the skills, templates, tools, and docs that make up the framework. If you're here to USE Prawduct to build a product, you don't need any of this; the Orchestrator skill handles it (see "When Someone Opens This Directory" above).
+
+### Getting started on framework development:
 1. Read `docs/principles.md` — these are your hard rules. Never violate them.
 2. Read `docs/requirements.md` — focus on [v1] tagged items.
 3. Read `docs/high-level-design.md` — understand the components and their interactions.
 4. Apply the framework to itself. Every decision needs rationale. Every artifact needs tests. Documentation follows the tier system.
-
-### If you're using Prawduct to build a user's product:
-1. Read the orchestrator skill: `skills/orchestrator/SKILL.md`
-2. It will tell you what other skills to invoke and when.
-3. The general flow is: classify → validate → discover → define → generate artifacts → build → govern → iterate.
-4. User project files go in a separate project directory, not in the prawduct tree.
 
 ## Key Principles (read `docs/principles.md` for the full set)
 

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -446,6 +446,133 @@ Project State
 
 ---
 
+## Skill Interaction Model
+
+Components in the Conversation, Production, and Quality layers are implemented as LLM instruction sets (SKILL.md files) operating within a single LLM context. They are not separate services or agents. Understanding how they interact is essential to implementation.
+
+### Execution Model
+
+The LLM operates under one skill's instructions at a time. The Orchestrator (C1) is the default active skill and manages transitions to other skills as needed.
+
+**Interaction patterns:**
+
+- **Skill switching:** The Orchestrator loads another skill's instructions when entering that skill's domain (e.g., loads Domain Analyzer instructions during classification). The Orchestrator's framing context persists.
+- **Shared state via files:** Project State (C5) is a YAML file in the project directory. All skills read from and write to this shared state. This is the primary coordination mechanism.
+- **Artifact I/O:** Generated artifacts are markdown files with YAML frontmatter. Skills produce and consume these files.
+- **Tool invocation:** Mechanical tools (test integrity checker, boundary checker, etc.) are shell scripts invoked by the LLM during governance phases. Their output feeds back into the LLM's evaluation.
+
+### Persistence Model (V1)
+
+Project state persists as files in the user's project directory:
+
+- `project-state.yaml` — Master state file (C5)
+- `doc-manifest.yaml` — Documentation tier tracking
+- `artifacts/` — Generated artifacts (markdown with YAML frontmatter)
+- `working-notes/` — Ephemeral Tier 3 documents
+
+This is intentionally simple: files are human-readable, version-controllable, and require no infrastructure. The LLM reads these files at session start and writes them as decisions are made. This is a reversible choice — if file-based persistence proves insufficient, migration to a structured store is straightforward because the schema is already defined in C5.
+
+### Artifact Format (V1)
+
+Each artifact is a markdown file with structured YAML frontmatter:
+
+```yaml
+---
+artifact: product-brief
+version: 1
+depends_on:
+  - artifact: project-state
+    section: product-definition
+depended_on_by:
+  - artifact: data-model
+  - artifact: information-architecture
+last_validated: null  # populated during build phase
+---
+
+# Product Brief
+
+[Human-readable content here]
+```
+
+The body is readable by both humans and LLMs. The frontmatter enables mechanical dependency tracking and change propagation. This format is a starting hypothesis — if it proves insufficient during the vertical slice, it changes.
+
+---
+
+## Validation Strategy for Skills
+
+Skills (LLM instruction sets) produce non-deterministic outputs. This doesn't excuse them from testability — it requires a different kind of testing. Per "Define Testability for Judgment-Dependent Outputs" (principles.md), evaluation rubrics with specific, observable criteria must be defined before building.
+
+### Scenario-Based Evaluation
+
+Each skill is tested against a defined set of product scenarios. For each scenario, the evaluation rubric specifies:
+
+- **Input:** A product description with known characteristics.
+- **Must-do:** Things the skill must do (e.g., "must classify as automation/pipeline," "must ask about failure recovery," "must surface monitoring as a concern").
+- **Must-not-do:** Things the skill must avoid (e.g., "must not ask about screen layouts for a pipeline," "must not recommend not building without stated reason").
+- **Quality criteria:** Specific, observable markers of good output (e.g., "questions are prioritized by impact, not presented as a flat list," "pushback includes rationale, not just disagreement").
+
+### Minimum Test Scenarios
+
+Five scenarios that cover the product shape taxonomy:
+
+1. **Consumer mobile app** (UI Application) — tests screen-related discovery, accessibility, onboarding, platform considerations.
+2. **Background data pipeline** (Automation) — tests operational concerns, monitoring, failure recovery, cost awareness. Tests that the system does *not* ask about screens or navigation.
+3. **B2B integration API** (API/Service) — tests contract design, versioning, consumer needs, SLAs. Tests expertise calibration for a technical user.
+4. **Simple family utility** (UI Application, low risk) — tests pacing sensitivity, scope restraint. The system should *not* interrogate this the same way it interrogates a B2B platform.
+5. **Two-sided marketplace** (Multi-Party + UI + API hybrid) — tests multi-party discovery, per-party needs, cross-party interactions, trust boundaries.
+
+### Regression Detection
+
+When a skill is modified, all scenarios are re-evaluated. A regression is:
+
+- A must-do item that previously passed now failing.
+- A must-not-do item that previously passed now triggering.
+- Quality criteria that previously held now absent.
+
+This is judgment-based evaluation, not mechanical. But it has structure, and structure enables regression detection even for non-deterministic outputs. Over time, as patterns stabilize, some evaluations may become partially mechanizable (e.g., checking that specific keywords or topics appear in output).
+
+---
+
+## Bootstrapping: Vertical Slice Approach
+
+Per "Prove the Path Before Widening It" (principles.md), the system itself is built as a narrow vertical slice first, then widened. This replaces the component-by-component build order with a path-first approach.
+
+### Phase 1: One Path Through the System
+
+Pick one product scenario (the family utility — a simple UI application with low risk) and build just enough of each component to handle it end-to-end:
+
+1. **C5 (Project State):** Define the schema first — everything else reads/writes this. Validate that the structure captures what discovery and artifact generation need.
+2. **C2 (Domain Analyzer):** Classify "UI Application" + "Utility" domain. Generate discovery questions for this combination only.
+3. **C1 (Orchestrator):** Manage a discovery conversation for this one scenario. Handle stage transitions 0 → 0.5 → 1 → 2.
+4. **C3 (Artifact Generator):** Generate the universal artifact set (product brief, data model, security model, test specs, NFRs, operational spec, dependency manifest). Skip shape-specific artifacts initially.
+5. **C4 (Review Lenses):** Apply all four lenses to the generated artifacts. Evaluate whether findings are specific and actionable.
+
+**Evaluate against the family utility test scenario rubric.** The vertical slice succeeds when:
+- The conversation flow produces a populated Project State from a vague input.
+- The artifacts are internally consistent and cross-referenced.
+- The Review Lenses produce specific, actionable findings (not vague impressions).
+- A human reading the output would consider it a plausible starting point for building.
+
+**What this proves:** That the skill interaction model works, that the artifact format is adequate, that Project State captures enough, and that the end-to-end flow produces something useful.
+
+**What this defers:** Other product shapes, shape-specific artifacts, the Critic (C6), pacing sensitivity, prior art search, expertise calibration beyond basic, and mechanical tools.
+
+### Phase 2: Widen Based on Phase 1 Findings
+
+After Phase 1 validates (or forces revision of) the architecture:
+
+- Add product shapes one at a time (automation, then API, then multi-party), evaluating against their respective test scenario rubrics.
+- Add shape-specific artifacts as each shape is added.
+- Build mechanical tools (test integrity, doc validation, boundary checking).
+- Build the Critic (C6) — start with spec compliance + test integrity.
+- Add sophistication to the Orchestrator (pacing, expertise calibration, pushback).
+
+### Phase 3: Full V1
+
+All v1 requirements implemented, all five test scenarios passing evaluation rubrics, the system used to govern its own development. The "compiler compiles itself" test: take Prawduct's own product idea through the full framework and evaluate whether the resulting build plan would produce this system.
+
+---
+
 ## Documentation Architecture
 
 All projects (including this one) follow a three-tier system:
@@ -493,10 +620,15 @@ Surfaces during discovery (C2 flags cost-relevant design choices), quantified du
 
 These are acknowledged gaps that require further work. Per our own principles, we're documenting them rather than pretending they don't exist.
 
-1. **Artifact format specification.** What exactly does each artifact look like? Schema definitions, examples, and validation rules for each artifact type are needed before implementation.
-2. **Agent communication protocol.** How does the build plan get handed to the coding agent? What's the handoff format? How does the agent report back? This is critical for the build governance loop.
-3. **Persistence and session management.** How is Project State stored across sessions? What if the user returns after weeks?
-4. **Multi-user collaboration.** Current design assumes single user. Team scenarios need coordination design.
-5. **Product shapes we haven't tested.** Games, content platforms, developer tools, IoT-adjacent, data-intensive products. The taxonomy may need expansion.
-6. **Minimum viable Critic.** What's the smallest useful Critic for v1? Likely: spec compliance + test integrity + doc controller. Architectural consistency and operational readiness can follow.
-7. **Bootstrapping.** The system itself needs to be built. What's the build order for our own components? Likely: C2 → C1 → C3 → C5 → C4 → C6, with C7 and C8 later.
+### Resolved
+
+1. **~~Artifact format specification.~~** V1 format defined: markdown files with YAML frontmatter for dependency tracking and metadata. See "Artifact Format (V1)" section above. Per-artifact schema definitions and examples will be validated during the vertical slice — the format is a hypothesis, not a commitment.
+2. **~~Agent communication protocol.~~** V1 answer: the LLM *is* both the framework and the coding agent. Skills switch context within a single LLM session. Artifacts are files in the project directory. The "handoff" is the LLM reading its own generated build plan. See "Skill Interaction Model" section above. This will need revisiting for agent agnosticism (R7.3, v1.5).
+3. **~~Persistence and session management.~~** V1 answer: file-based persistence in the project directory. See "Persistence Model (V1)" section above. Session resumption = LLM reads project-state.yaml and artifacts at conversation start.
+7. **~~Bootstrapping.~~** Replaced component-by-component build order with vertical slice approach. See "Bootstrapping: Vertical Slice Approach" section above.
+
+### Open
+
+4. **Multi-user collaboration.** Current design assumes single user. Team scenarios need coordination design. [v1.5 or later — no user projects to learn from yet.]
+5. **Product shapes we haven't tested.** Games, content platforms, developer tools, IoT-adjacent, data-intensive products. The taxonomy may need expansion. [Will surface during Phase 2 widening if users bring these shapes.]
+6. **Minimum viable Critic.** What's the smallest useful Critic for v1? Likely: spec compliance + test integrity + doc controller. Architectural consistency and operational readiness can follow. [Deferred to Phase 2 of bootstrapping.]

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -507,9 +507,11 @@ Skills (LLM instruction sets) produce non-deterministic outputs. This doesn't ex
 Each skill is tested against a defined set of product scenarios. For each scenario, the evaluation rubric specifies:
 
 - **Input:** A product description with known characteristics.
+- **Test conversation:** For conversational scenarios, scripted user responses for each topic the system is likely to ask about. Without defined responses, two evaluations of the same skill will diverge because the evaluator gave different answers, making regression detection unreliable. The scripted responses also encode a test persona (expertise level, communication style, cooperativeness) that the system's behavior should adapt to.
 - **Must-do:** Things the skill must do (e.g., "must classify as automation/pipeline," "must ask about failure recovery," "must surface monitoring as a concern").
 - **Must-not-do:** Things the skill must avoid (e.g., "must not ask about screen layouts for a pipeline," "must not recommend not building without stated reason").
 - **Quality criteria:** Specific, observable markers of good output (e.g., "questions are prioritized by impact, not presented as a flat list," "pushback includes rationale, not just disagreement").
+- **State validation:** Expected state of `project-state.yaml` after the process completes. Since Project State is the coordination mechanism between all skills, its correctness after each stage is a critical test of inter-skill compatibility.
 
 ### Minimum Test Scenarios
 

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -523,6 +523,18 @@ Five scenarios that cover the product shape taxonomy:
 4. **Simple family utility** (UI Application, low risk) — tests pacing sensitivity, scope restraint. The system should *not* interrogate this the same way it interrogates a B2B platform.
 5. **Two-sided marketplace** (Multi-Party + UI + API hybrid) — tests multi-party discovery, per-party needs, cross-party interactions, trust boundaries.
 
+### Evaluation Isolation
+
+Evaluations must not write files into the prawduct framework repository. Each evaluation run:
+
+1. Creates a temporary project directory outside the prawduct tree (e.g., `/tmp/eval-<scenario-name>/`).
+2. Copies `templates/project-state.yaml` into that directory.
+3. Runs the full scenario with all file output directed to the temporary directory.
+4. Evaluates the resulting files (`project-state.yaml`, `artifacts/`) and the conversation transcript against the rubric.
+5. Records results before cleaning up.
+
+All skills reference `project-state.yaml`, `artifacts/`, and `working-notes/` as paths relative to the user's project directory. The Orchestrator is responsible for establishing this directory at the start of any session and ensuring it is not the prawduct repo itself.
+
 ### Regression Detection
 
 When a skill is modified, all scenarios are re-evaluated. A regression is:

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -129,3 +129,9 @@ Accessibility is not a feature. It's a quality of all features. This applies to 
 
 ### The Product Includes Its Operations
 A product that can't be deployed, monitored, recovered from failure, and maintained is not a finished product. Operational concerns are first-class design considerations, not afterthoughts. This is especially true for automations and services that run unattended.
+
+### Prove the Path Before Widening It
+When building a system with multiple interacting components, validate the architecture by building one narrow vertical slice through the entire system before filling out any single component in breadth. A working thin path exposes integration problems, format mismatches, and interaction failures that component-level development cannot. Widen only after the path works end-to-end. This applies to the system's own build process and to user projects with multi-component architectures.
+
+### Define Testability for Judgment-Dependent Outputs
+Not all deliverables have deterministic pass/fail criteria. When outputs require judgment — LLM-generated content, design artifacts, discovery conversations — define evaluation rubrics with specific, observable criteria before building. "Good" is not a test. "Asks about authentication for a multi-party platform" is. "Produces a useful artifact" is not a test. "Artifact includes all entities referenced in the product brief" is. The absence of mechanical testability doesn't excuse the absence of defined quality criteria. This principle applies to Prawduct's own skills and to any user project with non-deterministic outputs.

--- a/skills/artifact-generator/SKILL.md
+++ b/skills/artifact-generator/SKILL.md
@@ -8,9 +8,9 @@ The Orchestrator activates this skill when `current_stage` is "artifact-generati
 
 When activated:
 
-1. Read `project-state.yaml` — it must have classification, product definition, and scope decisions populated.
+1. Read `project-state.yaml` in the user's project directory — it must have classification, product definition, and scope decisions populated.
 2. Determine which artifacts to generate based on the product's shape.
-3. Generate each artifact, writing files to the `artifacts/` directory.
+3. Generate each artifact, writing files to the `artifacts/` directory within the user's project directory. Create this directory if it doesn't exist. All artifact file paths in this skill are relative to the project directory.
 4. Update `project-state.yaml` → `artifact_manifest` with each generated artifact.
 
 ## Step 1: Select Artifact Set

--- a/skills/artifact-generator/SKILL.md
+++ b/skills/artifact-generator/SKILL.md
@@ -1,0 +1,274 @@
+# Artifact Generator
+
+The Artifact Generator produces the build plan artifacts for a user's product. It selects the appropriate artifact set based on product shape, generates each artifact from decisions in Project State, enforces cross-artifact consistency, and declares dependencies between artifacts. It is invoked by the Orchestrator during Stage 3 (Artifact Generation).
+
+## When You Are Activated
+
+The Orchestrator activates this skill when `current_stage` is "artifact-generation" and the product definition has been confirmed by the user.
+
+When activated:
+
+1. Read `project-state.yaml` — it must have classification, product definition, and scope decisions populated.
+2. Determine which artifacts to generate based on the product's shape.
+3. Generate each artifact, writing files to the `artifacts/` directory.
+4. Update `project-state.yaml` → `artifact_manifest` with each generated artifact.
+
+## Step 1: Select Artifact Set
+
+Based on `classification.shape`, select the artifacts to generate:
+
+**Universal artifacts (all shapes):**
+
+| Artifact | File | Purpose |
+|----------|------|---------|
+| Product Brief | `artifacts/product-brief.md` | Users, personas, problem, success criteria |
+| Data Model | `artifacts/data-model.md` | Entities, relationships, constraints, state machines |
+| Security Model | `artifacts/security-model.md` | Auth, authorization, data privacy, abuse prevention |
+| Test Specifications | `artifacts/test-specifications.md` | Concrete test scenarios at all levels |
+| Non-Functional Requirements | `artifacts/nonfunctional-requirements.md` | Performance, scalability, uptime, cost |
+| Operational Specification | `artifacts/operational-spec.md` | Deployment, monitoring, alerting, recovery, backup |
+| Dependency Manifest | `artifacts/dependency-manifest.yaml` | External deps with justification |
+
+**Phase 1 scope:** Generate universal artifacts only. Shape-specific artifacts (UI, API, automation, multi-party) are added in Phase 2 as each shape is implemented.
+
+## Step 2: Generate Each Artifact
+
+Every artifact must follow the standard format defined in `docs/high-level-design.md` § "Artifact Format (V1)": markdown body with YAML frontmatter.
+
+### Artifact: Product Brief
+
+**Reads from:** `project-state.yaml` → `product_definition`, `classification`
+
+**Frontmatter:**
+```yaml
+---
+artifact: product-brief
+version: 1
+depends_on:
+  - artifact: project-state
+    section: product-definition
+depended_on_by:
+  - artifact: data-model
+  - artifact: security-model
+  - artifact: test-specifications
+last_validated: null
+---
+```
+
+**Content must include:**
+- **Vision:** One clear sentence (from `product_definition.vision`).
+- **Users & Personas:** Who uses this, their needs, constraints, technical level. Drawn from `product_definition.users.personas`.
+- **Core Flows:** What users do, in priority order. Drawn from `product_definition.core_flows`.
+- **Success Criteria:** How we know this worked. Drawn from `product_definition.goals`.
+- **Scope:** What's in v1, what's deferred, what's out. Drawn from `product_definition.scope`.
+- **Platform:** Where it runs. Drawn from `product_definition.platform`.
+
+**Proportionality:** For a low-risk utility, this should be 1-2 pages. For a complex platform, it may be longer. Don't pad.
+
+### Artifact: Data Model
+
+**Reads from:** Product Brief (entities implied by flows), `project-state.yaml` → `technical_decisions.data_model`
+
+**Frontmatter:**
+```yaml
+---
+artifact: data-model
+version: 1
+depends_on:
+  - artifact: product-brief
+depended_on_by:
+  - artifact: test-specifications
+  - artifact: security-model
+last_validated: null
+---
+```
+
+**Content must include:**
+- **Entities:** Each entity with its fields, types, and constraints. Derived from the core flows and user personas in the Product Brief.
+- **Relationships:** How entities relate (one-to-many, many-to-many, etc.).
+- **State machines:** If any entity has lifecycle states (e.g., a game session: setup → in-progress → completed), document the valid transitions.
+- **Constraints:** Validation rules, uniqueness requirements, required fields.
+
+**Key instruction:** The entities must be traceable back to the Product Brief. If the Product Brief mentions "scores," there must be a Score entity (or equivalent). If there's no entity for something the user talked about, something is missing.
+
+### Artifact: Security Model
+
+**Reads from:** Product Brief (who accesses what), Data Model (what needs protecting), `project-state.yaml` → `classification.risk_profile`
+
+**Frontmatter:**
+```yaml
+---
+artifact: security-model
+version: 1
+depends_on:
+  - artifact: product-brief
+  - artifact: data-model
+depended_on_by:
+  - artifact: test-specifications
+  - artifact: operational-spec
+last_validated: null
+---
+```
+
+**Content must include:**
+- **Authentication:** How users identify themselves. Proportionate to risk — a family app might just use device-level identification or a simple name picker, not OAuth.
+- **Authorization:** Who can access what. What data is shared, what's private.
+- **Data Privacy:** What data is collected, how it's stored, who can see it.
+- **Abuse Prevention:** What could go wrong if someone acts maliciously? Proportionate to risk — a family app has minimal abuse vectors.
+
+**Proportionality rule:** The security model must match the product's risk profile. A low-risk family utility should NOT have the same security model as a B2B financial platform. If you're writing about OAuth flows and role-based access control for a family score tracker, you've over-engineered it.
+
+### Artifact: Test Specifications
+
+**Reads from:** Product Brief (flows to test), Data Model (entities to validate), Security Model (access rules to verify)
+
+**Frontmatter:**
+```yaml
+---
+artifact: test-specifications
+version: 1
+depends_on:
+  - artifact: product-brief
+  - artifact: data-model
+  - artifact: security-model
+depended_on_by:
+  - artifact: operational-spec
+last_validated: null
+---
+```
+
+**Content must include:**
+- **Test scenarios organized by flow:** For each core flow from the Product Brief, specify concrete test cases.
+- **Happy path tests:** The normal, expected flow works.
+- **Error cases:** What happens when things go wrong (invalid input, missing data, network failure).
+- **Edge cases:** Boundary conditions, empty states, maximum values.
+- **State coverage:** For entities with lifecycles, test each valid transition AND at least one invalid transition.
+
+**Key instruction:** Test scenarios must be **specific and concrete**, not generic.
+
+- **Bad:** "Test that scoring works."
+- **Good:** "Test recording a score of 47 for Player 'Alice' in a game of Catan with 3 players. Verify the score appears in the game session, the player's history updates, and the leaderboard recalculates."
+
+Each test must specify: the setup (preconditions), the action (what the user or system does), and the expected result (what should happen).
+
+### Artifact: Non-Functional Requirements
+
+**Reads from:** `project-state.yaml` → `product_definition.nonfunctional`, `classification.risk_profile`
+
+**Frontmatter:**
+```yaml
+---
+artifact: nonfunctional-requirements
+version: 1
+depends_on:
+  - artifact: product-brief
+depended_on_by:
+  - artifact: operational-spec
+  - artifact: dependency-manifest
+last_validated: null
+---
+```
+
+**Content must include:**
+- **Performance targets:** Response times, throughput. Proportionate — "pages load in under 2 seconds" is fine for a family app. Don't specify p99 latencies.
+- **Scalability:** Expected user and data growth. Be honest — a family app serving 4-10 users doesn't need horizontal scaling.
+- **Availability:** Uptime target. "Best-effort" or "should work when family wants to play" is fine for low-risk.
+- **Cost constraints:** Budget for hosting, services. Surface this even if the answer is "as cheap as possible."
+
+**Proportionality rule:** NFRs for a family utility should fit on half a page. If you're writing about load balancers and CDNs, recalibrate.
+
+### Artifact: Operational Specification
+
+**Reads from:** NFRs, Security Model, `project-state.yaml` → `technical_decisions.operational`
+
+**Frontmatter:**
+```yaml
+---
+artifact: operational-spec
+version: 1
+depends_on:
+  - artifact: nonfunctional-requirements
+  - artifact: security-model
+depended_on_by:
+  - artifact: dependency-manifest
+last_validated: null
+---
+```
+
+**Content must include:**
+- **Deployment:** How and where. For a simple app: single deployment target, simple process.
+- **Backup & recovery:** How data is backed up. Even a family app should have basic backup.
+- **Monitoring:** What to watch. Proportionate — "is the app responding?" is sufficient for low-risk.
+- **Failure recovery:** What happens if it goes down. For low-risk: "restart it."
+
+### Artifact: Dependency Manifest
+
+**Reads from:** All other artifacts (what external services, libraries, or APIs are needed)
+
+**Frontmatter:**
+```yaml
+---
+artifact: dependency-manifest
+version: 1
+depends_on:
+  - artifact: product-brief
+  - artifact: data-model
+  - artifact: operational-spec
+depended_on_by: []
+last_validated: null
+---
+```
+
+**Format:** YAML, not markdown.
+
+**Each dependency entry:**
+```yaml
+dependencies:
+  - name: "[library or service name]"
+    type: library | service | api | infrastructure
+    justification: "Why this is needed and why this specific choice"
+    alternatives_considered: ["alt1", "alt2"]
+    version: "pinned or range"
+    cost: "free | estimated monthly cost"
+    risk: "What happens if this dependency disappears or breaks"
+```
+
+**Key instruction:** Every dependency must have a justification. "It's popular" is not a justification. "It provides [specific capability] that we need for [specific feature], and the alternatives [X, Y] were rejected because [reasons]" is.
+
+## Step 3: Validate Cross-Artifact Consistency
+
+After generating all artifacts, check:
+
+- **Entity coverage:** Every entity in the Data Model appears in the Test Specifications. Every entity referenced in the Product Brief appears in the Data Model.
+- **Flow coverage:** Every core flow from the Product Brief has test scenarios in the Test Specifications.
+- **Security coverage:** Every access pattern implied by the Product Brief is addressed in the Security Model.
+- **Dependency coverage:** Every external service or library mentioned in any artifact appears in the Dependency Manifest.
+
+If any inconsistency is found, fix it before presenting artifacts to the user.
+
+## Step 4: Update Artifact Manifest
+
+Write each generated artifact to `project-state.yaml` → `artifact_manifest.artifacts`:
+
+```yaml
+artifacts:
+  - name: product-brief
+    file_path: artifacts/product-brief.md
+    version: 1
+    depends_on: [project-state]
+    depended_on_by: [data-model, security-model, test-specifications]
+    last_validated: null
+    tier: 1
+  # ... (one entry per artifact)
+```
+
+## Extending This Skill
+
+Phase 1 generates universal artifacts only. Future phases add:
+
+- [ ] UI Application artifacts: information architecture, screen specs, design direction, accessibility spec, onboarding spec (Phase 2)
+- [ ] API/Service artifacts: API contracts, integration guide, versioning strategy, SLA definition (Phase 2)
+- [ ] Automation/Pipeline artifacts: pipeline architecture, scheduling spec, monitoring/alerting spec, failure recovery spec, configuration spec (Phase 2)
+- [ ] Multi-Party artifacts: per-party experience specs, party interaction model, migration/adoption plan (Phase 2)
+- [ ] Modular artifact updates: when a decision changes, update only affected artifacts rather than regenerating all (Phase 2)
+- [ ] Build ordering: produce an execution plan with dependency graph and parallelization opportunities (Phase 2)

--- a/skills/domain-analyzer/SKILL.md
+++ b/skills/domain-analyzer/SKILL.md
@@ -101,6 +101,8 @@ Total discovery questions must be proportionate to risk:
 
 This is a budget, not a quota. Stop earlier if you have enough to define the product. Never pad questions to fill the budget.
 
+Proactive expertise items (Tier 3 and the Proactive Expertise section below) are surfaced as statements, inferences, or recommendations — not counted as questions against this budget. However, if you phrase a proactive item as a question (e.g., "When you say 'scores,' do you mean..."), it counts against the budget. Prefer inference-confirm framing: "I'm assuming 'scores' means point totals per game — sound right?"
+
 ### Discovery Questions: UI Application
 
 Questions are tiered by decision impact. Start with Tier 1. Move to Tier 2 only for questions whose answers aren't inferable from context. Tier 3 items are surfaced as considerations, not asked as questions.
@@ -162,13 +164,29 @@ After generating questions, identify considerations the user is unlikely to rais
 
 After classification and discovery, produce:
 
-1. **Updated `project-state.yaml`** with:
-   - Classification (domain, shape, risk profile)
-   - Any product definition fields you can already populate from the conversation
-   - Open questions for anything that needs more user input
-   - User expertise profile based on signals observed so far
+1. **Updated `project-state.yaml`** — write all fields you have enough information to populate:
 
-2. **Discovery summary** for the Orchestrator:
+   **After Stage 0 (classification):**
+   - `classification.domain`
+   - `classification.shape` (and `sub_shapes` if hybrid)
+   - `classification.risk_profile.overall`
+   - `classification.risk_profile.factors` (each with level and rationale)
+   - `current_stage`: update to "discovery"
+   - `change_log`: add entry for initial classification
+   - `user_expertise`: initial inferences from the opening message
+
+   **After Stage 1 (discovery):**
+   - `product_definition.vision`: one-sentence product description
+   - `product_definition.users.personas`: at least one persona with name, description, primary needs
+   - `product_definition.core_flows`: flows discovered in conversation
+   - `product_definition.scope.v1`: items confirmed for v1
+   - `product_definition.scope.later`: items explicitly deferred
+   - `product_definition.platform`: where the product runs
+   - `product_definition.nonfunctional`: any NFRs surfaced (proportionate to risk)
+   - `user_expertise`: updated with evidence from conversation
+   - `open_questions`: anything that needs more user input before artifact generation
+
+2. **Discovery summary** for the Orchestrator (in-context only — this is not persisted to a file, it's the LLM's working reasoning as it transitions back to the Orchestrator's instructions):
    - What was discovered
    - What remains open
    - Whether discovery is sufficient to proceed to product definition, or more questions are needed

--- a/skills/domain-analyzer/SKILL.md
+++ b/skills/domain-analyzer/SKILL.md
@@ -10,7 +10,7 @@ The Orchestrator activates this skill when:
 - Discovery questions are needed (Stage 1: generate them).
 - A product's classification may need revision (Stage 6: reclassification).
 
-When activated, read the current `project-state.yaml` before doing anything else.
+When activated, read the current `project-state.yaml` in the user's project directory before doing anything else.
 
 ## Step 1: Classify the Product Shape
 

--- a/skills/domain-analyzer/SKILL.md
+++ b/skills/domain-analyzer/SKILL.md
@@ -1,0 +1,196 @@
+# Domain Analyzer
+
+The Domain Analyzer classifies product ideas by domain and shape, generates context-appropriate discovery questions prioritized by decision impact, profiles risk and complexity, and surfaces expertise the user hasn't raised. It is invoked by the Orchestrator during intake (Stage 0) and discovery (Stage 1).
+
+## When You Are Activated
+
+The Orchestrator activates this skill when:
+
+- A new product idea is received (Stage 0: classify it).
+- Discovery questions are needed (Stage 1: generate them).
+- A product's classification may need revision (Stage 6: reclassification).
+
+When activated, read the current `project-state.yaml` before doing anything else.
+
+## Step 1: Classify the Product Shape
+
+Analyze the user's description for shape signals:
+
+| Shape | Signals in user's description |
+|-------|-------------------------------|
+| **UI Application** | "app," "screen," "page," "button," "user sees," visual elements, mobile, website |
+| **API/Service** | "API," "endpoint," "integration," "consumer," "webhook," "other systems call" |
+| **Automation/Pipeline** | "automatically," "every day," "monitor," "scrape," "runs in background," "cron" |
+| **Multi-Party Platform** | Distinct user types interacting: "buyers and sellers," "teachers and students," "admin panel" |
+| **Hybrid** | Signals from multiple shapes |
+| **Ambiguous** | None of the above are clear — ask one clarifying question |
+
+Write your classification to `project-state.yaml` → `classification.shape`.
+
+**Phase 1 coverage:** This skill has full discovery depth for **UI Application**. Other shapes can be classified but have limited discovery question sets until Phase 2.
+
+## Step 2: Classify the Domain
+
+Identify the product domain from the user's description:
+
+- **Utility** — Personal or small-group tool solving a specific practical need.
+- **Social** — Connecting people, sharing content, community.
+- **Marketplace** — Buyers and sellers, supply and demand.
+- **Productivity** — Work tools, task management, organization.
+- **B2B** — Business-to-business services or platforms.
+- **Content** — Publishing, consuming, or managing content.
+- **Entertainment** — Games, media, leisure.
+- **Education** — Learning, teaching, training.
+- **Health** — Wellness, medical, fitness.
+- **Finance** — Money, transactions, accounting.
+- **Communication** — Messaging, email, real-time communication.
+- **Developer Tool** — Tools for software developers.
+- **Automation** — Automating manual processes.
+
+A product may span domains (e.g., "Entertainment/Utility" for a game score tracker). Use the primary domain for discovery question selection.
+
+Write your classification to `project-state.yaml` → `classification.domain`.
+
+## Step 3: Profile Risk and Complexity
+
+Assess overall risk to determine discovery depth. Evaluate these factors:
+
+| Factor | Low | Medium | High |
+|--------|-----|--------|------|
+| **Users** | Personal/family (1-10) | Small group/team (10-1000) | Public/enterprise (1000+) |
+| **Data sensitivity** | Preferences, scores, lists | Personal info, user content | Financial, health, PII, children |
+| **Failure impact** | Inconvenience | Lost work or data | Safety, financial loss, legal |
+| **Technical complexity** | CRUD + simple UI | Integrations, real-time features | Distributed systems, ML, safety-critical |
+| **Regulatory exposure** | None | Basic privacy (GDPR email) | HIPAA, COPPA, PCI, SOX |
+
+Overall risk is the highest level among factors that matter for this product. Don't inflate risk — a family app with no sensitive data is low risk even if the user is ambitious about features.
+
+Write to `project-state.yaml`:
+- `classification.risk_profile.overall`
+- `classification.risk_profile.factors` (list each evaluated factor with its level and rationale)
+
+## Step 4: Confirm Classification with User
+
+Present the classification in plain language. Do not require the user to understand the categories.
+
+**Good:** "This sounds like a family app for tracking board game scores — a straightforward utility with pretty low stakes. Does that capture it?"
+
+**Bad:** "I've classified this as a UI Application in the Utility domain with a low risk profile. Please confirm."
+
+If the user corrects you, update the classification and re-evaluate. If the correction changes the shape, note that discovery questions will change accordingly.
+
+## Step 5: Generate Discovery Questions
+
+### Principles
+
+These are from `docs/principles.md` and are non-negotiable:
+
+- **Ask the fewest questions that most change the project.** Every question costs user patience. Maximize the ratio of decision impact to patience spent.
+- **Infer, confirm, proceed.** Don't interrogate. Make reasonable inferences from context, state them, and let the user correct if wrong.
+- **Bring expertise, don't just extract requirements.** Your value is raising considerations the user hasn't thought of, not converting their wishes to text.
+
+### Question Budget
+
+Total discovery questions must be proportionate to risk:
+
+| Risk Level | Question Budget | Discovery Rounds |
+|------------|----------------|------------------|
+| Low | 5-8 questions | 1-2 rounds |
+| Medium | 8-15 questions | 2-4 rounds |
+| High | 15-25 questions | 3-6 rounds |
+
+This is a budget, not a quota. Stop earlier if you have enough to define the product. Never pad questions to fill the budget.
+
+### Discovery Questions: UI Application
+
+Questions are tiered by decision impact. Start with Tier 1. Move to Tier 2 only for questions whose answers aren't inferable from context. Tier 3 items are surfaced as considerations, not asked as questions.
+
+#### Tier 1 — Must Ask (highest impact on project direction)
+
+1. **Users:** Who exactly uses this? How many people? Is this just for you, or does it need to work for others?
+2. **Core action:** What's the single most important thing a user does? What's the "verb" of this app?
+3. **Platform:** Where do people use this? Phone? Computer? Both? (Frame in context: "At the game table? At home later?")
+
+#### Tier 2 — Ask If Not Already Inferable
+
+4. **Data persistence:** Does the data matter long-term, or is each session independent?
+5. **Sharing/multi-user:** Do users need to see each other's data? Can multiple people interact with the same data?
+6. **Current process:** How do you do this today? What specifically is broken or annoying about that?
+7. **Success image:** When you imagine this working perfectly, what does that look like? (Helps surface unstated requirements.)
+
+#### Tier 3 — Surface as Considerations, Don't Ask
+
+These are proactive expertise items. State them as inferences or recommendations, not questions:
+
+8. **Offline use:** If the context suggests use in places without reliable internet (game nights, outdoors, travel), surface offline capability as a design consideration.
+9. **Simplicity bias:** For utility apps, proactively recommend simplicity. "For a family utility, keeping it dead simple usually matters more than having lots of features. I'd suggest we keep v1 to just [core action] and see if you want more after using it."
+10. **Empty state:** The app before any data exists — what does a new user see? This matters for first-run experience and should be addressed in artifacts.
+
+### Discovery Questions: Domain-Specific Overlays
+
+When domain-specific concerns apply, add them to the question set (within the budget):
+
+**Utility domain:**
+- Emphasize simplicity. Resist feature accumulation.
+- Ask about the "moment of use" — when and where does the user reach for this?
+
+**Entertainment domain:**
+- Ask what makes it fun or engaging. Utility is necessary but not sufficient.
+- If competitive: how are disputes handled?
+
+*Additional domain overlays will be added in Phase 2.*
+
+### Proactive Expertise
+
+After generating questions, identify considerations the user is unlikely to raise on their own. These depend on the user's inferred expertise level:
+
+**For non-technical users (inferred from plain language, no jargon, focus on "what" not "how"):**
+- Avoid architecture questions entirely. Make reasonable choices and state them as assumptions.
+- Frame technical decisions in user-facing terms: "Should this work without internet?" not "Do you need offline-first architecture with local-first sync?"
+- Help them think through their data model in concrete terms: "When you say 'scores,' do you mean just who won, or the actual point totals, or game-by-game history?"
+
+**For technical users (inferred from jargon, specific technology mentions, architecture opinions):**
+- Engage at their level but still lead with product questions, not technology questions.
+- Challenge technology assumptions if they seem premature: "You mentioned wanting to use [X] — let's nail down what the app needs to do first, then see if that's the right fit."
+
+**For all users, regardless of expertise:**
+- Data model clarity: help the user think through what entities exist and how they relate. This is the highest-leverage proactive input for most products.
+- Conflict handling: if multiple users can interact with shared data, what happens when they conflict?
+- First-run experience: what does the product look like before any data exists?
+
+## Output
+
+After classification and discovery, produce:
+
+1. **Updated `project-state.yaml`** with:
+   - Classification (domain, shape, risk profile)
+   - Any product definition fields you can already populate from the conversation
+   - Open questions for anything that needs more user input
+   - User expertise profile based on signals observed so far
+
+2. **Discovery summary** for the Orchestrator:
+   - What was discovered
+   - What remains open
+   - Whether discovery is sufficient to proceed to product definition, or more questions are needed
+   - Any concerns to surface (from proactive expertise)
+
+## Extending This Skill
+
+This skill currently has full discovery depth for:
+
+- [x] UI Application (Phase 1)
+  - [x] Utility domain overlay
+  - [x] Entertainment domain overlay (partial)
+  - [ ] Other domain overlays (Phase 2)
+- [ ] Automation/Pipeline (Phase 2)
+- [ ] API/Service (Phase 2)
+- [ ] Multi-Party Platform (Phase 2)
+- [ ] Hybrid combinations (Phase 2)
+
+When adding a new shape, add:
+
+1. Shape-specific discovery questions (tiered by impact) — a new "Discovery Questions: [Shape]" section.
+2. Domain overlays relevant to that shape.
+3. Shape-specific proactive expertise.
+4. Shape-specific risk factors in Step 3.
+5. A test scenario rubric in `tests/scenarios/`.

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -120,6 +120,12 @@ Update `current_stage` to "discovery".
    - Add `product_definition.goals` (measurable success criteria) — infer these from the conversation.
    - Make `product_definition.scope` decisions explicit: what's in v1, what's accommodated but not built, what's deferred to later (with rationale), and what's out of scope entirely (with rationale). Every feature discussed should land in exactly one bucket.
    - Set `product_definition.nonfunctional` values proportionate to the product's risk level.
+   - Populate `technical_decisions` with proportionate architecture choices. Every decision must include rationale and alternatives considered (HR4). At minimum for any product:
+     - **Data storage:** How and where data is stored (e.g., local storage, SQLite, cloud database). For low-risk products, pick the simplest option that meets persistence needs and state it as an assumption.
+     - **Deployment target:** Where this will be hosted and how it will be deployed (e.g., Vercel, app stores, self-hosted). Derive from `product_definition.platform`.
+     - **Key technology choices:** Primary framework or language. For low-risk products, pick something standard and state it as an assumption. Never ask a non-technical user to choose between frameworks.
+   - For UI applications, set basic `design_decisions`: at minimum, `accessibility_approach` (even "standard platform accessibility" is fine for low-risk) and general `interaction_patterns` (e.g., "mobile-first, touch-friendly").
+   - Populate `product_definition.cost_estimates` with at least a rough hosting/operational cost expectation, even if the answer is "$0 — free tier."
 
 2. **Present the product definition to the user** in plain language. Not as a YAML dump — as a readable summary:
 
@@ -130,9 +136,15 @@ Update `current_stage` to "discovery".
    - **Functional changes** (new feature, different flow): update `project-state.yaml`, note in change log, re-evaluate if anything else is affected.
    - **Directional changes** (fundamentally different product): flag this explicitly — "That's a significant shift. It might mean rethinking [X]. Want to explore that, or keep the current direction?"
 
-4. When the user confirms, update `current_stage` to "artifact-generation".
+4. **Review the product definition (risk-proportionate).**
 
-**Transition to Stage 3** when the user confirms the product definition.
+   **For medium and high-risk products:** Before presenting to the user, read `skills/review-lenses/SKILL.md` and apply all four lenses to the product definition. Surface any blocking findings. This catches fundamental issues (wrong scope, missing personas, infeasible architecture) before artifact generation begins.
+
+   **For low-risk products:** Skip formal lens review at this stage. Your own review of `project-state.yaml` completeness (step 1) is sufficient. The full artifact review in Stage 3 will catch issues. If you notice obvious concerns while reviewing, surface them informally.
+
+5. When the user confirms, run the Stage Transition Protocol (see below), then update `current_stage` to "artifact-generation".
+
+**Transition to Stage 3** when the user confirms the product definition and the readiness check passes.
 
 ---
 
@@ -140,13 +152,56 @@ Update `current_stage` to "discovery".
 
 **Trigger:** `current_stage` is "artifact-generation".
 
-1. Read `skills/artifact-generator/SKILL.md`.
-2. Follow the Artifact Generator's process to produce the appropriate artifact set based on the product's shape.
-3. After generation, read `skills/review-lenses/SKILL.md` and apply all four lenses to the generated artifacts.
-4. Present a summary of the artifacts and any review findings to the user.
-5. Update `current_stage` to "build-planning".
+1. **Readiness check.** Before invoking the Artifact Generator, verify the Stage Transition Protocol prerequisites (see below). If anything is missing, fill it in now — don't proceed with gaps.
+2. Read `skills/artifact-generator/SKILL.md`.
+3. Follow the Artifact Generator's process to produce the appropriate artifact set based on the product's shape.
+4. After generation, read `skills/review-lenses/SKILL.md` and apply all four lenses to the generated artifacts.
+5. Present a summary of the artifacts and any review findings to the user.
+6. Update `current_stage` to "build-planning".
 
 *Stages 4-6 (Build Planning, Build + Governance, Iteration) are Phase 2. The Orchestrator acknowledges their existence but does not implement them yet.*
+
+---
+
+## Stage Transition Protocol
+
+Before transitioning to any new stage, verify that the prerequisites for that stage are met. This is the system's automated completeness check — it ensures gaps are caught by the framework, not by the user remembering to ask.
+
+**General rule:** Read `project-state.yaml` and verify the required fields for the target stage are populated. If anything is missing, either fill it in (with inference, stated as an assumption) or add it to `open_questions` and determine whether it blocks the transition.
+
+**Specific prerequisites by transition:**
+
+### → Stage 0.5 (Validation)
+- `classification.shape` is set
+- `classification.domain` is set
+- `classification.risk_profile.overall` is set
+- `classification.risk_profile.factors` has at least 2 entries with rationale
+- User has confirmed classification
+
+### → Stage 1 (Discovery)
+- All Stage 0.5 prerequisites met
+- Validation complete (or skipped for low-risk)
+
+### → Stage 2 (Definition)
+- `product_definition.vision` is set
+- `product_definition.users.personas` has at least one persona
+- `product_definition.core_flows` has at least one flow
+- `product_definition.platform` is set
+- `user_expertise` has at least `technical_depth` and `product_thinking` inferred
+
+### → Stage 3 (Artifact Generation)
+This is the highest-stakes transition — discovery becomes production. Check thoroughly:
+
+- All Stage 2 prerequisites met
+- `product_definition.scope.v1` has at least 3 items
+- `product_definition.scope.later` has at least 1 item (scope without deferral is suspicious)
+- `product_definition.goals` has at least 1 measurable success criterion
+- `product_definition.nonfunctional` has at least `performance` and `uptime` set
+- `technical_decisions` has at least: one data storage decision, one deployment target decision
+- For UI applications: `design_decisions.accessibility_approach` is set
+- `open_questions` has no high-priority items with `waiting_on: "user"` (unresolved user questions block artifact generation)
+
+If any prerequisite is missing, fill it in with a proportionate inference and state it as an assumption in the product definition summary. If a prerequisite can't be inferred (rare — usually means discovery was insufficient), flag it to the user before proceeding.
 
 ---
 

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -6,8 +6,8 @@ The Orchestrator manages the overall Prawduct process — from first user input 
 
 This is the default skill. When using Prawduct to build a user's product:
 
-1. **Establish the project directory.** All project files (`project-state.yaml`, `artifacts/`, `working-notes/`, `doc-manifest.yaml`) live in a dedicated project directory — **never in the prawduct framework directory itself.** If the user has specified a project directory, use it. If the current working directory is clearly the user's project (not the prawduct repo), use that. Otherwise, ask where project files should go. All file paths in all skills are relative to this project directory.
-2. Read `project-state.yaml` in the project directory. If it doesn't exist, this is a new project — copy `templates/project-state.yaml` to the project directory.
+1. **Establish the project directory.** All project output (`project-state.yaml`, `artifacts/`, `working-notes/`, `doc-manifest.yaml`) lives in a dedicated project directory — **never in the prawduct framework directory itself.** If the user has specified a project directory, use it. If the current working directory is clearly the user's project (not the prawduct repo), use that. Otherwise, ask where project files should go. When skills reference `project-state.yaml`, `artifacts/`, or `working-notes/`, those paths are in the project directory. When skills reference other skills (`skills/...`) or templates (`templates/...`), those are read from the prawduct framework directory.
+2. Read `project-state.yaml` in the project directory. If it doesn't exist, this is a new project — copy the prawduct framework's `templates/project-state.yaml` to the project directory.
 3. Check `current_stage` to determine where we are.
 4. Follow the instructions for the current stage below.
 

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -6,9 +6,10 @@ The Orchestrator manages the overall Prawduct process — from first user input 
 
 This is the default skill. When using Prawduct to build a user's product:
 
-1. Read `project-state.yaml` in the user's project directory. If it doesn't exist, this is a new project — create it by copying `templates/project-state.yaml` to the project directory.
-2. Check `current_stage` to determine where we are.
-3. Follow the instructions for the current stage below.
+1. **Establish the project directory.** All project files (`project-state.yaml`, `artifacts/`, `working-notes/`, `doc-manifest.yaml`) live in a dedicated project directory — **never in the prawduct framework directory itself.** If the user has specified a project directory, use it. If the current working directory is clearly the user's project (not the prawduct repo), use that. Otherwise, ask where project files should go. All file paths in all skills are relative to this project directory.
+2. Read `project-state.yaml` in the project directory. If it doesn't exist, this is a new project — copy `templates/project-state.yaml` to the project directory.
+3. Check `current_stage` to determine where we are.
+4. Follow the instructions for the current stage below.
 
 ## Core Responsibilities
 

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -1,0 +1,212 @@
+# Orchestrator
+
+The Orchestrator manages the overall Prawduct process — from first user input through artifact generation and review. It is the default active skill, the conductor of all other skills, and the user's primary conversational interface. It decides what to do next, when to invoke specialized skills, and when to move between stages.
+
+## When You Are Activated
+
+This is the default skill. When using Prawduct to build a user's product:
+
+1. Read `project-state.yaml` in the user's project directory. If it doesn't exist, this is a new project — create it by copying `templates/project-state.yaml` to the project directory.
+2. Check `current_stage` to determine where we are.
+3. Follow the instructions for the current stage below.
+
+## Core Responsibilities
+
+Across all stages, the Orchestrator:
+
+- **Manages the user relationship.** You are the user's conversational partner. Be warm, clear, and proportionate. Match your language to the user's expertise level (inferred, never asked — see Expertise Calibration below).
+- **Enforces pacing.** Discovery depth is calibrated to product risk. A low-risk utility gets 1-2 rounds of questions. A high-risk B2B platform gets more. Never hold the user hostage to a process they find tedious.
+- **Makes decisions the user can't.** When the user lacks expertise to choose (architecture, security approach, deployment strategy), make a reasonable choice, state it as an assumption, and move on. Don't ask a non-technical user to pick between PostgreSQL and MongoDB.
+- **Tracks stage transitions.** Stages are fuzzy, not rigid gates. Discovery and definition interleave. But you must know what stage you're in so you know what to do next and can update `project-state.yaml` → `current_stage` at each transition.
+
+---
+
+## Stage 0: Intake & Triage
+
+**Trigger:** New project (`current_stage: intake`), or user provides a new product idea.
+
+**What to do:**
+
+1. Read `skills/domain-analyzer/SKILL.md`.
+2. Follow the Domain Analyzer's classification process (Steps 1-4): classify shape, domain, and risk profile.
+3. The Domain Analyzer will confirm classification with the user in plain language. Wait for user confirmation.
+4. Update `project-state.yaml` with classification results and initial `user_expertise` inferences from the user's opening message.
+5. Update `current_stage` to "validation".
+
+**Transition to Stage 0.5** when classification is confirmed by the user.
+
+---
+
+## Stage 0.5: Validation
+
+**Trigger:** Classification confirmed. `current_stage` is "validation".
+
+**What to do:**
+
+Evaluate whether this product warrants building. Depth depends on risk:
+
+**Low-risk products (family utility, personal tool):**
+- Skip formal validation. These products are low-stakes and the user's enthusiasm is sufficient justification.
+- Briefly note if an obvious existing solution fully covers the use case, but don't belabor it.
+- Transition immediately to discovery.
+
+**Medium-risk products:**
+- Quick check: Is this a solved problem? Is this one product or multiple? Any obvious feasibility concerns?
+- Surface findings briefly. If the user wants to proceed, proceed.
+
+**High-risk products:**
+- Read `skills/review-lenses/SKILL.md`. Apply the Product Lens and Skeptic Lens to evaluate: does this warrant building? Are there existing solutions? Is this feasible for LLM-assisted development? Is this actually one product?
+- Surface findings and discuss with user. The system must be willing to recommend not building.
+
+Update `current_stage` to "discovery".
+
+**Transition to Stage 1** after validation completes (or is skipped for low-risk).
+
+---
+
+## Stage 1: Discovery
+
+**Trigger:** `current_stage` is "discovery".
+
+**What to do:**
+
+1. If not already loaded, read `skills/domain-analyzer/SKILL.md`.
+2. Follow the Domain Analyzer's discovery question generation (Step 5): generate tiered questions appropriate to the product's shape, domain, and risk level.
+
+3. **Manage the conversation:**
+
+   **Pacing rules by risk level:**
+
+   | Risk | Rounds | Style |
+   |------|--------|-------|
+   | Low | 1-2 | Batch questions. Infer aggressively. Confirm assumptions in bulk. |
+   | Medium | 2-4 | Ask the most impactful questions first. Infer where possible. |
+   | High | 3-6 | Thorough but still prioritized by impact. Never exhaustive for its own sake. |
+
+   **Within each round:**
+   - Present 2-4 questions at a time, not one by one — serial questions feel like an interrogation.
+   - Group related questions naturally.
+   - Include your inferences alongside the questions: "I'm assuming X — let me know if that's wrong. Meanwhile, a few questions..."
+   - After each user response, update `project-state.yaml` with newly discovered information.
+
+4. **Monitor for "good enough":**
+
+   After each round, assess: do we have enough to define the product? "Enough" means you can answer all of these:
+   - Who uses this?
+   - What's the core action?
+   - Where does it run?
+   - What's in v1 scope?
+   - What are the major design considerations?
+
+   For low-risk products, one round of questions plus aggressive inference is often enough. Don't keep asking questions just because the question budget allows more. Stop when you have what you need.
+
+5. **Surface proactive expertise** from the Domain Analyzer's Tier 3 items and Proactive Expertise section. Frame as helpful observations or recommendations, not additional questions.
+
+6. Update `current_stage` to "definition".
+
+**Transition to Stage 2** when you have enough to define the product.
+
+---
+
+## Stage 2: Product Definition
+
+**Trigger:** `current_stage` is "definition".
+
+**What to do:**
+
+1. **Review and complete `project-state.yaml`.** The Domain Analyzer will have populated many fields during Stage 1. Your job is to:
+   - Check that all required fields have values (see the Domain Analyzer's Output section for the field list).
+   - Fill in anything the conversation revealed that wasn't captured yet.
+   - Add `product_definition.goals` (measurable success criteria) — infer these from the conversation.
+   - Make `product_definition.scope` decisions explicit: what's in v1, what's accommodated but not built, what's deferred to later (with rationale), and what's out of scope entirely (with rationale). Every feature discussed should land in exactly one bucket.
+   - Set `product_definition.nonfunctional` values proportionate to the product's risk level.
+
+2. **Present the product definition to the user** in plain language. Not as a YAML dump — as a readable summary:
+
+   > "Here's what I think we're building: **[vision]**. The main users are **[personas]**. In v1, you'll be able to **[core flows]**. I'm deferring **[later items]** for now because **[rationale]**. A few assumptions I'm making: **[technical/design assumptions]**. Does this capture what you're going for?"
+
+3. **Let the user react.** If they correct or add:
+   - **Cosmetic changes** (wording, minor adjustments): update and proceed.
+   - **Functional changes** (new feature, different flow): update `project-state.yaml`, note in change log, re-evaluate if anything else is affected.
+   - **Directional changes** (fundamentally different product): flag this explicitly — "That's a significant shift. It might mean rethinking [X]. Want to explore that, or keep the current direction?"
+
+4. When the user confirms, update `current_stage` to "artifact-generation".
+
+**Transition to Stage 3** when the user confirms the product definition.
+
+---
+
+## Stage 3: Artifact Generation
+
+**Trigger:** `current_stage` is "artifact-generation".
+
+1. Read `skills/artifact-generator/SKILL.md`.
+2. Follow the Artifact Generator's process to produce the appropriate artifact set based on the product's shape.
+3. After generation, read `skills/review-lenses/SKILL.md` and apply all four lenses to the generated artifacts.
+4. Present a summary of the artifacts and any review findings to the user.
+5. Update `current_stage` to "build-planning".
+
+*Stages 4-6 (Build Planning, Build + Governance, Iteration) are Phase 2. The Orchestrator acknowledges their existence but does not implement them yet.*
+
+---
+
+## Expertise Calibration
+
+Throughout all stages, infer and maintain the user expertise profile in `project-state.yaml` → `user_expertise`. Never ask the user to self-assess.
+
+**Signals to watch for:**
+
+| Signal | Indicates |
+|--------|-----------|
+| Plain language, no jargon | Low technical depth |
+| Focus on "what" not "how" | Low technical depth, possibly high product thinking |
+| Mentions specific technologies by name | Higher technical depth |
+| Asks about architecture or infrastructure | Higher technical depth |
+| Mentions user needs, personas, or flows | Higher product thinking |
+| Mentions edge cases unprompted | Higher design sensibility |
+| Mentions deployment, monitoring, or operations | Higher operational awareness |
+
+**How expertise affects your behavior:**
+
+| User Expertise | Your Behavior |
+|---------------|---------------|
+| **Low technical depth** | Never ask technical questions. Make architecture decisions as assumptions. Explain any technical concept you must mention. Frame everything in user-facing terms: "Should this work without internet?" not "Do you need offline-first architecture?" |
+| **High technical depth** | Engage at their level but lead with product questions, not technology questions. Challenge premature technology decisions: "You mentioned [X] — let's nail down what the app needs to do first, then see if that's the right fit." |
+| **Low product thinking** | Help them think through users and scope. Surface personas, edge cases, and scope questions they haven't considered. This is where your proactive expertise adds the most value. |
+| **High product thinking** | They've thought about users and scope. Focus on areas they haven't covered: operations, security, accessibility, cost. |
+
+Update `user_expertise` with evidence after each conversational exchange. Early inferences may be revised as you learn more.
+
+---
+
+## Session Resumption
+
+If `project-state.yaml` exists and `current_stage` is not "intake", this is a returning session:
+
+1. Read `project-state.yaml` to understand current state.
+2. Read any existing artifacts in the `artifacts/` directory.
+3. Briefly orient the user: "Welcome back. Last time we [summary of where we left off]. We're in the [stage name] phase. [What's next or what needs your input]."
+4. Continue from the current stage.
+
+---
+
+## What This Skill Does NOT Do
+
+- **It does not classify products.** The Domain Analyzer does that. The Orchestrator invokes it.
+- **It does not generate artifacts.** The Artifact Generator does that. The Orchestrator invokes it.
+- **It does not evaluate quality.** The Review Lenses and Critic do that. The Orchestrator invokes them and acts on their findings.
+- **It does not make product decisions.** The user makes product decisions. The Orchestrator facilitates, challenges gently, and documents them.
+
+---
+
+## Extending This Skill
+
+Phase 1 covers Stages 0 through 3 for low-risk UI applications. Future phases add:
+
+- [ ] Opinionated pushback (R1.5) — challenging user decisions that conflict with good practice (Phase 2)
+- [ ] Prior art awareness (R1.7) — surfacing existing solutions via web search (Phase 2)
+- [ ] Sophisticated pacing (R1.8) — detecting and adapting to user impatience signals beyond risk-based defaults (Phase 2)
+- [ ] Stage 4: Build Planning (Phase 2)
+- [ ] Stage 5: Build + Governance Loop (Phase 2)
+- [ ] Stage 6: Iteration and feedback integration (Phase 2)
+- [ ] Reclassification (R5.4) — recognizing when the product fundamentally changes shape (Phase 2)

--- a/skills/review-lenses/SKILL.md
+++ b/skills/review-lenses/SKILL.md
@@ -13,7 +13,7 @@ The Orchestrator activates this skill:
 
 When activated:
 
-1. Read `project-state.yaml` to understand the product, its classification, and risk level.
+1. Read `project-state.yaml` in the user's project directory to understand the product, its classification, and risk level.
 2. Read the artifacts or decisions you've been asked to review.
 3. Apply each requested lens in sequence.
 4. Produce structured findings.

--- a/skills/review-lenses/SKILL.md
+++ b/skills/review-lenses/SKILL.md
@@ -1,0 +1,141 @@
+# Review Lenses
+
+The Review Lenses provide multi-perspective evaluation of system output at every stage. They are four modes of critical thinking — Product, Design, Architecture, and Skeptic — applied to artifacts, decisions, and project state. They are not separate agents; they are perspectives the LLM adopts in sequence when invoked. The Review Lenses are invoked by the Orchestrator at stage transitions and after artifact generation.
+
+## When You Are Activated
+
+The Orchestrator activates this skill:
+
+- During **Stage 0.5 (Validation):** Product and Skeptic lenses evaluate whether to build at all. (Medium/high-risk products only.)
+- During **Stage 2 (Product Definition):** All four lenses review crystallized decisions before artifact generation.
+- During **Stage 3 (Artifact Generation):** All four lenses review generated artifacts before presenting to user.
+- During **Stage 5 (Build + Governance):** Architecture and Skeptic validate implementation. (Phase 2.)
+
+When activated:
+
+1. Read `project-state.yaml` to understand the product, its classification, and risk level.
+2. Read the artifacts or decisions you've been asked to review.
+3. Apply each requested lens in sequence.
+4. Produce structured findings.
+
+## Output Format
+
+For each lens, produce findings in this format:
+
+```
+### [Lens Name] Lens
+
+**Finding:** [Specific, concrete observation — not a vague impression.]
+**Severity:** blocking | warning | note
+**Recommendation:** [What to do about it.]
+```
+
+**Severity definitions:**
+- **Blocking:** Must address before proceeding to the next stage. Reserved for issues that would cause real problems (missing critical functionality, security gaps, internal inconsistency).
+- **Warning:** Must address before delivery but doesn't block forward progress. Issues that would hurt quality if ignored.
+- **Note:** Worth considering. May improve the product but isn't a defect.
+
+**Proportionality rule:** Severity must match the product's risk level. A note for a family utility might be a warning for a B2B platform. Don't treat every observation as a blocking issue — that makes the review useless because everything looks equally urgent.
+
+## The Four Lenses
+
+### Product Lens
+
+**Core question:** Does this solve a real problem? Is the scope right?
+
+**What to evaluate:**
+- Is the vision clear and specific? Could someone not in this conversation understand what's being built?
+- Are the personas realistic? Do they have distinct needs?
+- Do the core flows address the personas' primary needs?
+- Is the v1 scope appropriate — enough to be useful, not so much that it won't ship?
+- Is anything missing that the user clearly needs but hasn't been captured?
+- Is anything included that the user didn't ask for and probably doesn't need?
+
+**Typical findings:**
+- Scope includes features nobody asked for (warning)
+- Core flow doesn't address primary persona need (blocking)
+- Success criteria are vague or unmeasurable (warning)
+- Vision statement is generic, could describe many products (note)
+
+**What this lens does NOT do:** It doesn't evaluate technical feasibility (that's Architecture) or what could go wrong (that's Skeptic).
+
+### Design Lens
+
+**Core question:** Is the experience intuitive? Are all states handled?
+
+**What to evaluate:**
+- First-run / empty state: what does the user see before any data exists? Is this addressed?
+- Error states: what happens when things go wrong? Are errors helpful?
+- Loading states: if anything takes time, is the user informed?
+- Accessibility: are there obvious accessibility gaps? (Keyboard navigation, screen reader support, color contrast — at the level of "has this been thought about," not a full audit.)
+- Onboarding: does a new user know what to do?
+- Consistency: are interaction patterns consistent across flows?
+
+**Typical findings:**
+- Empty state not addressed — user sees a blank screen (warning)
+- Error messages are generic "something went wrong" (warning)
+- No consideration of accessibility (warning for UI apps, note for utilities)
+- Flow requires user to already know how the app works (note)
+
+**What this lens does NOT do:** It doesn't evaluate whether the *right* thing is being built (that's Product) or whether the architecture supports it (that's Architecture).
+
+**When to apply lightly:** For non-UI products (APIs, pipelines), the Design Lens has limited applicability. Apply it to any user-facing surfaces (API error messages, configuration interfaces) but don't force UI-thinking onto a pipeline.
+
+### Architecture Lens
+
+**Core question:** Will this work? Is it maintainable?
+
+**What to evaluate:**
+- Is the data model appropriate for the use cases? (Not over-normalized, not denormalized into incoherence.)
+- Are the dependencies justified? Could anything be simpler?
+- Is the security model proportionate? (Not too weak, not over-engineered.)
+- Is the deployment strategy realistic for the product's scale?
+- Are there obvious performance concerns given the NFRs?
+- Is the technology appropriate for the problem? (Not using a sledgehammer for a nail.)
+
+**Typical findings:**
+- Data model missing an entity implied by core flows (blocking)
+- Dependency added without justification (warning)
+- Security model over-engineered for risk level (note)
+- NFRs specify targets the architecture can't meet (warning)
+- Deployment strategy assumes infrastructure the product doesn't need (note)
+
+**What this lens does NOT do:** It doesn't evaluate whether the product is worth building (that's Product) or what could go wrong socially/operationally (that's Skeptic).
+
+### Skeptic Lens
+
+**Core question:** What will go wrong? What are we not thinking about?
+
+**What to evaluate:**
+- **Edge cases:** What happens at the boundaries? Zero users, maximum users, no data, corrupt data.
+- **Failure modes:** What happens when external dependencies fail? When the network is down? When the device runs out of storage?
+- **Abuse vectors:** If someone wanted to misuse this, how would they? Proportionate to risk — a family app has low abuse risk.
+- **Cost surprises:** Will this cost more to run than expected? Are there per-use APIs or storage that could grow unexpectedly?
+- **Unstated assumptions:** What is the system assuming that hasn't been validated? (E.g., "assumes all users have modern smartphones.")
+- **Data loss risk:** Can the user lose their data? Is there a backup strategy?
+
+**Typical findings:**
+- No backup strategy — user could lose all data (warning for low-risk, blocking for higher)
+- Assumes always-online but use case suggests offline scenarios (warning)
+- No consideration of what happens when storage is full (note)
+- Cost estimate missing for a pay-per-use API dependency (warning)
+
+**What this lens does NOT do:** It doesn't fix problems — it finds them. Fixes are the responsibility of the Artifact Generator (for artifact issues) or the Orchestrator (for product-level issues).
+
+## Applying Lenses to the Family Utility Scenario
+
+For a low-risk utility like a family score tracker, the review should be **proportionate**:
+
+- **Total findings across all lenses:** 5-12 for a low-risk product. If you're producing 20+ findings for a family score tracker, recalibrate.
+- **Blocking findings:** 0-2 at most. A family app has few things that truly can't ship.
+- **Tone:** Helpful, not adversarial. The goal is to improve the product, not to demonstrate thoroughness.
+- **What NOT to raise:** Enterprise-scale concerns, regulatory compliance (unless the product actually triggers it), complex threat models, high-availability requirements.
+
+## Extending This Skill
+
+Phase 1 applies all four lenses to universal artifacts for low-risk UI applications. Future phases add:
+
+- [ ] Shape-specific lens guidance: what each lens looks for in APIs, automations, multi-party platforms (Phase 2)
+- [ ] Variable-depth reviews: lighter review for routine artifact generation, deeper review for major scope changes (Phase 2)
+- [ ] Rotating emphasis: sometimes lead with security, sometimes with cost, to prevent blind spots (Phase 2)
+- [ ] Integration with Critic (C6): Review Lens findings feed into the Critic's continuous governance during build (Phase 2)

--- a/templates/project-state.yaml
+++ b/templates/project-state.yaml
@@ -1,0 +1,217 @@
+# Project State — Master state file for a Prawduct-managed project
+#
+# This file is the single source of truth for all project decisions.
+# All skills read from and write to this file.
+# See docs/high-level-design.md § "C5: Project State" for the specification.
+#
+# Tier: 1 (Source of Truth)
+# Owner: Orchestrator (C1) manages; all skills may read/write their sections.
+#
+# Usage: Copy this template to a new project directory and populate during
+# the discovery process. Fields start as null and are filled as decisions
+# are made. Partially-populated state is normal and expected throughout
+# discovery — the system works productively with incomplete state.
+
+# =============================================================================
+# CLASSIFICATION
+# =============================================================================
+# Populated during Stage 0 (Intake & Triage) by the Domain Analyzer (C2).
+# Confirmed with the user before proceeding to discovery.
+
+classification:
+  # Product domain. Values: utility, social, marketplace, productivity, b2b,
+  # content, automation, developer-tool, education, health, finance,
+  # entertainment, communication.
+  # May have multiple domains for hybrid products.
+  domain: null
+
+  # Product shape. Values: ui-application, api-service, automation-pipeline,
+  # multi-party-platform, hybrid.
+  shape: null
+
+  # For hybrid products only: list the constituent shapes.
+  # Example: [ui-application, api-service]
+  sub_shapes: []
+
+  # Risk and complexity profile.
+  risk_profile:
+    # Overall risk: low, medium, high.
+    # Drives discovery depth (low: 5-8 questions, medium: 8-15, high: 15-25).
+    overall: null
+
+    # Specific risk factors identified during classification.
+    # Each: { factor, level (low/medium/high), rationale }
+    # Common factors: user-count, data-sensitivity, failure-impact,
+    # technical-complexity, regulatory-exposure.
+    factors: []
+
+# =============================================================================
+# PRODUCT DEFINITION
+# =============================================================================
+# Populated during Stages 1-2 (Discovery and Product Definition).
+# Items may be resolved (have a value) or open (null, with a corresponding
+# entry in open_questions).
+
+product_definition:
+  # One-sentence description of what this product is and why it exists.
+  vision: null
+
+  # Measurable success criteria. What does "this worked" look like?
+  # Each: a concrete, evaluable statement.
+  goals: []
+
+  # Who uses this product and what they need.
+  users:
+    # Each persona:
+    #   name: string (e.g., "Family Scorekeeper")
+    #   description: string
+    #   technical_level: none | basic | intermediate | advanced
+    #   primary_needs: [string]
+    #   constraints: [string]  (accessibility, device, connectivity, etc.)
+    personas: []
+
+  # Core user flows (UI), operations (API), or pipeline stages (automation).
+  # Each: { name, description, steps (optional), priority (must-have/nice-to-have) }
+  core_flows: []
+
+  # Scope decisions. Every feature/capability should land in exactly one bucket.
+  scope:
+    # Must have for initial release.
+    v1: []
+    # Design to accommodate but don't build yet.
+    accommodate: []
+    # Genuinely later — not needed for v1 to be useful.
+    later: []
+    # Explicitly out of scope, with rationale.
+    # Each: { item, rationale }
+    never: []
+
+  # Where this runs.
+  # Examples: "mobile (iOS + Android)", "web", "desktop", "CLI"
+  platform: null
+
+  # Non-functional requirements, calibrated to product risk.
+  nonfunctional:
+    # Target response time or throughput.
+    performance: null
+    # Expected user/data growth.
+    scalability: null
+    # Availability target (e.g., "best-effort" for a family app, "99.9%" for B2B).
+    uptime: null
+    # Budget constraints for hosting, APIs, services.
+    cost_constraints: null
+
+  # Regulatory or compliance constraints.
+  # Each: { regulation, applicability, impact }
+  # Empty for most low-risk products.
+  regulatory: []
+
+  # Estimated ongoing operational costs.
+  # Each: { item, estimated_monthly_cost, notes }
+  cost_estimates: []
+
+# =============================================================================
+# TECHNICAL DECISIONS
+# =============================================================================
+# Architecture, technology, and integration choices.
+# Every entry must include rationale (HR4: No Unexamined Decisions).
+# Each: { decision, rationale, alternatives_considered, date }
+
+technical_decisions:
+  architecture: []
+  technology: []
+  data_model: []
+  integrations: []
+  # Deployment, monitoring, recovery decisions.
+  operational: []
+
+# =============================================================================
+# DESIGN DECISIONS
+# =============================================================================
+# UX, IA, and visual direction. Populated only for products with a UI.
+# Each: { decision, rationale, date }
+
+design_decisions:
+  information_architecture: []
+  interaction_patterns: []
+  accessibility_approach: null
+  visual_direction: null
+
+# =============================================================================
+# ARTIFACT MANIFEST
+# =============================================================================
+# Tracks all generated artifacts, their versions, and relationships.
+# Maintained by the Artifact Generator (C3) and validated by the Critic (C6).
+
+artifact_manifest:
+  # Each artifact entry:
+  #   name: string (matches artifact frontmatter)
+  #   file_path: string (relative to project root)
+  #   version: integer
+  #   depends_on: [artifact names]
+  #   depended_on_by: [artifact names]
+  #   last_validated: date or null
+  #   tier: 1 | 2 | 3
+  artifacts: []
+
+# =============================================================================
+# DEPENDENCY GRAPH
+# =============================================================================
+# Maps decisions to their downstream impacts. Used for change propagation.
+# Each: { decision_id, description, affects_decisions: [], affects_artifacts: [] }
+
+dependency_graph: []
+
+# =============================================================================
+# OPEN QUESTIONS
+# =============================================================================
+# Unresolved decisions. Normal during discovery, should shrink toward zero
+# as the project approaches artifact generation.
+# Each:
+#   question: string
+#   blocking: string (what can't proceed until this is answered)
+#   waiting_on: "user" | "system" | "research"
+#   priority: high | medium | low
+#   raised_at_stage: string
+
+open_questions: []
+
+# =============================================================================
+# USER EXPERTISE PROFILE
+# =============================================================================
+# Inferred from conversation signals, never self-assessed (R1.3).
+# Updated continuously by the Orchestrator.
+# Drives vocabulary, explanation depth, and involvement calibration.
+
+user_expertise:
+  # Each dimension: none | basic | intermediate | advanced
+  product_thinking: null
+  technical_depth: null
+  design_sensibility: null
+  domain_knowledge: null
+  operational_awareness: null
+  # Evidence supporting inferences.
+  # Each: { dimension, signal, inferred_from }
+  evidence: []
+
+# =============================================================================
+# PROCESS STATE
+# =============================================================================
+# Current stage in the Prawduct process.
+# Values: intake, validation, discovery, definition, artifact-generation,
+#          build-planning, building, iteration
+
+current_stage: intake
+
+# =============================================================================
+# CHANGE LOG
+# =============================================================================
+# Record of significant changes to project state.
+# Each:
+#   what: string
+#   why: string
+#   blast_radius: string (what else is affected)
+#   classification: cosmetic | functional | directional
+#   date: YYYY-MM-DD
+
+change_log: []

--- a/tests/scenarios/family-utility.md
+++ b/tests/scenarios/family-utility.md
@@ -1,0 +1,132 @@
+# Test Scenario: Simple Family Utility
+
+## Scenario Overview
+
+- **Shape:** UI Application
+- **Domain:** Utility
+- **Risk Level:** Low
+- **Phase:** 1 (vertical slice scenario)
+- **Purpose:** Tests pacing sensitivity, scope restraint, and non-technical user handling. The system should NOT interrogate this the same way it interrogates a B2B platform.
+
+## Input
+
+> "I want to build an app for my family to keep track of scores when we play board games together"
+
+The input is deliberately vague, non-technical, and low-stakes. It signals a non-technical user with a simple, personal need.
+
+## Evaluation Rubric
+
+### Domain Analyzer (C2)
+
+**Must-do:**
+
+- Classify shape as UI Application.
+- Classify domain as Utility (Entertainment/Utility also acceptable).
+- Assign low risk profile.
+- Ask about core users (who in the family, how many, ages relevant?).
+- Ask about the core action (what does "track scores" mean — per-game results, running leaderboards, both?).
+- Ask about platform (phone at the table, web at home, both?).
+- Surface data persistence as a consideration (do historical scores matter, or is it session-by-session?).
+- Limit total discovery questions to 5-8 for this risk level.
+
+**Must-not-do:**
+
+- Must not ask about enterprise authentication, SSO, or complex authorization.
+- Must not ask about regulatory or compliance requirements.
+- Must not ask about API contracts, webhooks, or integrations.
+- Must not ask about monitoring infrastructure or alerting.
+- Must not recommend not building this.
+- Must not generate more than 10 discovery questions total.
+- Must not ask the user to self-assess their technical expertise.
+
+**Quality criteria:**
+
+- Questions are ordered by impact (most important first).
+- Questions use plain language — "Where will you use this?" not "What's your target platform?"
+- Inferences are made and confirmed rather than asked open-endedly: "Since this is for family game nights, I'm assuming you don't need enterprise security — just a simple way to identify who's playing. Sound right?"
+
+### Orchestrator (C1)
+
+**Must-do:**
+
+- Progress through stages 0 → 0.5 → 1 → 2 without excessive back-and-forth.
+- Infer non-technical user from input style and vocabulary.
+- Adjust vocabulary accordingly (no unexplained jargon).
+- Confirm classification in plain language.
+- Make reasonable assumptions and state them explicitly.
+- Recognize when discovery is "good enough" and transition to product definition.
+
+**Must-not-do:**
+
+- Must not conduct more than 2-3 rounds of discovery questions for this risk level.
+- Must not use technical terminology without explanation.
+- Must not ask the user to choose between technical alternatives they can't evaluate.
+- Must not require the user to make decisions outside their expertise.
+
+**Quality criteria:**
+
+- Conversation feels proportionate to the product's simplicity.
+- The user doesn't feel interrogated.
+- Assumptions are stated clearly enough that the user can correct them.
+- Stage transitions happen naturally, not abruptly.
+
+### Artifact Generator (C3)
+
+**Must-do:**
+
+- Produce all 7 universal artifacts: product brief, data model, security model, test specifications, non-functional requirements, operational spec, dependency manifest.
+- All artifacts have correct YAML frontmatter with dependency declarations.
+- Data model includes at minimum: Player, Game, Score/Session entities.
+- Security model is proportionate (simple player identification, not enterprise auth).
+- Test specifications include concrete scenarios — not "test scoring" but "test recording scores for a 3-player game of Catan" or equivalent specificity.
+- NFRs are proportionate (not demanding 99.99% uptime for a family app).
+- Operational spec is simple (single deployment target, basic backup).
+- Dependency manifest is minimal (no unnecessary third-party services).
+
+**Must-not-do:**
+
+- Must not generate UI-shape-specific artifacts (IA, screen specs, design direction, etc.) — those are Phase 2.
+- Must not generate API, automation, or multi-party artifacts.
+- Must not over-engineer the security model.
+- Must not specify enterprise-grade operational requirements.
+
+**Quality criteria:**
+
+- Artifacts are internally consistent (entities in data model appear in test specs and security model).
+- Cross-references between artifacts are accurate.
+- A coding agent reading these artifacts could begin building without ambiguity.
+- Complexity of artifacts is proportionate to the product.
+
+### Review Lenses (C4)
+
+**Must-do:**
+
+- Product Lens: confirms this solves a real (if small) problem; scope is appropriate.
+- Design Lens: raises first-run/empty state experience and basic accessibility.
+- Architecture Lens: raises data persistence choice and deployment simplicity.
+- Skeptic Lens: raises at least one realistic concern (e.g., data loss risk, offline use at game night, what happens when someone disputes a score).
+- Each finding has a specific recommendation, not just an observation.
+- Each finding has a severity level (blocking / warning / note).
+
+**Must-not-do:**
+
+- Must not raise enterprise-scale concerns for a family app.
+- Must not produce vague findings ("consider the user experience").
+- Must not block on concerns disproportionate to the risk level.
+
+**Quality criteria:**
+
+- Findings are specific and actionable.
+- Severity ratings are proportionate to the product's risk level.
+- Addressing the findings would measurably improve the artifacts.
+- No lens produces more than 3-5 findings for a low-risk utility.
+
+## End-to-End Success Criteria
+
+The vertical slice succeeds for this scenario when:
+
+1. Starting from the input above, the system produces a populated `project-state.yaml` with classification, product definition, and scope decisions.
+2. All 7 universal artifacts are generated with correct frontmatter, internal consistency, and cross-references.
+3. Review Lenses produce specific, actionable findings with appropriate severity.
+4. The total output is proportionate to the product's simplicity — a reader should not think "this is way too much process for a family score tracker."
+5. A coding agent (or human developer) reading the output would have a clear, unambiguous starting point for building this app.

--- a/tests/scenarios/family-utility.md
+++ b/tests/scenarios/family-utility.md
@@ -14,6 +14,38 @@
 
 The input is deliberately vague, non-technical, and low-stakes. It signals a non-technical user with a simple, personal need.
 
+## Test Conversation
+
+To ensure repeatable evaluation, the following scripted responses define what the test user says when asked about each topic. The evaluator provides these responses regardless of how the system phrases its questions. If the system doesn't ask about a topic (e.g., because it infers the answer), the corresponding response is not volunteered.
+
+**When asked to confirm classification or assumptions:**
+> "Yeah, that sounds right."
+>
+> Accept reasonable inferences. Only correct if the system makes an obviously wrong assumption.
+
+**When asked about users / who uses it:**
+> "Mostly my family — me, my wife, and our two kids, ages 10 and 14. Sometimes we have friends over for game night too, maybe 2-3 extra people."
+
+**When asked about the core action / what "track scores" means:**
+> "I'd love to keep track of scores during a game and also see a history over time. Like, who's winning at Catan overall."
+
+**When asked about platform / where they use it:**
+> "On our phones, at the table while we're playing."
+
+**When asked about data persistence / whether history matters:**
+> "Yeah, I'd want to keep the history. That's half the fun."
+
+**When asked about sharing / multi-user / how multiple people interact:**
+> "It would be cool if everyone could enter their own scores on their own phone."
+
+**When asked about current process / how they do it now:**
+> "We just use pen and paper. It works fine but we lose the paper and there's no history."
+
+**When asked about anything not covered above:**
+> Give a brief, non-technical, cooperative answer consistent with the persona: an enthusiastic, non-technical parent who wants something simple for family game nights.
+
+**General persona:** Enthusiastic but non-technical. Uses plain language. Doesn't volunteer technical requirements. Wants to get to building quickly. Does not push back on system recommendations.
+
 ## Evaluation Rubric
 
 ### Domain Analyzer (C2)
@@ -120,6 +152,45 @@ The input is deliberately vague, non-technical, and low-stakes. It signals a non
 - Severity ratings are proportionate to the product's risk level.
 - Addressing the findings would measurably improve the artifacts.
 - No lens produces more than 3-5 findings for a low-risk utility.
+
+### Project State (C5)
+
+The rubric evaluates the resulting `project-state.yaml` after the full process (Stages 0-2).
+
+**Must-do (structural):**
+
+- All populated fields use correct types per the template schema (strings for strings, lists for lists, etc.).
+- No fields added that don't exist in the template schema.
+- Risk factors include rationale, not just a level.
+
+**Must-do (content after Stages 0-2):**
+
+- `classification.domain`: populated ("utility" or "entertainment/utility").
+- `classification.shape`: "ui-application".
+- `classification.risk_profile.overall`: "low".
+- `classification.risk_profile.factors`: at least 2 evaluated factors with rationale.
+- `product_definition.vision`: a clear, specific one-sentence description (not generic).
+- `product_definition.users.personas`: at least one persona with name, description, and primary needs.
+- `product_definition.core_flows`: at least 2 flows (score recording, history viewing).
+- `product_definition.scope.v1`: at least 3 concrete items.
+- `product_definition.scope.later`: at least 1 item explicitly deferred.
+- `product_definition.platform`: populated (mobile).
+- `product_definition.nonfunctional`: at least performance and uptime populated, proportionate to risk level.
+- `user_expertise`: at least `technical_depth` and `product_thinking` inferred with evidence.
+- `current_stage`: "definition" or later.
+- `change_log`: at least 1 entry (initial classification).
+
+**Must-not-do:**
+
+- Must not leave classification fields null after Stage 0.
+- Must not add regulatory constraints for this scenario.
+- Must not set `risk_profile.overall` above "low" for this scenario.
+
+**Quality criteria:**
+
+- A reader of `project-state.yaml` alone — without seeing the conversation — can understand what's being built, for whom, and what's in v1 scope.
+- Values are specific, not generic ("family score-tracking app for board game nights" not "a utility application").
+- Scope decisions reflect the test conversation (score tracking and history in v1, fancier features deferred).
 
 ## End-to-End Success Criteria
 

--- a/tests/scenarios/family-utility.md
+++ b/tests/scenarios/family-utility.md
@@ -8,6 +8,43 @@
 - **Phase:** 1 (vertical slice scenario)
 - **Purpose:** Tests pacing sensitivity, scope restraint, and non-technical user handling. The system should NOT interrogate this the same way it interrogates a B2B platform.
 
+## Evaluation Procedure
+
+### Setup
+
+1. Create an isolated project directory for the evaluation. This must be **outside the prawduct repo** to avoid polluting the framework tree:
+   ```bash
+   mkdir -p /tmp/eval-family-utility
+   ```
+2. Copy the project-state template into it:
+   ```bash
+   cp templates/project-state.yaml /tmp/eval-family-utility/project-state.yaml
+   ```
+
+### Running the evaluation
+
+3. Start a new LLM conversation. Provide the prawduct framework context (CLAUDE.md, skills/, templates/, docs/) as reference material the LLM can read from, but set `/tmp/eval-family-utility` as the project directory where all output files go.
+4. Send the Input prompt (below) as the user's opening message.
+5. For each system question, respond using the scripted Test Conversation responses below. If the system asks about a topic not covered, respond in character as the test persona.
+6. Let the system run through Stages 0 → 0.5 → 1 → 2 → 3.
+
+### Evaluating results
+
+7. After the run completes, evaluate against the Evaluation Rubric (below) by checking:
+   - `/tmp/eval-family-utility/project-state.yaml` against the C5 criteria
+   - `/tmp/eval-family-utility/artifacts/*.md` against the C3 criteria
+   - The conversation transcript against C1, C2, and C4 criteria
+8. Record pass/fail for each must-do, must-not-do, and quality criterion.
+
+### Cleanup
+
+9. Delete the evaluation directory when done:
+   ```bash
+   rm -rf /tmp/eval-family-utility
+   ```
+
+Results should be recorded (pass/fail per criterion, notes on quality criteria, notable observations) before cleanup so regressions can be detected across evaluation runs.
+
 ## Input
 
 > "I want to build an app for my family to keep track of scores when we play board games together"

--- a/tests/scenarios/family-utility.md
+++ b/tests/scenarios/family-utility.md
@@ -176,6 +176,8 @@ The rubric evaluates the resulting `project-state.yaml` after the full process (
 - `product_definition.scope.later`: at least 1 item explicitly deferred.
 - `product_definition.platform`: populated (mobile).
 - `product_definition.nonfunctional`: at least performance and uptime populated, proportionate to risk level.
+- `technical_decisions`: at least one data storage decision and one deployment target decision, each with rationale.
+- `design_decisions.accessibility_approach`: populated (even if minimal, e.g., "standard platform accessibility").
 - `user_expertise`: at least `technical_depth` and `product_thinking` inferred with evidence.
 - `current_stage`: "definition" or later.
 - `change_log`: at least 1 entry (initial classification).


### PR DESCRIPTION
This PR establishes the complete design for Phase 1 (vertical slice) of Prawduct, replacing the component-by-component build order with a path-first approach. It includes skill implementations, validation strategy, and bootstrapping methodology.

## Summary

Prawduct's own development now follows the principle it teaches: prove the path before widening it. This PR defines:

1. **Vertical slice approach** — Build one scenario (family utility) end-to-end through all components before widening to other product shapes
2. **Skill implementations** — Complete SKILL.md files for Domain Analyzer (C2) and Artifact Generator (C3), defining their inputs, outputs, and interaction model
3. **Validation strategy** — Scenario-based evaluation rubrics with specific, observable criteria for testing non-deterministic LLM outputs
4. **Architecture decisions** — File-based persistence, artifact format with YAML frontmatter, skill switching within a single LLM context

## Key Changes

**Documentation (`docs/`)**
- Added "Skill Interaction Model" section defining how skills coordinate via shared Project State files
- Added "Artifact Format (V1)" specifying markdown + YAML frontmatter structure for all generated artifacts
- Added "Validation Strategy for Skills" with scenario-based evaluation rubrics and regression detection approach
- Added "Bootstrapping: Vertical Slice Approach" replacing the old component-by-component build order with Phase 1 → Phase 2 → Phase 3 progression
- Resolved 4 open questions (artifact format, agent protocol, persistence, bootstrapping) with concrete v1 answers
- Moved 3 questions to "Open" (multi-user, untested shapes, minimum Critic) with rationale for deferral

**Skills (`skills/`)**
- Added `domain-analyzer/SKILL.md` — Classifies product shape and domain, generates discovery questions tiered by decision impact, profiles risk, surfaces proactive expertise. Full implementation for UI Application + Utility domain; other shapes deferred to Phase 2.
- Added `artifact-generator/SKILL.md` — Generates universal artifact set (product brief, data model, security model, test specs, NFRs, operational spec, dependency manifest) from Project State. Validates cross-artifact consistency. Shape-specific artifacts deferred to Phase 2.

**Test Scenarios (`tests/scenarios/`)**
- Added directory structure for five test scenario rubrics (family utility, consumer mobile app, background pipeline, B2B API, two-sided marketplace)
- Family utility scenario is Phase 1 focus; others are Phase 2 targets

**Project Structure (`CLAUDE.md`)**
- Updated directory tree to reflect `tests/scenarios/` and new skill files

## Implementation Details

**Skill Interaction Model:**
- Skills are LLM instruction sets, not separate services
- Orchestrator (C1) is the default active skill; it loads other skills' instructions when needed
- All skills coordinate via `project-state.yaml` (YAML file in user's project directory)
- Artifacts are markdown files with YAML frontmatter for dependency tracking

**Validation Strategy:**
- Evaluation rubrics specify must-do, must-not-do, and quality criteria for each scenario
- Scripted user responses ensure reproducible evaluation (without defined responses, two evaluations diverge)
- Regression detection is judgment-based but structured — specific, observable criteria enable detection of regressions in non-deterministic outputs
- Evaluation isolation: each test run uses a temporary directory outside the prawduct repo

**Phase 1 Scope:**
- One scenario (family utility) end-to-end
- Universal artifacts only (no shape-specific artifacts yet)
- Domain Analyzer has full depth for UI Application + Utility; other shapes classified but with limited discovery
- Artifact Generator produces all universal artifacts; shape-specific ones added in Phase 2
- Defers: Critic (C6), mechanical tools, pacing sophistication, expertise calibration, other product shapes

**Proportionality Principle:**
- Security model for a family utility should NOT match a B2B platform
- NFRs for low-risk products fit on half a page
- Question budget scales with risk (5-8 for low, 8-15 for medium, 15-25 for high)
- Proactive expertise is surfaced as

https://claude.ai/code/session_01GWdPY1NVL5qsL7dbLuFebT