### PR TITLE
Critic duration tracking + do-not-interrupt guidance

### DIFF
--- a/agents/critic/SKILL.md
+++ b/agents/critic/SKILL.md
@@ -156,6 +156,7 @@ If no findings: "No issues found. Changes are ready to proceed."
 ```json
 {
   "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
+  "duration_seconds": 180,
   "files_reviewed": ["file1", "file2"],
   "findings": [
     {"goal": "Nothing Is Unintended", "severity": "warning", "summary": "Description"}
@@ -163,6 +164,8 @@ If no findings: "No issues found. Changes are ready to proceed."
   "summary": "N warnings. Changes ready to proceed."
 }
 ```
+
+`duration_seconds` is your best estimate of how long the review took (wall-clock, from activation to writing findings). This is surfaced in the session briefing to set expectations for future reviews.
 
 For a clean review, findings array is empty and summary says "No issues found."
 

--- a/methodology/building.md
+++ b/methodology/building.md
@@ -189,6 +189,8 @@ For medium/large reviews, the Critic uses a coordinator pattern — spawning par
 
 See `agents/critic/SKILL.md` (framework) or `.prawduct/critic-review.md` (products) for full instructions.
 
+**The Critic takes time.** Reviews typically take 1-5 minutes depending on codebase size and change scope. Do not check on it, interrupt it, or send messages to hurry it along — the Agent tool notifies you when it completes. Do other work while waiting, or simply wait.
+
 **Blocking findings** must be resolved before proceeding. **Warnings** should be addressed — the Critic only uses WARNING when confident something is a real issue. **Notes** are genuinely ambiguous — the Critic isn't sure and the builder should decide. If you disagree with a finding, think carefully before dismissing — the Critic catches blind spots the builder can't see.
 
 ## Creating Pull Requests

--- a/templates/critic-review.md
+++ b/templates/critic-review.md
@@ -80,6 +80,7 @@ Write to `.prawduct/.critic-findings.json`:
 ```json
 {
   "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
+  "duration_seconds": 180,
   "files_reviewed": ["src/app.py"],
   "findings": [
     {"goal": "Nothing Is Unintended", "severity": "warning", "summary": "description"}
@@ -87,5 +88,7 @@ Write to `.prawduct/.critic-findings.json`:
   "summary": "1 warning. Changes ready to proceed after addressing."
 }
 ```
+
+`duration_seconds`: your best estimate of wall-clock review time. Surfaced in session briefing to set expectations.
 
 Clean review: empty findings array, summary says "No issues found."

--- a/templates/product-claude.md
+++ b/templates/product-claude.md
@@ -103,6 +103,8 @@ Spawn a new agent (Task tool) and tell it:
 
 The Critic receives goals and signals (files changed, work type, work size) and reasons about what to check. It is not a fixed checklist — it focuses on what matters for the specific change.
 
+**The Critic takes time.** Reviews typically take 1-5 minutes depending on codebase size and change scope. Do not check on it, interrupt it, or send messages to hurry it along — the Agent tool notifies you when it completes. Do other work while waiting, or simply wait.
+
 ## Compact Instructions
 
 When compacting, preserve: what's being built, current work and governance level, unresolved issues, instruction to re-read CLAUDE.md and learnings.md, Critic review requirement, reflection requirement, in-progress learnings. Do NOT inline full file contents — summarize what was learned and reference file paths for re-reading.

--- a/tests/test_v5_hooks.py
+++ b/tests/test_v5_hooks.py
@@ -535,6 +535,46 @@ class TestSessionBriefing:
         # The line should not appear since there's nothing to track
         assert "if you add or remove tests" not in briefing
 
+    def test_briefing_shows_critic_duration(self, tmp_path: Path):
+        """Briefing should show last Critic review duration."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        (prawduct / "project-state.yaml").write_text(
+            'product_identity:\n  name: "MyApp"\n\n'
+            "build_state:\n  source_root: null\n  test_tracking:\n    test_count: 0\n"
+        )
+        (prawduct / ".critic-findings.json").write_text(json.dumps({
+            "timestamp": "2026-03-19T10:00:00Z",
+            "duration_seconds": 195,
+            "files_reviewed": ["src/app.py"],
+            "findings": [],
+            "summary": "No issues found."
+        }))
+
+        result = run_hook("clear", tmp_path)
+
+        assert "3m15s" in result.stdout
+        assert "do not interrupt" in result.stdout.lower()
+
+    def test_briefing_no_critic_duration_when_missing(self, tmp_path: Path):
+        """Briefing should not show duration if findings have no duration_seconds."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        (prawduct / "project-state.yaml").write_text(
+            'product_identity:\n  name: "MyApp"\n\n'
+            "build_state:\n  source_root: null\n  test_tracking:\n    test_count: 0\n"
+        )
+        (prawduct / ".critic-findings.json").write_text(json.dumps({
+            "timestamp": "2026-03-19T10:00:00Z",
+            "files_reviewed": ["src/app.py"],
+            "findings": [],
+            "summary": "No issues found."
+        }))
+
+        result = run_hook("clear", tmp_path)
+
+        assert "Last Critic review" not in result.stdout
+
     def test_briefing_excludes_redundant_reminders(self, tmp_path: Path):
         """Briefing should not include reminders that are already in CLAUDE.md Critical Rules."""
         prawduct = tmp_path / ".prawduct"

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -459,6 +459,23 @@ def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
         except Exception:  # prawduct:ok-broad-except — briefing must never block session start
             pass
 
+    # Last Critic review duration (set expectations for wait time)
+    critic_path = prawduct_dir / ".critic-findings.json"
+    if critic_path.is_file():
+        try:
+            critic_data = json.loads(critic_path.read_text())
+            duration = critic_data.get("duration_seconds")
+            if duration and isinstance(duration, (int, float)) and duration > 0:
+                minutes = int(duration) // 60
+                seconds = int(duration) % 60
+                if minutes > 0:
+                    dur_str = f"{minutes}m{seconds:02d}s"
+                else:
+                    dur_str = f"{seconds}s"
+                lines.append(f"Last Critic review took {dur_str} — do not interrupt or check on the Critic while it runs")
+        except Exception:  # prawduct:ok-broad-except — briefing must never block session start
+            pass
+
     # Relevant learnings
     learnings_path = prawduct_dir / "learnings.md"
     if learnings_path.is_file():


### PR DESCRIPTION
## Summary
- Critic now records `duration_seconds` in `.critic-findings.json`
- Session briefing surfaces it: "Last Critic review took 3m15s — do not interrupt or check on the Critic while it runs"
- Explicit "do not interrupt" guidance added to building.md and product-claude.md
- Prevents the pattern where Claude gets impatient and tries to hurry/check on the review subagent

## Test plan
- [x] 676 tests pass (2 new: duration shown, duration absent when missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)