### PR TITLE
Improve sync output with clear user guidance

### DIFF
--- a/tools/product-hook
+++ b/tools/product-hook
@@ -83,14 +83,34 @@ def try_sync(project_dir: Path) -> None:
                 actions = sync_result.get("actions", [])
                 notes = sync_result.get("notes", [])
                 if actions:
-                    print(f"Framework sync: {', '.join(actions)}")
-                for note in notes:
-                    print(f"  * {note}")
-                if any("CLAUDE.md" in a for a in actions):
-                    print(
-                        "IMPORTANT: CLAUDE.md was updated by framework sync. "
-                        "Re-read CLAUDE.md now to pick up the latest instructions."
-                    )
+                    is_bootstrap = any("Bootstrapped" in a for a in actions)
+                    needs_restart = any("settings.json" in a for a in actions)
+                    claude_updated = any("CLAUDE.md" in a for a in actions)
+
+                    # Header
+                    if is_bootstrap:
+                        print("PRAWDUCT SYNC: First framework sync for this repo")
+                    else:
+                        print("PRAWDUCT SYNC: Framework updated")
+
+                    # List changes
+                    for action in actions:
+                        if "Bootstrapped" not in action:  # Already shown in header
+                            print(f"  + {action}")
+                    for note in notes:
+                        print(f"  * {note}")
+
+                    # Actionable guidance
+                    if claude_updated:
+                        print(
+                            "  ACTION: CLAUDE.md was updated — re-read CLAUDE.md now "
+                            "to pick up the latest instructions."
+                        )
+                    if needs_restart:
+                        print(
+                            "  ACTION: Settings updated — exit and restart this session "
+                            "for greeting and hook changes to take effect."
+                        )
             except json.JSONDecodeError:
                 pass
     except Exception as e:  # prawduct:ok-broad-except — sync must never block session start


### PR DESCRIPTION
## Summary

Restructures `try_sync()` output in the product-hook so users clearly see what prawduct updated and what action to take.

**Before:** `Framework sync: Updated CLAUDE.md, Merged .claude/settings.json`

**After:**
```
PRAWDUCT SYNC: First framework sync for this repo
  + Updated CLAUDE.md
  + New: .claude/skills/pr/SKILL.md — /pr skill
  + Merged .claude/settings.json
  ACTION: CLAUDE.md was updated — re-read CLAUDE.md now.
  ACTION: Settings updated — exit and restart for changes to take effect.
```

## Test plan

- [x] All 629 tests pass
- [x] Output format verified for bootstrap, incremental update, and no-changes scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)