### PR TITLE
Fix spurious stop hook triggers from sync-modified files

### DIFF
--- a/tools/product-hook
+++ b/tools/product-hook
@@ -1016,15 +1016,10 @@ def cmd_clear(project_dir: Path) -> int:
         if f.is_file():
             f.unlink()
 
-    # Create session start timestamp and git baseline
+    # Create session start timestamp
     if prawduct_dir.is_dir():
         stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         (prawduct_dir / ".session-start").write_text(stamp)
-
-        # Capture git status baseline for session-scoped change detection
-        baseline = git_status_output(project_dir)
-        if baseline is not None:
-            (prawduct_dir / ".session-git-baseline").write_text(baseline)
 
     # Agent-facing messages go to stdout (SessionStart hooks show stdout to the model).
     # stderr is only visible to the user in the terminal, not to the agent.
@@ -1090,6 +1085,13 @@ def cmd_clear(project_dir: Path) -> int:
 
     # Trigger framework sync (best-effort)
     try_sync(project_dir)
+
+    # Capture git status baseline AFTER sync so sync-modified files
+    # (settings.json, product-hook, etc.) don't trigger spurious stop-hook gates
+    if prawduct_dir.is_dir():
+        baseline = git_status_output(project_dir)
+        if baseline is not None:
+            (prawduct_dir / ".session-git-baseline").write_text(baseline)
 
     # v5: Staleness scan + session briefing + subagent briefing
     if prawduct_dir.is_dir():


### PR DESCRIPTION
## Summary

Moves git baseline capture to **after** framework sync runs. Previously the baseline was captured before sync, so files modified by sync (settings.json, product-hook, skills) appeared as "new session changes" and triggered the reflection/Critic gates spuriously.

## Root cause

Order was: capture baseline → run sync → session. Sync modifies files on disk. Stop hook compares current status to baseline → sees sync changes as user changes → demands reflection.

## Fix

Order is now: run sync → capture baseline → session. Sync modifications are part of the baseline, so the stop hook only fires on actual changes made during the session.

## Test plan

- [x] All 629 tests pass
- [x] Verified the baseline capture happens after `try_sync()` in the clear hook flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)