### PR TITLE
Strengthen PR review enforcement to match Critic model

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,5 +1,7 @@
 You are managing the PR lifecycle for this project. Detect the current state and take the appropriate action.
 
+**CRITICAL: The independent PR review is the core value of this skill. Do NOT skip, defer, or abbreviate the reviewer agent step. If you create a PR without running the reviewer first, the review gate has failed.**
+
 ## Context Detection
 
 Check git state to determine the action:
@@ -24,10 +26,31 @@ $ARGUMENTS
 
 ## Create Flow
 
-1. **Branch hygiene**: Verify on a feature branch (not main/master/develop). Verify commits ahead of base. If uncommitted changes, offer to commit or stash. Run the test suite.
-2. **Spawn PR reviewer agent**: Use the Task tool to spawn a separate agent. Tell it: "You are the PR reviewer. Read `agents/pr-reviewer/SKILL.md` for your review instructions. The project is at `$CLAUDE_PROJECT_DIR`. The base branch is `main`. Review the changes on the current branch."
-3. **Handle findings**: BLOCKING → present and stop. WARNING → present, proceed unless user objects. NOTE → include in output.
-4. **Create PR**: Push branch with `-u`. Draft title and description from work context + review findings. Create via `gh pr create`. Update evidence file with PR number.
+### Step 1: Branch hygiene
+Verify on a feature branch (not main/master/develop). Verify commits ahead of base. If uncommitted changes, offer to commit or stash. Run the test suite.
+
+### Step 2: Independent review — MANDATORY
+**STOP. Do NOT proceed to step 3 until the reviewer agent has completed and written its evidence file.**
+
+Spawn a **separate agent** (via the Task tool) for independent review. The reviewer must run in its own context — it has NOT seen your reasoning, and that independence is the point.
+
+Tell it: "You are the PR reviewer. Read `agents/pr-reviewer/SKILL.md` for your review instructions. The project is at `[project directory]`. The base branch is `[base branch]`. Review the changes on the current branch. Write your findings to `.prawduct/.pr-reviews/<branch-name>.json` (replace `/` with `--` in the branch name)."
+
+**Wait for the agent to complete.** Then:
+- Read the evidence file at `.prawduct/.pr-reviews/<branch-name>.json`
+- If the file does not exist, the review did not complete — do NOT proceed
+- Present findings to the user: BLOCKING → stop and fix. WARNING → present, proceed unless user objects. NOTE → include in output.
+
+### Step 3: Verify review gate
+Before creating the PR, confirm:
+- The evidence file `.prawduct/.pr-reviews/<branch-name>.json` exists
+- It contains valid JSON with a `findings` array and `summary` field
+- There are no unresolved BLOCKING findings
+
+If any check fails, STOP. Do not create the PR.
+
+### Step 4: Create PR
+Push branch with `-u`. Draft title and description from work context + review findings summary. Create via `gh pr create`. Update `pr_number` in the evidence file.
 
 ## Update Flow
 
@@ -40,7 +63,7 @@ $ARGUMENTS
 
 1. Verify CI checks pass (`gh pr checks`)
 2. Verify no merge conflicts
-3. Verify PR review evidence exists for this branch
+3. Verify PR review evidence exists for this branch — if missing, run the reviewer first
 4. Merge using squash strategy (or project-configured strategy from project-preferences.md)
 5. Delete remote branch, switch to base branch, pull, delete local branch
 6. Clean up evidence file
@@ -51,12 +74,13 @@ Show: PR URL, CI status, review status, approval status, merge readiness.
 
 ## Evidence
 
-PR review evidence is stored in `.prawduct/.pr-reviews/<branch-name>.json` (with `/` replaced by `--` in filenames). This is checked by the stop hook.
+PR review evidence is stored in `.prawduct/.pr-reviews/<branch-name>.json` (with `/` replaced by `--` in filenames). The stop hook BLOCKS session end if a PR exists without review evidence.
 
 ## Important
 
