### PR TITLE
Auto-bootstrap sync manifest for repos missing one

### DIFF
--- a/tests/test_prawduct_sync.py
+++ b/tests/test_prawduct_sync.py
@@ -27,7 +27,9 @@ render_template = _mod.render_template
 merge_settings = _mod.merge_settings
 create_manifest = _mod.create_manifest
 apply_renames = _mod.apply_renames
+_bootstrap_manifest = _mod._bootstrap_manifest
 FILE_RENAMES = _mod.FILE_RENAMES
+MANAGED_FILES = _mod.MANAGED_FILES
 run_sync = _mod.run_sync
 _try_pull_framework = _mod._try_pull_framework
 BLOCK_BEGIN = _mod.BLOCK_BEGIN
@@ -211,6 +213,123 @@ class TestCreateManifest:
             "tools/product-hook",
             ".claude/settings.json",
         }
+
+
+# =============================================================================
+# _bootstrap_manifest
+# =============================================================================
+
+
+class TestBootstrapManifest:
+    """Tests for automatic manifest creation on repos missing one."""
+
+    def test_bootstrap_creates_manifest_on_sync(self, tmp_path: Path):
+        """run_sync bootstraps a manifest when .prawduct/ exists but no manifest."""
+        fw = tmp_path / "framework"
+        fw.mkdir()
+        templates = fw / "templates"
+        templates.mkdir()
+        (templates / "product-claude.md").write_text(
+            f"# {{{{PRODUCT_NAME}}}}\n\n"
+            f"{BLOCK_BEGIN}\nContent\n{BLOCK_END}\n"
+        )
+
+        product = tmp_path / "myapp"
+        product.mkdir()
+        (product / ".prawduct").mkdir()
+
+        result = run_sync(str(product), framework_dir=str(fw))
+        assert result["synced"] is True
+        assert any("Bootstrapped" in a for a in result["actions"])
+        assert (product / ".prawduct" / "sync-manifest.json").is_file()
+
+    def test_bootstrap_infers_product_name_from_state(self, tmp_path: Path):
+        """Bootstrap reads product_name from project-state.yaml."""
+        fw = tmp_path / "framework"
+        fw.mkdir()
+        (fw / "templates").mkdir()
+
+        product = tmp_path / "mydir"
+        product.mkdir()
+        prawduct_dir = product / ".prawduct"
+        prawduct_dir.mkdir()
+        (prawduct_dir / "project-state.yaml").write_text(
+            'product_name: "WorldGround"\nschema_version: 2\n'
+        )
+
+        manifest = _bootstrap_manifest(product, fw)
+        assert manifest["product_name"] == "WorldGround"
+
+    def test_bootstrap_falls_back_to_dir_name(self, tmp_path: Path):
+        """Without project-state.yaml, bootstrap uses directory name."""
+        fw = tmp_path / "framework"
+        fw.mkdir()
+        (fw / "templates").mkdir()
+
+        product = tmp_path / "cool-app"
+        product.mkdir()
+        (product / ".prawduct").mkdir()
+
+        manifest = _bootstrap_manifest(product, fw)
+        assert manifest["product_name"] == "cool-app"
+
+    def test_bootstrap_hashes_existing_files(self, tmp_path: Path):
+        """Existing files get real hashes; missing files get None."""
+        fw = tmp_path / "framework"
+        fw.mkdir()
+        (fw / "templates").mkdir()
+
+        product = tmp_path / "app"
+        product.mkdir()
+        (product / ".prawduct").mkdir()
+        # Create one managed file
+        critic = product / ".prawduct" / "critic-review.md"
+        critic.write_text("# Critic review\n")
+
+        manifest = _bootstrap_manifest(product, fw)
+        # Existing file gets a real hash
+        assert manifest["files"][".prawduct/critic-review.md"]["generated_hash"] is not None
+        # Missing file gets None
+        assert manifest["files"][".prawduct/pr-review.md"]["generated_hash"] is None
+
+    def test_bootstrap_checks_old_rename_paths(self, tmp_path: Path, monkeypatch):
+        """Bootstrap finds files at old rename paths for hash computation."""
+        monkeypatch.setattr(_mod, "FILE_RENAMES", {
+            "old/cmd.md": "new/skill/SKILL.md",
+        })
+        monkeypatch.setattr(_mod, "MANAGED_FILES", {
+            "new/skill/SKILL.md": {
+                "template": "templates/skill.md",
+                "strategy": "template",
+                "description": "test",
+            },
+        })
+
+        fw = tmp_path / "framework"
+        fw.mkdir()
+        (fw / "templates").mkdir()
+
+        product = tmp_path / "app"
+        product.mkdir()
+        (product / ".prawduct").mkdir()
+        (product / "old").mkdir()
+        (product / "old" / "cmd.md").write_text("skill content")
+
+        manifest = _bootstrap_manifest(product, fw)
+        # Hash computed from old path, stored under new key
+        assert manifest["files"]["new/skill/SKILL.md"]["generated_hash"] is not None
+
+    def test_no_bootstrap_without_prawduct_dir(self, tmp_path: Path):
+        """No .prawduct/ directory: returns 'not a prawduct repo'."""
+        fw = tmp_path / "framework"
+        fw.mkdir()
+
+        product = tmp_path / "random-dir"
+        product.mkdir()
+
+        result = run_sync(str(product), framework_dir=str(fw))
+        assert result["synced"] is False
+        assert result["reason"] == "not a prawduct repo"
 
 
 # =============================================================================
