### PR TITLE
Behavioral choices in discovery, backwards-compat checks, PR merge preference, sync onboarding

### DIFF
--- a/agents/critic/SKILL.md
+++ b/agents/critic/SKILL.md
@@ -39,6 +39,7 @@ Your goals, in priority order:
 
 ### 2. Nothing Is Missing
 - Every requirement for this work is implemented or explicitly descoped → **BLOCKING** if silently dropped.
+- **Behavioral choices**: Does this change introduce a new feature that affects user workflow? If so, is the behavior configurable via `project-preferences.md` with a safe default? A feature that could reasonably work two ways (automatic vs. manual, verbose vs. quiet) but ships with only one hardcoded behavior → **WARNING**.
 - For user-visible changes: was the product verified beyond tests? → **WARNING** if no evidence.
 - Error paths have test coverage. Happy path + at least one error case per flow → **WARNING** if missing.
 - For products with `has_human_interface`: accessibility alongside features → **WARNING** if missing.
@@ -77,7 +78,7 @@ Your goals, in priority order:
 ### 7. The Design Is Sound
 - **Encapsulation**: Modules expose only what consumers need. Internal implementation details don't leak through public interfaces. State that should be private isn't accessible externally. → **WARNING** if boundaries are unclear or internals exposed.
 - **Coupling**: Changes in one module shouldn't force changes in unrelated modules. Watch for god objects/functions that concentrate too many responsibilities, and for modules that know too much about each other's internals. → **WARNING** if coupling is inappropriate.
-- **Simplification**: Could the same result be achieved with less complexity? Unnecessary abstractions, premature generalization, dead code paths, over-engineering for hypothetical requirements. → **WARNING** if simpler approach exists.
+- **Simplification**: Could the same result be achieved with less complexity? Unnecessary abstractions, premature generalization, dead code paths, over-engineering for hypothetical requirements. → **WARNING** if simpler approach exists. **Unnecessary backwards compatibility** is a common variant: migration paths, fallbacks, or compatibility shims when there is no existing deployment to migrate. If nobody asked for backwards compatibility, it's unnecessary complexity → **WARNING**.
 - **Deduplication**: Duplicated logic that should be extracted. Copy-paste patterns across files. Near-identical implementations that vary only in superficial ways. → **WARNING** for meaningful duplication.
 
 This goal applies proportionally — a 2-line helper doesn't need design review. Focus on patterns that will compound: a leaked abstraction others will depend on, coupling that will spread, complexity that will accumulate.