-- The PR reviewer runs as a **separate agent** via the Task tool — it must have independent context
+- The PR reviewer runs as a **separate agent** — it must have independent context
 - For the framework repo itself, the reviewer reads `agents/pr-reviewer/SKILL.md`
 - For product repos, the reviewer reads `.prawduct/pr-review.md`
 - Always run the full test suite before creating a PR
 - Include review findings summary in the PR description
+- **Never run `gh pr create` without a valid evidence file on disk**

--- a/.prawduct/artifacts/build-plan.md
+++ b/.prawduct/artifacts/build-plan.md
@@ -30,12 +30,12 @@
 **Files:**
 - `tools/prawduct-init.py` — deploy pr-review.md, commands/pr.md, .pr-reviews/ gitignore
 - `tools/prawduct-sync.py` — add manifest entries for new files
-- `tools/product-hook` — stop hook advisory for PR review evidence
+- `tools/product-hook` — stop hook gate (blocker) for PR review evidence
 - `tests/test_pr_reviewer.py` — tests for init/sync/hook integration
 - `.prawduct/cross-cutting-concerns.md` — add PR Review row
 - `.prawduct/project-state.yaml` — update WIP, test count, change log
 
-**Acceptance:** `prawduct-init.py` creates all PR reviewer files in new products. Sync updates them. Stop hook warns if PR created without review evidence. All tests pass.
+**Acceptance:** `prawduct-init.py` creates all PR reviewer files in new products. Sync updates them. Stop hook blocks if PR exists without review evidence. All tests pass.
 
 ## Post-Build
 - Critic review after chunk 3

--- a/.prawduct/artifacts/pr-reviewer-design.md
+++ b/.prawduct/artifacts/pr-reviewer-design.md
@@ -231,7 +231,7 @@ The `/pr` skill is defined as a Claude Code command file in the product repo, pl
 
 ### Stop hook enhancement
 
-The stop hook gains a third check: if a PR was created this session (detectable via `gh pr list --author @me --state open` or git reflog), warn if no PR review evidence exists for that branch. This is advisory (WARNING), not blocking — the Critic gate remains the hard block.
+The stop hook gains a third gate: if a PR exists for the current branch, block session end if no valid PR review evidence exists. This matches the Critic's enforcement model — both are BLOCKING gates with evidence file validation.
 
 ### Build methodology reference
 
@@ -253,7 +253,7 @@ Add "PR Review" row to `.prawduct/cross-cutting-concerns.md`:
 | **Scope** | One chunk's changes | Full PR diff (all chunks) |
 | **Perspective** | Is the work good? | Is this ready to merge? |
 | **Key concerns** | Spec compliance, tests, coherence | Bugs, scope, narrative, simplification |
-| **Enforcement** | BLOCKING (stop hook) | WARNING (stop hook advisory) |
+| **Enforcement** | BLOCKING (stop hook) | BLOCKING (stop hook gate) |
 | **Independence** | Separate agent (Task tool) | Separate agent (Task tool) |
 
 ## Configuration

--- a/.prawduct/cross-cutting-concerns.md
+++ b/.prawduct/cross-cutting-concerns.md
@@ -25,7 +25,7 @@ Maps concerns to pipeline coverage. Use this as a starting point for completenes
 | Infrastructure dependencies | discovery.md: Surface Infrastructure Dependencies | project-state.yaml: `infrastructure_dependencies` | building.md: Verify step + Common Traps | Goal 2 (Nothing Is Missing) + Goal 4 (Coherence) | Full coverage |
 | Boundary coherence | Structural: detected at build time | boundary-patterns.md | building.md: Investigated Changes | Goal 5 (Decisions Were Deliberate) | v5: boundary investigation + compliance canary |
 | Subagent governance | — | .subagent-briefing.md (generated) | building.md: Delegating Work | Goal 4 (Everything Is Coherent) | v5: briefing file + Critic reviews all output |