@@ -435,12 +554,12 @@ class TestRunSync:
 
         return product
 
-    def test_no_manifest_skips(self, tmp_path: Path):
+    def test_no_prawduct_dir_skips(self, tmp_path: Path):
         product = tmp_path / "product"
         product.mkdir()
         result = run_sync(str(product))
         assert result["synced"] is False
-        assert result["reason"] == "no manifest"
+        assert result["reason"] == "not a prawduct repo"
 
     def test_invalid_manifest_skips(self, tmp_path: Path):
         product = tmp_path / "product"

--- a/tools/prawduct-sync.py
+++ b/tools/prawduct-sync.py
@@ -136,6 +136,51 @@ def apply_renames(
                 pass  # Not empty — that's fine
 
 
+def _bootstrap_manifest(product: Path, fw_dir: Path) -> dict:
+    """Create initial sync manifest for a prawduct repo that doesn't have one.
+
+    Computes hashes of existing managed files so sync can track future changes.
+    Files that don't exist get None (triggers creation on first sync).
+    For files at old rename paths, uses the old path's content for hash computation
+    so the rename + sync flow works correctly.
+    """
+    # Infer product name from project-state.yaml or directory name
+    product_name = product.name
+    state_path = product / ".prawduct" / "project-state.yaml"
+    if state_path.is_file():
+        for line in state_path.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("product_name:"):
+                val = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+                if val:
+                    product_name = val
+                break
+
+    file_hashes: dict[str, str | None] = {}
+    for rel_path, config in MANAGED_FILES.items():
+        strategy = config.get("strategy", "template")
+        file_path = product / rel_path
+
+        # If file doesn't exist at new path, check old rename paths
+        if not file_path.is_file():
+            for old_rel, new_rel in FILE_RENAMES.items():
+                if new_rel == rel_path and (product / old_rel).is_file():
+                    file_path = product / old_rel
+                    break
+
+        if strategy == "block_template":
+            if file_path.is_file():
+                file_hashes[rel_path] = compute_block_hash(file_path.read_text())
+            else:
+                file_hashes[rel_path] = None
+        elif strategy == "merge_settings":
+            file_hashes[rel_path] = None  # merge_settings doesn't use hash
+        else:
+            file_hashes[rel_path] = compute_hash(file_path)
+
+    return create_manifest(product, fw_dir, product_name, file_hashes)
+
+
 def log(msg: str) -> None:
     """Print status to stderr."""
     print(msg, file=sys.stderr)
@@ -541,25 +586,41 @@ def run_sync(product_dir: str, framework_dir: str | None = None, *, no_pull: boo
     product = Path(product_dir).resolve()
     manifest_path = product / ".prawduct" / "sync-manifest.json"
 
-    if not manifest_path.is_file():
-        return {
-            "product_dir": str(product),
-            "synced": False,
-            "reason": "no manifest",
-            "actions": [],
-            "notes": [],
-        }
+    bootstrapped = False
 
-    try:
-        manifest = json.loads(manifest_path.read_text())
-    except json.JSONDecodeError:
-        return {
-            "product_dir": str(product),
-            "synced": False,
-            "reason": "invalid manifest JSON",
-            "actions": [],
-            "notes": [],
-        }
+    if not manifest_path.is_file():
+        if not (product / ".prawduct").is_dir():
+            return {
+                "product_dir": str(product),
+                "synced": False,
+                "reason": "not a prawduct repo",
+                "actions": [],
+                "notes": [],
+            }
+        # Bootstrap: create manifest for prawduct repo that doesn't have one
+        fw_dir = _resolve_framework_dir({}, framework_dir, product)
+        if fw_dir is None:
+            return {
+                "product_dir": str(product),
+                "synced": False,
+                "reason": "framework not found",
+                "actions": [],
+                "notes": [],
+            }
+        manifest = _bootstrap_manifest(product, fw_dir)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        bootstrapped = True
+    else:
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError:
+            return {
+                "product_dir": str(product),
+                "synced": False,
+                "reason": "invalid manifest JSON",
+                "actions": [],
+                "notes": [],
+            }
 
     fw_dir = _resolve_framework_dir(manifest, framework_dir, product)
     if fw_dir is None:
@@ -582,6 +643,9 @@ def run_sync(product_dir: str, framework_dir: str | None = None, *, no_pull: boo
     subs = {"{{PRODUCT_NAME}}": product_name}
     actions: list[str] = []
     notes: list[str] = list(pull_notes)
+
+    if bootstrapped:
+        actions.append("Bootstrapped sync manifest (first framework sync for this repo)")
 
     # V4→V5 migration (if needed)
     v5_actions = migrate_v4_to_v5(product)

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -47,11 +47,15 @@ def try_sync(project_dir: Path) -> None:
     """
     try:
         manifest_path = project_dir / ".prawduct" / "sync-manifest.json"
-        if not manifest_path.is_file():
-            return
 
-        manifest = json.loads(manifest_path.read_text())
-        fw_source = os.environ.get("PRAWDUCT_FRAMEWORK_DIR") or manifest.get("framework_source", "")
+        if manifest_path.is_file():
+            manifest = json.loads(manifest_path.read_text())
+            fw_source = os.environ.get("PRAWDUCT_FRAMEWORK_DIR") or manifest.get("framework_source", "")
+        elif (project_dir / ".prawduct").is_dir():
+            # Prawduct repo without manifest — sync will bootstrap one
+            fw_source = os.environ.get("PRAWDUCT_FRAMEWORK_DIR") or ""
+        else:
+            return  # Not a prawduct repo
 
         # Fall back to sibling ../prawduct if configured source not found
         if not fw_source or not Path(fw_source).is_dir():


### PR DESCRIPTION
## Summary

- When a product repo has `.prawduct/` but no `sync-manifest.json`, sync now auto-creates a bootstrap manifest instead of silently returning "no manifest"
- Product-hook `try_sync()` updated to call sync even without a manifest (when `.prawduct/` exists)
- Tested against real older repo (worldground) — bootstrapped manifest, updated framework files, created missing skills and artifacts, all in one session start

## How it works

1. `run_sync()` detects missing manifest + `.prawduct/` dir exists → calls `_bootstrap_manifest()`
2. Bootstrap infers product name from `project-state.yaml` (falls back to dir name)
3. Computes hashes of existing files (so sync correctly detects user edits vs template changes)
4. Checks old rename paths (so commands→skills migration works seamlessly after bootstrap)
5. Creates manifest, reports "Bootstrapped sync manifest", then proceeds with normal sync

## Test plan

- [x] 6 new bootstrap tests (creates manifest, infers name from state, falls back to dir name, hashes existing files, checks old rename paths, rejects non-prawduct dirs)
- [x] Updated existing "no manifest" test to "no prawduct dir" test
- [x] All 629 tests pass
- [x] Verified against real worldground repo: bootstrap + sync in one pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)