### PR TITLE
Backfill missing sync files + test_count briefing reminder

### DIFF
--- a/tests/test_v5_hooks.py
+++ b/tests/test_v5_hooks.py
@@ -503,6 +503,38 @@ class TestSessionBriefing:
         # Should NOT show first 2
         assert "When doing A" not in result.stdout
 
+    def test_briefing_shows_test_count_reminder(self, tmp_path: Path):
+        """Briefing should show test_count and remind to keep it updated."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        (prawduct / "project-state.yaml").write_text(
+            'product_identity:\n  name: "MyApp"\n\n'
+            "build_state:\n  source_root: null\n  test_tracking:\n    test_count: 42\n"
+        )
+
+        result = run_hook("clear", tmp_path)
+
+        assert "test_count" in result.stdout
+        assert "42" in result.stdout
+        assert "update" in result.stdout.lower()
+
+    def test_briefing_no_test_count_when_zero(self, tmp_path: Path):
+        """Briefing should not show test_count reminder when count is 0."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        (prawduct / "project-state.yaml").write_text(
+            'product_identity:\n  name: "MyApp"\n\n'
+            "build_state:\n  source_root: null\n  test_tracking:\n    test_count: 0\n"
+        )
+
+        result = run_hook("clear", tmp_path)
+
+        # 0 is valid but the regex matches \d+ which includes 0 — check that
+        # it doesn't show a reminder for count 0 (no tests to track)
+        briefing = result.stdout
+        # The line should not appear since there's nothing to track
+        assert "if you add or remove tests" not in briefing
+
     def test_briefing_excludes_redundant_reminders(self, tmp_path: Path):
         """Briefing should not include reminders that are already in CLAUDE.md Critical Rules."""
         prawduct = tmp_path / ".prawduct"

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -448,6 +448,17 @@ def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
         for s in staleness:
             lines.append(f"Stale: {s}")
 
+    # Test count reminder (skip if 0 — nothing to track yet)
+    state_path = prawduct_dir / "project-state.yaml"
+    if state_path.is_file():
+        try:
+            state_content = state_path.read_text()
+            tc_match = re.search(r"test_count:\s*(\d+)", state_content)
+            if tc_match and int(tc_match.group(1)) > 0:
+                lines.append(f"test_count in project-state.yaml: {tc_match.group(1)} — if you add or remove tests, update this before session end")
+        except Exception:  # prawduct:ok-broad-except — briefing must never block session start
+            pass
+
     # Relevant learnings
     learnings_path = prawduct_dir / "learnings.md"
     if learnings_path.is_file():


### PR DESCRIPTION
## Summary
- **Sync backfill**: Products initialized before new managed files were added now receive them automatically during sync (fixes missing /pr skill in older products)
- **test_count briefing reminder**: Session briefing shows documented test_count and reminds agent to update if tests change — no subprocess, just a nudge

## Test plan
- [x] Verified backfill end-to-end on discodon (pr-review.md and commands/pr.md created)
- [x] 674 tests pass (4 new: 2 backfill + 2 briefing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)