-| PR review | N/A (framework capability) | agents/pr-reviewer/SKILL.md, templates/pr-review.md | building.md: Creating Pull Requests | N/A (PR reviewer is peer of Critic) | `/pr` skill invokes reviewer agent; stop hook advisory |
+| PR review | N/A (framework capability) | agents/pr-reviewer/SKILL.md, templates/pr-review.md | building.md: Creating Pull Requests | N/A (PR reviewer is peer of Critic) | `/pr` skill invokes reviewer agent; stop hook blocks without evidence |
 
 ## Known Gaps
 

--- a/agents/pr-reviewer/SKILL.md
+++ b/agents/pr-reviewer/SKILL.md
@@ -147,7 +147,7 @@ After PR creation, update `pr_number` in the evidence file. After merge, delete 
 | **Scope** | One chunk's changes | Full PR diff (all chunks) |
 | **Perspective** | Is the work good? | Is this ready to merge? |
 | **Key concerns** | Spec compliance, tests, coherence | Bugs, scope, narrative, simplification |
-| **Enforcement** | BLOCKING (stop hook) | WARNING (stop hook advisory) |
+| **Enforcement** | BLOCKING (stop hook) | BLOCKING (stop hook gate) |
 | **Independence** | Separate agent (Task tool) | Separate agent (Task tool) |
 
 ## Extending This Skill

--- a/templates/commands-pr.md
+++ b/templates/commands-pr.md
@@ -1,5 +1,7 @@
 You are managing the PR lifecycle for this project. Detect the current state and take the appropriate action.
 
+**CRITICAL: The independent PR review is the core value of this skill. Do NOT skip, defer, or abbreviate the reviewer agent step. If you create a PR without running the reviewer first, the review gate has failed.**
+
 ## Context Detection
 
 Check git state to determine the action:
@@ -24,10 +26,31 @@ $ARGUMENTS
 
 ## Create Flow
 
-1. **Branch hygiene**: Verify on a feature branch (not main/master/develop). Verify commits ahead of base. If uncommitted changes, offer to commit or stash. Run the test suite.
-2. **Spawn PR reviewer agent**: Use the Task tool to spawn a separate agent. Tell it: "You are the PR reviewer. Read `.prawduct/pr-review.md` for your review instructions. The project is at `$CLAUDE_PROJECT_DIR`. The base branch is `main`. Review the changes on the current branch."
-3. **Handle findings**: BLOCKING → present and stop. WARNING → present, proceed unless user objects. NOTE → include in output.
-4. **Create PR**: Push branch with `-u`. Draft title and description from work context + review findings. Create via `gh pr create`. Update evidence file with PR number.
+### Step 1: Branch hygiene
+Verify on a feature branch (not main/master/develop). Verify commits ahead of base. If uncommitted changes, offer to commit or stash. Run the test suite.
+
+### Step 2: Independent review — MANDATORY
+**STOP. Do NOT proceed to step 3 until the reviewer agent has completed and written its evidence file.**
+
+Spawn a **separate agent** (via the Task tool) for independent review. The reviewer must run in its own context — it has NOT seen your reasoning, and that independence is the point.
+
+Tell it: "You are the PR reviewer. Read `.prawduct/pr-review.md` for your review instructions. The project is at `[project directory]`. The base branch is `[base branch]`. Review the changes on the current branch. Write your findings to `.prawduct/.pr-reviews/<branch-name>.json` (replace `/` with `--` in the branch name)."
+
+**Wait for the agent to complete.** Then:
+- Read the evidence file at `.prawduct/.pr-reviews/<branch-name>.json`
+- If the file does not exist, the review did not complete — do NOT proceed
+- Present findings to the user: BLOCKING → stop and fix. WARNING → present, proceed unless user objects. NOTE → include in output.
+
+### Step 3: Verify review gate
+Before creating the PR, confirm:
+- The evidence file `.prawduct/.pr-reviews/<branch-name>.json` exists
+- It contains valid JSON with a `findings` array and `summary` field
+- There are no unresolved BLOCKING findings
+
+If any check fails, STOP. Do not create the PR.
+
+### Step 4: Create PR
+Push branch with `-u`. Draft title and description from work context + review findings summary. Create via `gh pr create`. Update `pr_number` in the evidence file.
 
 ## Update Flow
 
