### PR TITLE
Backfill missing managed files during sync

### DIFF
--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -404,7 +404,7 @@ build_plan:
 build_state:
   source_root: "."
   test_tracking:
-    test_count: 670
+    test_count: 672
     test_files:
       - tests/scenarios/family-utility.md
       - tests/scenarios/background-data-pipeline.md

--- a/tests/test_prawduct_sync.py
+++ b/tests/test_prawduct_sync.py
@@ -30,6 +30,7 @@ run_sync = _mod.run_sync
 _try_pull_framework = _mod._try_pull_framework
 BLOCK_BEGIN = _mod.BLOCK_BEGIN
 BLOCK_END = _mod.BLOCK_END
+MANAGED_FILES = _mod.MANAGED_FILES
 
 
 # =============================================================================
@@ -566,6 +567,57 @@ class TestRunSync:
         assert result["synced"] is True
         data = json.loads((product / ".claude" / "settings.json").read_text())
         assert "TestApp" in data["companyAnnouncements"]
+
+    def test_backfills_missing_managed_files(self, tmp_path: Path):
+        """Sync adds managed files missing from manifest (added after product init)."""
+        fw = self._setup_framework(tmp_path)
+        product = self._setup_product(tmp_path, fw)
+
+        # Add a new template to the framework (simulating a new managed file)
+        (fw / "templates" / "pr-review.md").write_text("# {{PRODUCT_NAME}} PR Review v1")
+        (fw / "templates" / "commands-pr.md").write_text("# PR command for {{PRODUCT_NAME}}")
+
+        # Remove pr-review and commands/pr from the manifest (simulating old product)
+        manifest_path = product / ".prawduct" / "sync-manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["files"].pop(".prawduct/pr-review.md", None)
+        manifest["files"].pop(".claude/commands/pr.md", None)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+        result = run_sync(str(product), framework_dir=str(fw))
+        assert result["synced"] is True
+        assert any("Registered" in a and "pr-review" in a for a in result["actions"])
+        assert any("Registered" in a and "pr.md" in a for a in result["actions"])
+        assert (product / ".prawduct" / "pr-review.md").is_file()
+        assert (product / ".claude" / "commands" / "pr.md").is_file()
+
+        # Verify manifest now includes the new files
+        manifest = json.loads(manifest_path.read_text())
+        assert ".prawduct/pr-review.md" in manifest["files"]
+        assert ".claude/commands/pr.md" in manifest["files"]
+
+    def test_backfill_idempotent(self, tmp_path: Path):
+        """Running sync twice after backfill produces no updates."""
+        fw = self._setup_framework(tmp_path)
+        product = self._setup_product(tmp_path, fw)
+
+        (fw / "templates" / "pr-review.md").write_text("# {{PRODUCT_NAME}} PR Review v1")
+        (fw / "templates" / "commands-pr.md").write_text("# PR command for {{PRODUCT_NAME}}")
+
+        # Remove from manifest
+        manifest_path = product / ".prawduct" / "sync-manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["files"].pop(".prawduct/pr-review.md", None)
+        manifest["files"].pop(".claude/commands/pr.md", None)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+        # First sync creates files
+        run_sync(str(product), framework_dir=str(fw))
+
+        # Second sync — nothing to do
+        result = run_sync(str(product), framework_dir=str(fw))
+        assert result["synced"] is False
+        assert result["reason"] == "no updates needed"
 
 
 # =============================================================================

--- a/tools/prawduct-sync.py
+++ b/tools/prawduct-sync.py
@@ -35,6 +35,35 @@ from pathlib import Path
 BLOCK_BEGIN = "<!-- PRAWDUCT:BEGIN -->"
 BLOCK_END = "<!-- PRAWDUCT:END -->"
 
+# Canonical list of framework-managed files. Used by create_manifest (at init)
+# and run_sync (to backfill files added after a product was initialized).
+MANAGED_FILES = {
+    "CLAUDE.md": {
+        "template": "templates/product-claude.md",
+        "strategy": "block_template",
+    },
+    ".prawduct/critic-review.md": {
+        "template": "templates/critic-review.md",
+        "strategy": "template",
+    },
+    ".prawduct/pr-review.md": {
+        "template": "templates/pr-review.md",
+        "strategy": "template",
+    },
+    ".claude/commands/pr.md": {
+        "template": "templates/commands-pr.md",
+        "strategy": "template",
+    },
+    "tools/product-hook": {
+        "source": "tools/product-hook",
+        "strategy": "always_update",
+    },
+    ".claude/settings.json": {
+        "template": "templates/product-settings.json",
+        "strategy": "merge_settings",
+    },
+}
+
 
 def log(msg: str) -> None:
     """Print status to stderr."""
@@ -166,35 +195,7 @@ def create_manifest(
     """
     files: dict[str, dict] = {}
 
-    # Define the managed file configs
-    file_configs = {
-        "CLAUDE.md": {
-            "template": "templates/product-claude.md",
-            "strategy": "block_template",
-        },
-        ".prawduct/critic-review.md": {
-            "template": "templates/critic-review.md",
-            "strategy": "template",
-        },
-        ".prawduct/pr-review.md": {
-            "template": "templates/pr-review.md",
-            "strategy": "template",
-        },
-        ".claude/commands/pr.md": {
-            "template": "templates/commands-pr.md",
-            "strategy": "template",
-        },
-        "tools/product-hook": {
-            "source": "tools/product-hook",
-            "strategy": "always_update",
-        },
-        ".claude/settings.json": {
-            "template": "templates/product-settings.json",
-            "strategy": "merge_settings",
-        },
-    }
-
-    for rel_path, config in file_configs.items():
+    for rel_path, config in MANAGED_FILES.items():
         entry = dict(config)
         entry["generated_hash"] = file_hashes.get(rel_path)
         files[rel_path] = entry
@@ -519,6 +520,14 @@ def run_sync(product_dir: str, framework_dir: str | None = None, *, no_pull: boo
         manifest = json.loads(manifest_path.read_text())
 
     files = manifest.get("files", {})
+
+    # Backfill: add any managed files missing from the manifest (added after init)
+    for rel_path, config in MANAGED_FILES.items():
+        if rel_path not in files:
+            files[rel_path] = dict(config)
+            files[rel_path]["generated_hash"] = None  # Forces creation on first sync
+            actions.append(f"Registered {rel_path} (new managed file)")
+
     updated_files = dict(files)
 
     for rel_path, config in files.items():


### PR DESCRIPTION
## Summary
- Products initialized before new managed files were added (pr-review.md, commands/pr.md) never received them via sync
- Sync now compares manifest against canonical MANAGED_FILES list and registers missing entries
- Extracted file_configs into shared module-level constant

## Test plan
- [x] 672 tests pass (2 new: backfill creation + idempotency)
- [x] Verified end-to-end on discodon — both pr-review.md and commands/pr.md created

🤖 Generated with [Claude Code](https://claude.com/claude-code)