### PR TITLE
Fix 4 rough edges from scenario walkthrough

### DIFF
--- a/tests/test_prawduct_init.py
+++ b/tests/test_prawduct_init.py
@@ -296,6 +296,9 @@ class TestRunInit:
         assert (tmp_path / "tools" / "product-hook").is_file()
         assert (tmp_path / ".claude" / "settings.json").is_file()
         assert (tmp_path / ".gitignore").is_file()
+        assert (tmp_path / ".prawduct" / ".pr-reviews").is_dir()
+        assert (tmp_path / ".prawduct" / "pr-review.md").is_file()
+        assert (tmp_path / ".claude" / "commands" / "pr.md").is_file()
         assert len(result["actions"]) > 0
 
     def test_idempotent_second_run(self, tmp_path: Path):
@@ -351,6 +354,17 @@ class TestTemplatePropagation:
         assert "build_state:" in content
         # v5: current_phase replaced by work_in_progress
         assert "work_in_progress:" in content
+
+    def test_conftest_created_for_python(self, tmp_path: Path):
+        """conftest.py is created when Python markers exist."""
+        (tmp_path / "pyproject.toml").write_text("[tool.pytest]\n")
+        run_init(str(tmp_path), "PyApp")
+        assert (tmp_path / "tests" / "conftest.py").is_file()
+
+    def test_conftest_not_created_for_non_python(self, tmp_path: Path):
+        """conftest.py is NOT created when no Python markers exist."""
+        run_init(str(tmp_path), "JSApp")
+        assert not (tmp_path / "tests" / "conftest.py").is_file()
 
 
 # =============================================================================

--- a/tests/test_v5_hooks.py
+++ b/tests/test_v5_hooks.py
@@ -458,6 +458,40 @@ class TestSessionBriefing:
         assert "Stale:" in result.stdout
         assert "test count" in result.stdout
 