--- a/methodology/building.md
+++ b/methodology/building.md
@@ -226,14 +226,18 @@ Broad catches that swallow errors without logging (`except Exception: pass`, emp
 
 **Ignoring the Critic**: Dismissing findings without reflection.
 
-**Verification theater**: Claiming verification without exercising the product. Honest confidence (Principle 5). A common variant: all tests pass against mocked infrastructure, but the product has never been tested against real dependencies. If project-state.yaml declares infrastructure dependencies, verify against them.
+**Verification theater**: Claiming verification without exercising the product. All tests pass against mocks but the product has never touched real dependencies. If project-state.yaml declares infrastructure dependencies, verify against them.
 
-**Mock-as-implementation**: Using mocks during development and never replacing them with real integrations. Mocks are for test isolation, not for avoiding infrastructure work. If the data model says "persisted to Postgres" and the code uses an in-memory dictionary, that's an unfinished implementation — not a passing test suite.
+**Mock-as-implementation**: Using mocks during development and never replacing them with real integrations. If the data model says "Postgres" and the code uses an in-memory dict, that's unfinished — not passing.
 
-**"Pre-existing" dismissal**: Labeling any quality issue — failing test, broad exception, stale artifact, missing coverage — as "pre-existing" to justify ignoring it. There is no pre-existing exception. If you found it, it's yours to fix or flag.
+**"Pre-existing" dismissal**: Labeling a quality issue as "pre-existing" to justify ignoring it. There is no pre-existing exception. If you found it, it's yours to fix or flag.
 
-**Uninvestigated decisions**: Making a major technology or architectural choice without research. Lock-in, pervasiveness, structural impact, and external dependencies all warrant investigation before commitment.
+**Uninvestigated decisions**: Major technology or architectural choices without research. Lock-in, pervasiveness, structural impact, and external dependencies warrant investigation.
 
 **Boundary blindness**: Modifying a contract surface without checking consumers. The compliance canary catches this at session end, but checking proactively is cheaper.
 
 **Pacing blindness**: Asking implementation questions when the user is waiting for progress. Decide autonomously on minor details unless genuinely blocked.
+
+**Unnecessary backwards compatibility**: Adding migration paths or fallbacks when there's no existing deployment to migrate. Backwards compatibility is a requirement to be elicited, not an assumption.
+
+**Opinionated defaults without configuration**: Shipping a workflow-affecting feature with one hardcoded behavior. If a feature could reasonably work two ways, make it a preference in `project-preferences.md` with a safe default.

--- a/methodology/discovery.md
+++ b/methodology/discovery.md
@@ -121,6 +121,22 @@ Every product has observability needs — even when the answer is "console.error
 
 **Capture to `project-state.yaml`** under `design_decisions.observability_approach`.
 
+## Surface Behavioral Choices
+
+When a new feature affects user workflow, ask: what behavioral variations exist? Users have different preferences about automation, notification, and control. Ship a safe default but make the choice configurable.
+
+**Use infer-confirm-proceed.** "This feature can [run automatically / wait for your go-ahead]. I'll default to [safe default] — you can change this in `project-preferences.md` anytime. Sound right?"
+
+**Common behavioral choices to surface:**
+- Automatic vs. manual triggers (e.g., create PRs automatically vs. wait to be asked)
+- Notification level (verbose progress vs. quiet until done)
+- Merge/deploy strategy (auto-merge vs. wait for review)
+- Backwards compatibility (do we need migration paths, or can we just change it?)
+
+**The backwards-compatibility question is especially important.** Claude's instinct is to add migration paths, fallbacks, and compatibility shims even when nobody asked for them. Before adding any backwards-compatibility code, ask: is there actually an existing deployment that needs migration? If not, just make the change directly. Backwards compatibility is a requirement to be elicited, not an assumption to be baked in.
+
+**Capture to `project-preferences.md`** under the Workflow section. Preferences are the team's declared standards — the Critic validates code against them.
+
 ## Identify Boundary Patterns
 
 As structural characteristics emerge, note where components will interact — API endpoints, database schemas, IPC channels, frontend/backend type contracts. These become the project's contract surfaces, documented in `.prawduct/artifacts/boundary-patterns.md` during planning. Identifying them during discovery helps scope the build: boundary-heavy designs need more integration testing and consumer-impact investigation during building.
@@ -139,6 +155,7 @@ Discovery produces a `project-state.yaml` with:
 - **Observability approach**: signal types, correlation context, operational model — scaled to risk
 - **User expertise profile**: what the user knows and doesn't, inferred from conversation
 - **Product identity**: name, personality, technology preferences
+- **Workflow preferences**: behavioral choices for automation, PRs, merging — captured in `project-preferences.md`
 
 Discovery isn't a phase — it's continuous. Initial discovery produces enough understanding to start planning and building. But discovery continues throughout the project: new features need their own discovery, bug reports reveal missing understanding, and user feedback surfaces unasked questions. The depth of discovery scales with the work's size and risk, not with where you are in a timeline.
 

--- a/templates/commands-pr.md
+++ b/templates/commands-pr.md
@@ -67,6 +67,8 @@ Push branch with `-u`. Draft title and description from work context + review fi
 
 ## Merge Flow
 
+**Check `project-preferences.md` for `PR merge` setting.** If set to `wait_for_user` (default), present the PR URL and findings summary to the user and wait for them to say "merge" before proceeding. If set to `automatic`, merge after CI passes and review is clean.
+
 1. Verify CI checks pass (`gh pr checks`)
 2. Verify no merge conflicts
 3. Verify PR review evidence exists for this branch — if missing, run the reviewer first

--- a/templates/critic-review.md
+++ b/templates/critic-review.md
@@ -19,7 +19,7 @@ Decide what to check based on: **files changed** (which layers, boundary crossin
 Tests pass, count not decreased → **BLOCKING**. Tests verify behavior, not implementation. There is no "pre-existing" exception — if the Critic finds a problem, it's a finding regardless of when it was introduced. **Security in changed code:** input validation at trust boundaries → **BLOCKING** if exploitable; no injection vectors (SQL, command, XSS, path traversal) → **BLOCKING**; no hardcoded secrets → **BLOCKING**; auth/authz on new endpoints → **WARNING** if missing.
 
 ### 2. Nothing Is Missing
-Every requirement implemented or explicitly descoped → **BLOCKING**. Error paths have coverage → **WARNING** if missing. If `infrastructure_dependencies` declared: integration tests exercise real dependencies → **WARNING** if all mocked.
+Every requirement implemented or explicitly descoped → **BLOCKING**. **Behavioral choices:** new feature that affects user workflow should be configurable via `project-preferences.md` with a safe default → **WARNING** if hardcoded. Error paths have coverage → **WARNING** if missing. If `infrastructure_dependencies` declared: integration tests exercise real dependencies → **WARNING** if all mocked.
 
 ### 3. Nothing Is Unintended
 No unlisted dependencies → **BLOCKING**. No undocumented architectural decisions → **BLOCKING**. No scope creep → **WARNING**. No broad exception swallowing → **WARNING**. Catches marked with `prawduct:ok-broad-except` are intentional but still verifiable — confirm they log and are at system boundaries.
@@ -34,7 +34,7 @@ Dependencies have rationale. Architectural patterns documented. Boundary changes
 Error handling present → **WARNING** if missing. Logging appropriate → **WARNING** if absent in new paths. Observability strategy followed if it exists → **WARNING** if diverged. New capability with no failure detection → **BLOCKING**.
 
 ### 7. The Design Is Sound
-**Encapsulation:** modules expose only what consumers need; internals don't leak through public interfaces → **WARNING**. **Coupling:** changes in one module shouldn't force changes in unrelated modules; watch for god objects concentrating too many responsibilities → **WARNING**. **Simplification:** unnecessary abstractions, premature generalization, dead code, over-engineering → **WARNING** if simpler approach exists. **Deduplication:** duplicated logic across files, copy-paste patterns → **WARNING** for meaningful duplication. Apply proportionally — focus on patterns that will compound.
+**Encapsulation:** modules expose only what consumers need; internals don't leak through public interfaces → **WARNING**. **Coupling:** changes in one module shouldn't force changes in unrelated modules; watch for god objects concentrating too many responsibilities → **WARNING**. **Simplification:** unnecessary abstractions, premature generalization, dead code, over-engineering → **WARNING** if simpler approach exists; unnecessary backwards compatibility (migration paths, fallbacks when no existing deployment needs them) → **WARNING**. **Deduplication:** duplicated logic across files, copy-paste patterns → **WARNING** for meaningful duplication. Apply proportionally — focus on patterns that will compound.
 
 ## Severity
 

--- a/templates/product-claude.md
+++ b/templates/product-claude.md
@@ -20,6 +20,7 @@ These degrade at scale. The session briefing reinforces them; the stop hook dete
 - **Update artifacts when code changes what they describe.** Stale specs are worse than no specs.
 - **Invoke the Critic after medium+ work.** Not optional. The stop hook enforces this.
 - **Do not create PRs unless asked.** Only use `/pr` when the user explicitly asks to create a PR, push changes, merge, or check PR status. Check `project-preferences.md` — if `PR creation` is set to `automatic`, you may create PRs after Critic review passes without being asked.
+- **No unnecessary backwards compatibility.** Do not add migration paths, fallbacks, or compatibility shims unless the user has an existing deployment that needs them. Backwards compatibility is a requirement to be elicited, not an assumption. Just make the change directly.
 
 ## Principles
 

--- a/templates/project-preferences.md
+++ b/templates/project-preferences.md
@@ -39,6 +39,7 @@ Developer preferences for how code is written in this project. Captured during d
 ## Workflow
 
 - **PR creation**: wait_for_user (default: wait_for_user — only create PRs when explicitly asked; set to "automatic" to create PRs after Critic review passes)
+- **PR merge**: wait_for_user (default: wait_for_user — present the PR for user review before merging; set to "automatic" to merge after CI passes and review is clean)
 
 ---
 

--- a/tests/test_prawduct_sync.py
+++ b/tests/test_prawduct_sync.py
@@ -586,8 +586,8 @@ class TestRunSync:
 
         result = run_sync(str(product), framework_dir=str(fw))
         assert result["synced"] is True
-        assert any("Registered" in a and "pr-review" in a for a in result["actions"])
-        assert any("Registered" in a and "pr.md" in a for a in result["actions"])
+        assert any("New:" in a and "pr-review" in a for a in result["actions"])
+        assert any("New:" in a and "pr.md" in a for a in result["actions"])
         assert (product / ".prawduct" / "pr-review.md").is_file()
         assert (product / ".claude" / "commands" / "pr.md").is_file()
 

--- a/tools/prawduct-sync.py
+++ b/tools/prawduct-sync.py
@@ -37,30 +37,37 @@ BLOCK_END = "<!-- PRAWDUCT:END -->"
 
 # Canonical list of framework-managed files. Used by create_manifest (at init)
 # and run_sync (to backfill files added after a product was initialized).
+# "description" is shown to the user when a file is backfilled (new capability onboarding).
 MANAGED_FILES = {
     "CLAUDE.md": {
         "template": "templates/product-claude.md",
         "strategy": "block_template",
+        "description": "Core principles and methodology instructions",
     },
     ".prawduct/critic-review.md": {
         "template": "templates/critic-review.md",
         "strategy": "template",
+        "description": "Independent Critic review instructions (7 quality goals + coordinator pattern)",
     },
     ".prawduct/pr-review.md": {
         "template": "templates/pr-review.md",
         "strategy": "template",
+        "description": "PR reviewer instructions for release-readiness assessment",
     },
     ".claude/commands/pr.md": {
         "template": "templates/commands-pr.md",
         "strategy": "template",
+        "description": "/pr skill — PR lifecycle management (create, update, merge, status). Configure PR behavior in project-preferences.md",
     },
     "tools/product-hook": {
         "source": "tools/product-hook",
         "strategy": "always_update",
+        "description": "Session governance hooks (reflection gate, Critic gate, session briefing)",
     },
     ".claude/settings.json": {
         "template": "templates/product-settings.json",
         "strategy": "merge_settings",
+        "description": "Claude Code settings with hook configuration",
     },
 }
 
@@ -526,7 +533,11 @@ def run_sync(product_dir: str, framework_dir: str | None = None, *, no_pull: boo
         if rel_path not in files:
             files[rel_path] = dict(config)
             files[rel_path]["generated_hash"] = None  # Forces creation on first sync
-            actions.append(f"Registered {rel_path} (new managed file)")
+            desc = config.get("description", "")
+            if desc:
+                actions.append(f"New: {rel_path} — {desc}")
+            else:
+                actions.append(f"New: {rel_path}")
 
     updated_files = dict(files)
 


### PR DESCRIPTION
## Summary

Meta-fix: prawduct's own methodology didn't catch that new features (PR support, sync backfill) needed user-facing behavioral configuration. Three pipeline gaps caused three user complaints.

- **Discovery**: new "Surface Behavioral Choices" section — prompts for automation preferences, backwards-compat needs, workflow variations
- **Critic Goal 2**: new "Behavioral choices" check — features affecting workflow should be configurable (WARNING if hardcoded)
- **Critic Goal 7**: backwards compatibility without a stated requirement flagged as unnecessary complexity
- **Building**: two new Common Traps (unnecessary backwards compat, opinionated defaults)
- **product-claude.md**: "No unnecessary backwards compatibility" in Critical Rules
- **PR merge preference**: `wait_for_user` (default) or `automatic` in project-preferences.md
- **Sync onboarding**: backfilled files now show descriptions ("New: .claude/commands/pr.md — /pr skill...")

## Test plan
- [x] 676 tests pass
- [x] Token budget for building.md stays under 3800

🤖 Generated with [Claude Code](https://claude.com/claude-code)