@@ -40,7 +63,7 @@ $ARGUMENTS
 
 1. Verify CI checks pass (`gh pr checks`)
 2. Verify no merge conflicts
-3. Verify PR review evidence exists for this branch
+3. Verify PR review evidence exists for this branch — if missing, run the reviewer first
 4. Merge using squash strategy (or project-configured strategy from project-preferences.md)
 5. Delete remote branch, switch to base branch, pull, delete local branch
 6. Clean up evidence file
@@ -51,11 +74,12 @@ Show: PR URL, CI status, review status, approval status, merge readiness.
 
 ## Evidence
 
-PR review evidence is stored in `.prawduct/.pr-reviews/<branch-name>.json` (with `/` replaced by `--` in filenames). This is checked by the stop hook.
+PR review evidence is stored in `.prawduct/.pr-reviews/<branch-name>.json` (with `/` replaced by `--` in filenames). The stop hook BLOCKS session end if a PR exists without review evidence.
 
 ## Important
 
-- The PR reviewer runs as a **separate agent** via the Task tool — it must have independent context
+- The PR reviewer runs as a **separate agent** — it must have independent context
 - The reviewer reads `.prawduct/pr-review.md` for its instructions
 - Always run the full test suite before creating a PR
 - Include review findings summary in the PR description
+- **Never run `gh pr create` without a valid evidence file on disk**

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -350,6 +350,72 @@ class TestStopPrReviewGate:
         # No PR review blocker expected
         assert "PR REVIEW" not in result.stderr
 
+    def test_stop_with_pr_and_malformed_json_blocks(self, tmp_path: Path):
+        """When evidence file has malformed JSON, stop should block."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        reviews_dir = prawduct / ".pr-reviews"
+        reviews_dir.mkdir()
+        evidence = reviews_dir / "feature--test-pr.json"
+        evidence.write_text("not valid json {{{")
+
+        git_script = "\n".join([
+            'if [[ "$1" == "rev-parse" ]]; then echo ".git"; exit 0; fi',
+            'if [[ "$1" == "status" ]]; then printf ""; exit 0; fi',
+            'if [[ "$1" == "branch" && "$2" == "--show-current" ]]; then echo "feature/test-pr"; exit 0; fi',
+        ])
+        gh_script = "\n".join([
+            'if [[ "$1" == "pr" && "$2" == "list" ]]; then echo \'[{"number": 42}]\'; exit 0; fi',
+        ])
+
+        result = run_hook("stop", tmp_path, git_script=git_script, gh_script_body=gh_script)
+        assert result.returncode == 2
+        assert "PR REVIEW" in result.stderr
+
+    def test_stop_with_pr_and_evidence_missing_findings_blocks(self, tmp_path: Path):
+        """When evidence file is missing 'findings' key, stop should block."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        reviews_dir = prawduct / ".pr-reviews"
+        reviews_dir.mkdir()
+        evidence = reviews_dir / "feature--test-pr.json"
+        evidence.write_text(json.dumps({"summary": "No issues.", "branch": "feature/test-pr"}))
+
+        git_script = "\n".join([
+            'if [[ "$1" == "rev-parse" ]]; then echo ".git"; exit 0; fi',
+            'if [[ "$1" == "status" ]]; then printf ""; exit 0; fi',
+            'if [[ "$1" == "branch" && "$2" == "--show-current" ]]; then echo "feature/test-pr"; exit 0; fi',
+        ])
+        gh_script = "\n".join([
+            'if [[ "$1" == "pr" && "$2" == "list" ]]; then echo \'[{"number": 42}]\'; exit 0; fi',
+        ])
+
+        result = run_hook("stop", tmp_path, git_script=git_script, gh_script_body=gh_script)
+        assert result.returncode == 2
+        assert "PR REVIEW" in result.stderr
+
+    def test_stop_with_pr_and_evidence_missing_summary_blocks(self, tmp_path: Path):
+        """When evidence file is missing 'summary' key, stop should block."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        reviews_dir = prawduct / ".pr-reviews"
+        reviews_dir.mkdir()
+        evidence = reviews_dir / "feature--test-pr.json"
+        evidence.write_text(json.dumps({"findings": [], "branch": "feature/test-pr"}))
+
+        git_script = "\n".join([
+            'if [[ "$1" == "rev-parse" ]]; then echo ".git"; exit 0; fi',
+            'if [[ "$1" == "status" ]]; then printf ""; exit 0; fi',
+            'if [[ "$1" == "branch" && "$2" == "--show-current" ]]; then echo "feature/test-pr"; exit 0; fi',
+        ])
+        gh_script = "\n".join([
+            'if [[ "$1" == "pr" && "$2" == "list" ]]; then echo \'[{"number": 42}]\'; exit 0; fi',
+        ])
+
+        result = run_hook("stop", tmp_path, git_script=git_script, gh_script_body=gh_script)
+        assert result.returncode == 2
+        assert "PR REVIEW" in result.stderr
+
     def test_stop_on_main_branch_skips_pr_check(self, tmp_path: Path):
         """PR review check should skip main/master/develop branches."""
         prawduct = tmp_path / ".prawduct"

--- a/tests/test_pr_reviewer.py
+++ b/tests/test_pr_reviewer.py
@@ -277,11 +277,11 @@ class TestCreateManifestPrEntries:
 
 
 # =============================================================================
-# Hook: Stop advisory for PR review evidence
+# Hook: Stop gate for PR review evidence
 # =============================================================================
 
 
-class TestStopPrReviewAdvisory:
+class TestStopPrReviewGate:
     def test_stop_clean_without_pr(self, tmp_path: Path):
         """Stop hook exits clean when there's no PR."""
         prawduct = tmp_path / ".prawduct"