+    def test_briefing_flags_zero_count_with_tests(self, tmp_path: Path):
+        """Staleness scan flags test_count: 0 when test functions exist."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        (prawduct / "project-state.yaml").write_text(
+            'product_identity:\n  name: "MyApp"\n\n'
+            "build_state:\n  source_root: null\n  test_tracking:\n    test_count: 0\n"
+        )
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_app.py").write_text(
+            "\n".join(f"def test_case_{i}():\n    pass\n" for i in range(20))
+        )
+
+        result = run_hook("clear", tmp_path)
+
+        assert "test_count is 0" in result.stdout
+        assert "update project-state" in result.stdout.lower()
+
+    def test_briefing_shows_current_chunk(self, tmp_path: Path):
+        """Session briefing shows current_chunk from WIP."""
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        (prawduct / "project-state.yaml").write_text(
+            'product_identity:\n  name: "MyApp"\n\n'
+            'work_in_progress:\n  description: "Building auth"\n  size: "large"\n'
+            '  type: "feature"\n  current_chunk: "chunk 5 of 12: OAuth integration"\n'
+        )
+
+        result = run_hook("clear", tmp_path)
+
+        assert "Resume:" in result.stdout
+        assert "chunk 5 of 12" in result.stdout
+
     def test_briefing_includes_learnings(self, tmp_path: Path):
         prawduct = tmp_path / ".prawduct"
         prawduct.mkdir()

--- a/tools/prawduct-init.py
+++ b/tools/prawduct-init.py
@@ -194,7 +194,12 @@ def run_init(target_dir: str, product_name: str) -> dict:
     ):
         actions.append("Created .prawduct/artifacts/boundary-patterns.md")
 
-    # 6.5. PR review instructions
+    # 6.5. PR review evidence directory
+    pr_reviews_dir = target / ".prawduct" / ".pr-reviews"
+    if ensure_dir(pr_reviews_dir):
+        actions.append("Created .prawduct/.pr-reviews/")
+
+    # 6.7. PR review instructions
     if write_template(
         TEMPLATES_DIR / "pr-review.md",
         target / ".prawduct" / "pr-review.md",
@@ -202,7 +207,7 @@ def run_init(target_dir: str, product_name: str) -> dict:
     ):
         actions.append("Created .prawduct/pr-review.md")
 
-    # 6.6. PR slash command
+    # 6.8. PR slash command
     commands_dir = target / ".claude" / "commands"
     if ensure_dir(commands_dir):
         actions.append("Created .claude/commands/")
@@ -211,14 +216,19 @@ def run_init(target_dir: str, product_name: str) -> dict:
     if pr_cmd_src.is_file() and write_template(pr_cmd_src, pr_cmd_dst, subs):
         actions.append("Created .claude/commands/pr.md")
 
-    # 7. Test infrastructure (conftest.py with parallel test support)
+    # 7. Test infrastructure (conftest.py — only for Python projects)
+    is_python = any(
+        (target / f).is_file()
+        for f in ("pyproject.toml", "setup.py", "setup.cfg", "Pipfile", "requirements.txt")
+    )
     tests_dir = target / "tests"
     if ensure_dir(tests_dir):
         actions.append("Created tests/")
-    conftest_dst = tests_dir / "conftest.py"
-    if not conftest_dst.is_file():
-        shutil.copy2(TEMPLATES_DIR / "conftest.py", conftest_dst)
-        actions.append("Created tests/conftest.py (parallel test support)")
+    if is_python:
+        conftest_dst = tests_dir / "conftest.py"
+        if not conftest_dst.is_file():
+            shutil.copy2(TEMPLATES_DIR / "conftest.py", conftest_dst)
+            actions.append("Created tests/conftest.py (parallel test support)")
 
     # 8. Learnings starter
     learnings = target / ".prawduct" / "learnings.md"

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -293,12 +293,15 @@ def staleness_scan(project_dir: Path) -> list[str]:
     # 1. Test count divergence
     test_count_match = re.search(r"test_count:\s*(\d+)", state_content)
     documented_count = int(test_count_match.group(1)) if test_count_match else 0
+    actual_count = _count_test_functions(project_dir)
     if documented_count > 0:
-        actual_count = _count_test_functions(project_dir)
         if actual_count > 0:
             threshold = max(5, int(documented_count * 0.1))
             if abs(actual_count - documented_count) > threshold:
                 findings.append(f"test count: documented {documented_count}, found ~{actual_count}")
+    elif actual_count > 10:
+        # test_count is 0 but tests exist — nudge to set the count
+        findings.append(f"test_count is 0 but found ~{actual_count} test functions — update project-state.yaml")
 
     # 2. Architecture coverage
     source_root_match = re.search(r"source_root:\s*[\"']?([^\"'\n#]+)", state_content)
@@ -430,8 +433,10 @@ def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
     work_desc = _get_work_in_progress(prawduct_dir)
     lines.append(f"Project: {project_name} | Work: {work_desc}")
 
-    # WIP context (the detail behind the description)
+    # WIP context and current chunk
     wip = _parse_wip(prawduct_dir)
+    if wip.get("current_chunk"):
+        lines.append(f"Resume: {wip['current_chunk']}")
     if wip.get("context"):
         ctx = wip["context"]
         if len(ctx) > 200:


### PR DESCRIPTION
## Summary
From thorough scenario walkthrough across 10 common usage patterns:

1. **`.pr-reviews/` created at init** — first `/pr` run could fail without it
2. **test_count:0 drift detection** — staleness scan now flags when tests exist but count is 0
3. **conftest.py only for Python** — checks for pyproject.toml/setup.py/Pipfile before placing
4. **Current chunk in session briefing** — shows "Resume: chunk 5 of 12" for multi-session work

## Test plan
- [x] 680 tests pass (4 new: zero-count drift, current chunk briefing, conftest python/non-python)

🤖 Generated with [Claude Code](https://claude.com/claude-code)