@@ -290,8 +290,8 @@ class TestStopPrReviewAdvisory:
         result = run_hook("stop", tmp_path, git_output="")
         assert result.returncode == 0
 
-    def test_stop_with_pr_no_evidence_warns(self, tmp_path: Path):
-        """When a PR exists but no review evidence, stop should include advisory."""
+    def test_stop_with_pr_no_evidence_blocks(self, tmp_path: Path):
+        """When a PR exists but no review evidence, stop should BLOCK."""
         prawduct = tmp_path / ".prawduct"
         prawduct.mkdir()
 
@@ -310,10 +310,10 @@ class TestStopPrReviewAdvisory:
             git_script=git_script,
             gh_script_body=gh_script,
         )
-        # Advisory is in canary findings (stderr), not a blocker
-        assert result.returncode == 0
-        # The warning about PR without evidence should be in stderr
-        assert "PR exists for branch" in result.stderr or "PR review evidence" in result.stderr
+        # PR without evidence is now a blocker, not advisory
+        assert result.returncode == 2
+        assert "PR REVIEW" in result.stderr
+        assert "PR exists for branch" in result.stderr or "no review evidence" in result.stderr
 
     def test_stop_with_pr_and_evidence_no_warning(self, tmp_path: Path):
         """When PR exists AND review evidence exists, no warning."""
@@ -347,8 +347,8 @@ class TestStopPrReviewAdvisory:
             gh_script_body=gh_script,
         )
         assert result.returncode == 0
-        # No PR review warning expected
-        assert "PR review evidence" not in result.stderr
+        # No PR review blocker expected
+        assert "PR REVIEW" not in result.stderr
 
     def test_stop_on_main_branch_skips_pr_check(self, tmp_path: Path):
         """PR review check should skip main/master/develop branches."""
@@ -392,6 +392,21 @@ class TestPrReviewTemplateContent:
         assert "Update Flow" in content
         assert "Merge Flow" in content
         assert "Status Flow" in content
+
+    def test_pr_command_template_has_review_gate(self):
+        """The /pr command template must enforce review before PR creation."""
+        content = (FRAMEWORK_DIR / "templates" / "commands-pr.md").read_text()
+        # Must contain hard gate language, not just numbered steps
+        assert "MANDATORY" in content
+        assert "Do NOT proceed" in content or "DO NOT proceed" in content
+        assert "evidence file" in content
+
+    def test_framework_pr_command_has_review_gate(self):
+        """The framework /pr command must enforce review before PR creation."""
+        content = (FRAMEWORK_DIR / ".claude" / "commands" / "pr.md").read_text()
+        assert "MANDATORY" in content
+        assert "Do NOT proceed" in content or "DO NOT proceed" in content
+        assert "evidence file" in content
 
     def test_agent_skill_matches_template_goals(self):
         """The full SKILL.md and condensed template should have the same goals."""

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -1184,8 +1184,7 @@ def cmd_stop(project_dir: Path) -> int:
                     "  After review, record findings to .prawduct/.critic-findings.json\n"
                 )
 
-    # Advisory: PR review evidence check
-    # If a PR was created this session but no review evidence exists, warn
+    # Gate 3: PR review evidence (when a PR exists for the current branch)
     pr_reviews_dir = prawduct_dir / ".pr-reviews"
     try:
         branch_result = subprocess.run(
@@ -1208,15 +1207,24 @@ def cmd_stop(project_dir: Path) -> int:
                     pass
 
             if has_pr:
-                # Check for review evidence
+                # Check for review evidence with content validation
                 branch_file = current_branch.replace("/", "--") + ".json"
                 evidence_path = pr_reviews_dir / branch_file
-                if not evidence_path.is_file():
-                    canary_findings.append(
-                        f"PR exists for branch '{current_branch}' but no PR review evidence found. "
-                        f"Use /pr to run the PR reviewer before merging."
+                pr_review_valid = False
+                if evidence_path.is_file():
+                    try:
+                        data = json.loads(evidence_path.read_text())
+                        if isinstance(data.get("findings"), list) and data.get("summary"):
+                            pr_review_valid = True
+                    except (json.JSONDecodeError, OSError):
+                        pass
+                if not pr_review_valid:
+                    blockers.append(
+                        f"PR REVIEW: PR exists for branch '{current_branch}' but no valid review evidence found.\n"
+                        "  Run /pr to invoke the PR reviewer before merging.\n"
+                        "  The reviewer writes evidence to .prawduct/.pr-reviews/<branch>.json\n"
                     )
-    except Exception:  # prawduct:ok-broad-except — advisory check must never block session end
+    except Exception:  # prawduct:ok-broad-except — gate check must not crash session end
         pass
 
     # Report blockers or exit clean


### PR DESCRIPTION
## Summary
- Upgrades PR review stop hook from advisory (canary) to **blocker** (exit code 2) — matches Critic enforcement model
- Restructures `/pr` slash command with hard gate language: STOP/MANDATORY before PR creation, explicit evidence file verification step
- Adds JSON content validation to stop hook (checks for `findings` array + `summary` field)
- Updates all artifacts that described enforcement as "advisory" (SKILL.md, design doc, build plan, cross-cutting concerns)
- 5 new tests: 3 for content validation (malformed JSON, missing findings, missing summary) + 2 for gate language in command files

650 tests pass, 0 regressions.

## PR Review Findings (resolved)
- **WARNING: Stale documentation** — 4 artifacts still said "advisory". Fixed in second commit.
- **WARNING: Missing content validation tests** — 3 tests added for malformed/incomplete evidence. Fixed in second commit.
- **NOTE: Decision rationale** — Commit message explains the what; the why (reviewer was skipped during actual use) is documented in the PR description.

## Test plan
- [x] Full test suite passes (650 tests)
- [x] `test_stop_with_pr_no_evidence_blocks` — verifies exit code 2
- [x] `test_stop_with_pr_and_malformed_json_blocks` — malformed JSON blocks
- [x] `test_stop_with_pr_and_evidence_missing_findings_blocks` — missing findings key blocks
- [x] `test_stop_with_pr_and_evidence_missing_summary_blocks` — missing summary key blocks
- [x] `test_pr_command_template_has_review_gate` — gate language in product template
- [x] `test_framework_pr_command_has_review_gate` — gate language in framework command

🤖 Generated with [Claude Code](https://claude.com/claude-code)