### PR TITLE
fix: nine ROI backlog fixes (views/hook/advisory hardening + tests)

### DIFF
--- a/.prawduct/artifacts/build-plan-roi-batch-2.md
+++ b/.prawduct/artifacts/build-plan-roi-batch-2.md
@@ -1,0 +1,201 @@
+---
+artifact: build-plan
+version: 2
+# Explicit scope (NOT null, and DISTINCT from `roi-batch`) — distinct scope keeps
+# this batch's chunk-ID namespace (01–09) from colliding with the still-pending
+# roi-batch plan's chunks 01–05 at regen time (collect_shipped_chunks is
+# scope-filtered). Tag change-log entries `scope=roi-batch-2` when shipping.
+scope: roi-batch-2
+depends_on: []
+last_validated: null
+---
+
+## Requirements Confidence
+
+**Level:** High
+
+**Why:** Nine backlog items, all from the 2026-06-04 rough-edges hunt + one older re-verified
+item, each verified real before filing with a written fix-shape and a named file set. Two are
+silent-degradation correctness bugs (STH-2J9F exit code, ADV-9K2T corruption swallow), one is a
+release-process footgun (VWS-3K7P typo-guard), the rest are gate-precision, a refactor-to-constant,
+and pure test coverage. Scope is closed.
+
+**Open assumptions / unknowns:** None material. STH-6B4R's two gate sites are anchored by
+grep (`findings_mtime > session_start` and the cumulative-critic equivalent); the agent confirms
+the exact lines before editing (the backlog's line numbers predate recent edits).
+
+**What would raise confidence:** N/A.
+
+## Status
+
+<!-- Derived view. Mark a chunk shipped by adding a change-log entry tagged
+     scope=roi-batch-2 / status=shipped, then run `prawduct-hook regen-views`.
+     Do NOT hand-edit the checkboxes. Chunks are INDEPENDENT (no depends-on) and
+     are built by ONE workflow with three file-disjoint lanes (see Build model). -->
+
+- [ ] Chunk 01: VWS-3K7P — validate change-log status= values + reconcile views.py docstring
+- [ ] Chunk 02: STH-2J9F — regen-views returns exit 1 (not 0) on ImportError
+- [ ] Chunk 03: VWS-8M2Q — harden views.py tag/frontmatter parsers
+- [ ] Chunk 04: STH-6B4R — gate freshness timestamp comparison precision + tie rule
+- [ ] Chunk 05: STH-1W5N — centralize trivial-change protected-path bounds into a documented constant
+- [ ] Chunk 06: TST-1D5W — tighten _validate_evidence_schema against bool-as-int
+- [ ] Chunk 07: TST-7Q3D — stop-gate regression coverage gaps (3 cases)
+- [ ] Chunk 08: ADV-9K2T — advisory_store surfaces corruption via a .corrupt sentinel
+- [ ] Chunk 09: TST-4H8M — unit coverage for migrate _collapse_blank_runs edge cases
+Context: Plan authored 2026-06-04. Built by ONE workflow, three file-disjoint lanes:
+HOOK (bin/prawduct-hook + lib/views.py + their tests; chunks 01–07, run as two sequential
+sub-agents A=01–03, B=04–07 because both touch bin/prawduct-hook), ADV (lib/advisory_store.py;
+chunk 08), MIG (tests/test_plugin_migrate.py; chunk 09). The workflow does the BUILD half only
+(fix + regression test + SCOPED test run, no commit, no Critic). The launching session does the
+governance half: full suite → single `/prawduct:critic cumulative` → commit → `/prawduct:pr`
+→ archive the 9 backlog items + change-log.
+
+## Scaffolding
+
+N/A — existing repo, no scaffold. Test runner: `python3 -m pytest`.
+
+## Project Structure
+
+N/A — edits land in existing trees: `lib/views.py`, `lib/advisory_store.py`, `bin/prawduct-hook`,
+`tests/`.
+
+## Build Chunks
+
+<!-- Build model: the chunks are independent. ONE background workflow builds them across three
+     file-disjoint lanes against a single feature branch (`fix/roi-batch-2`). File sets are
+     disjoint across CONCURRENT agents by construction, so the shared working tree never sees a
+     same-file race. The HOOK lane's two sub-agents (A then B) both touch bin/prawduct-hook, so
+     they run SEQUENTIALLY within the lane. Per-chunk "Done when" Critic steps are satisfied ONCE,
+     cumulatively, by the launching session after the workflow finishes — see Governance. -->
+
+### Lane HOOK-A (owns lib/views.py, bin/prawduct-hook::cmd_regen_views, tests/test_views.py)
+
+#### Chunk 01: VWS-3K7P — validate change-log `status=` values + reconcile docstring
+**Type:** code
+**Acceptance criteria:**
+- New pure helper `validate_status_values(entries) -> list[str]` in `lib/views.py` returns a
+  warning string for every change-log entry whose `status=` tag is present but not in
+  `{shipped, merged}` (e.g. `status=shippd`). Empty list when all are valid/absent.
+- `bin/prawduct-hook::cmd_regen_views` calls it and prints each warning to stderr (NON-fatal —
+  does not change the exit code or the flip rule).
+- The `lib/views.py` module docstring (~line 19) status enum reconciled from
+  `shipped | in-progress | deferred` to `shipped | merged` (note: only `shipped` flips checkboxes;
+  `merged` is the release-pending intermediate). The flip rule itself is UNCHANGED — only `shipped`
+  ever flips.
+- Tests in `tests/test_views.py`: a typo `status=shippd` yields one warning; valid `shipped`/`merged`
+  yield none; absent status yields none.
+**Done when:** scoped `pytest tests/test_views.py` green; `/prawduct:critic` (cumulative, by launching session).
+
+#### Chunk 02: STH-2J9F — regen-views returns exit 1 on ImportError
+**Type:** code
+**Acceptance criteria:**
+- `cmd_regen_views`'s `except ImportError:` branch returns **1** (honest-failure), matching
+  `accept-operator-verification`/`verify-operator-verification`'s ImportError handling — a
+  state-mutating command must not report success on a broken install.
+- The disabled-by-config path (`if not enabled: return 0`) and the success path stay **0**.
+- Test asserts ImportError path → exit 1 (in `tests/test_views.py`).
+**Done when:** scoped tests green; cumulative Critic.
+
+#### Chunk 03: VWS-8M2Q — harden views.py tag/frontmatter parsers
+**Type:** code
+**Acceptance criteria:**
+- `parse_tag_line` (or the scope-rollup formatter) no longer emits unparseable YAML when a chunk
+  ID contains a quote/special char — validate chunk IDs against the safe charset (mirror
+  `CHUNK_LINE_RE`'s `[A-Za-z0-9_-]`) and drop/skip invalid ones, OR `yaml.safe_dump` the rollup
+  block. A malformed chunk ID must not corrupt `scope_rollups:`.
+- `_parse_build_plan_frontmatter_scope`: an UNCLOSED HTML comment is handled explicitly — either
+  flag it or document the leniency in the docstring; add the malformed-frontmatter test the
+  v1.5.1 R5 note asked for and never landed.
+- Tests in `tests/test_views.py` for both corners.
+**Done when:** scoped tests green; cumulative Critic.
+
+### Lane HOOK-B (owns bin/prawduct-hook gate/trivial/evidence regions, tests/test_plugin_runtime.py, tests/test_trivial_fileset_gate.py)
+
+#### Chunk 04: STH-6B4R — gate freshness timestamp comparison precision + tie rule
+**Type:** code
+**Acceptance criteria:**
+- The stop-hook Critic gate (`findings_mtime > session_start`, ~L1796–1804) and the
+  check-cumulative-critic equivalent compare timestamps at IDENTICAL precision
+  (`%Y-%m-%dT%H:%M:%SZ` both sides) OR via numeric epoch seconds — no lexicographic mismatch.
+- The tie case is DEFINED and tested: `findings_mtime == session_start` is treated as NOT fresh
+  (rejected) for the Critic-gate sites (consistent with the existing strict `>`). Document the
+  tie-breaking rule in a comment.
+- Regression test for the tie (findings mtime exactly == session-start → gate not satisfied).
+**Done when:** scoped `pytest tests/test_plugin_runtime.py` green; cumulative Critic.
+NOTE: Do not change the evidence-freshness `>=` site (`_test_status`, ~L466–477) unless needed —
+its `>=` is a deliberately different convention; if touched, preserve its semantics and test it.
+
+#### Chunk 05: STH-1W5N — centralize trivial-change protected-path bounds
+**Type:** code
+**Acceptance criteria:**
+- The Type:trivial / doc-only fileset bounds (skills/, methodology/, templates/, CLAUDE.md,
+  test deletions, new files) currently inline in `_classify_trivial_change` /
+  `_is_trivial_fileset_eligible` (~L3111–3180) are extracted to a documented module-level
+  constant (e.g. `_TRIVIAL_PROTECTED_PATHS` frozenset) with a one-line rationale per path,
+  referenced from every call site. Behavior-preserving refactor.
+- An existing trivial-fileset test still passes; add a test asserting the constant is the source
+  of truth (the bound list is non-empty and contains the documented paths).
+**Done when:** scoped `pytest tests/test_trivial_fileset_gate.py tests/test_plugin_runtime.py` green; cumulative Critic.
+
+#### Chunk 06: TST-1D5W — tighten _validate_evidence_schema against bool-as-int
+**Type:** code
+**Acceptance criteria:**
+- `_validate_evidence_schema` (~L535) rejects a bool where an int is required (Python `bool` is a
+  subclass of `int`, so `{"passed": True}` currently slips through `isinstance(v, int)`). Add
+  `and not isinstance(v, bool)` (with a comment) to the int-field checks.
+- New test `TestValidateEvidenceSchema::test_bool_rejected_for_int_field` in
+  `tests/test_plugin_runtime.py`.
+**Done when:** scoped tests green; cumulative Critic.
+
+#### Chunk 07: TST-7Q3D — stop-gate regression coverage gaps (test-only)
+**Type:** code
+**Acceptance criteria:** add three regression cases to `TestPluginStopGate`
+(`tests/test_plugin_runtime.py`), NO runtime change:
+- (a) verify-resolutions mode out-of-scope file blocking: findings with `files_reviewed=[a.py]`,
+  diff modifies `[a.py, b.py]` → assert exit 2 / out-of-scope reason.
+- (b) Type:trivial chunk modifying files outside the allowed bounds → assert exit 2 / fileset reason.
+- (c) gate-waiver unknown key → assert stderr diagnostic WITHOUT blocking.
+**Done when:** scoped `pytest tests/test_plugin_runtime.py` green; cumulative Critic.
+
+### Lane ADV (owns lib/advisory_store.py, tests/test_advisory_store.py)
+
+#### Chunk 08: ADV-9K2T — advisory_store surfaces corruption via a .corrupt sentinel
+**Type:** code
+**Acceptance criteria:**
+- In `read_store`, when an EXISTING `.advisories.json` fails to parse (`json.JSONDecodeError`) or
+  parses to the wrong shape (not a dict / `advisories` not a list), preserve the corrupt content
+  aside as `.advisories.json.corrupt` (best-effort) BEFORE returning the empty default, so the
+  corruption is surfaced for user recovery instead of silently swallowed. A MISSING file stays the
+  normal first-run empty path (no sentinel). An `OSError` (unreadable) stays empty, no sentinel
+  (can't read it to preserve it). Remains non-raising / best-effort.
+- Tests in `tests/test_advisory_store.py`: corrupt JSON → empty store returned AND `.corrupt`
+  sentinel written with the original bytes; wrong-shape JSON → sentinel written; missing file →
+  no sentinel; valid file → no sentinel.
+**Done when:** scoped `pytest tests/test_advisory_store.py` green; cumulative Critic.
+
+### Lane MIG (owns tests/test_plugin_migrate.py)
+
+#### Chunk 09: TST-4H8M — unit coverage for migrate _collapse_blank_runs edge cases (test-only)
+**Type:** code
+**Acceptance criteria:** add `TestCollapseBlankRuns` in `tests/test_plugin_migrate.py` exercising
+`lib/migrate_plugin.py::_collapse_blank_runs` directly (NO runtime change): 3/4/5/7+ consecutive
+newlines collapse to exactly 2; only-newlines input; empty string; and while-loop convergence
+(`a\n\n\nb\n\n\nc` → `a\n\nb\n\nc`).
+**Done when:** scoped `pytest tests/test_plugin_migrate.py` green; cumulative Critic.
+
+## Governance Checkpoints
+
+- **Per-chunk Critic:** satisfied ONCE, cumulatively, by the launching session after the workflow
+  finishes (matches the roi-batch precedent — independent fixes, disjoint files, one cumulative pass).
+- **Cumulative Critic** over `origin/develop...HEAD` gates `/prawduct:pr create`.
+- **Full suite** (`python3 -m pytest`) run by the launching session on the integrated tree before
+  the Critic — the workflow agents run only their own SCOPED test files.
+
+## Release note (two release-pending plans)
+
+This is the SECOND release-pending plan: `build-plan-roi-batch.md` (scope=roi-batch, chunks 01–05,
+status=merged) is still pending its develop→main release. At that release, `regen-views` must run
+once PER plan/scope (it resolves a single plan via the `active_build_plan` pointer): regen with the
+pointer at roi-batch, then at roi-batch-2, before clearing the pointer. The `active_build_plan`
+comment in `project-state.yaml` records both. (If this two-plan regen proves fiddly in practice,
+it's a candidate backlog item against the release tooling.)

--- a/.prawduct/artifacts/build-plan-roi-batch-2.md
+++ b/.prawduct/artifacts/build-plan-roi-batch-2.md
@@ -45,10 +45,13 @@ the exact lines before editing (the backlog's line numbers predate recent edits)
 Context: Plan authored 2026-06-04. Built by ONE workflow, three file-disjoint lanes:
 HOOK (bin/prawduct-hook + lib/views.py + their tests; chunks 01–07, run as two sequential
 sub-agents A=01–03, B=04–07 because both touch bin/prawduct-hook), ADV (lib/advisory_store.py;
-chunk 08), MIG (tests/test_plugin_migrate.py; chunk 09). The workflow does the BUILD half only
-(fix + regression test + SCOPED test run, no commit, no Critic). The launching session does the
-governance half: full suite → single `/prawduct:critic cumulative` → commit → `/prawduct:pr`
-→ archive the 9 backlog items + change-log.
+chunk 08), MIG (tests/test_plugin_migrate.py; chunk 09). The workflow did the BUILD half only
+(fix + regression test + SCOPED test run, no commit, no Critic). STATUS 2026-06-04: all 9 chunks
+BUILT + committed on `fix/roi-batch-2` (df64ac0 scaffold, de87b74 build, 723082b Critic-fix), full
+suite 749 passed, cumulative Critic CLEAN (0 blocking/0 warning/2 notes — heading WARNING resolved
+in 723082b). AWAITING `/prawduct:pr` (PR creation: wait_for_user). Remaining governance half runs at
+merge: add `scope=roi-batch-2 / status=merged` change-log entry (chunks 01–09), archive the 9
+backlog items, KEEP active_build_plan (release-pending — see project-state note: TWO plans pending).
 
 ## Scaffolding
 

--- a/.prawduct/artifacts/build-plan-roi-batch-2.md
+++ b/.prawduct/artifacts/build-plan-roi-batch-2.md
@@ -68,15 +68,15 @@ N/A — edits land in existing trees: `lib/views.py`, `lib/advisory_store.py`, `
      they run SEQUENTIALLY within the lane. Per-chunk "Done when" Critic steps are satisfied ONCE,
      cumulatively, by the launching session after the workflow finishes — see Governance. -->
 
-### Lane HOOK-A (owns lib/views.py, bin/prawduct-hook::cmd_regen_views, tests/test_views.py)
+**Lane HOOK-A (owns lib/views.py, bin/prawduct-hook::cmd_regen_views, tests/test_views.py)**
 
-#### Chunk 01: VWS-3K7P — validate change-log `status=` values + reconcile docstring
+### Chunk 01: VWS-3K7P — validate change-log `status=` values + reconcile docstring
 **Type:** code
 **Acceptance criteria:**
 - New pure helper `validate_status_values(entries) -> list[str]` in `lib/views.py` returns a
   warning string for every change-log entry whose `status=` tag is present but not in
   `{shipped, merged}` (e.g. `status=shippd`). Empty list when all are valid/absent.
-- `bin/prawduct-hook::cmd_regen_views` calls it and prints each warning to stderr (NON-fatal —
+- `cmd_regen_views` (in `bin/prawduct-hook`) calls it and prints each warning to stderr (NON-fatal —
   does not change the exit code or the flip rule).
 - The `lib/views.py` module docstring (~line 19) status enum reconciled from
   `shipped | in-progress | deferred` to `shipped | merged` (note: only `shipped` flips checkboxes;
@@ -86,7 +86,7 @@ N/A — edits land in existing trees: `lib/views.py`, `lib/advisory_store.py`, `
   yield none; absent status yields none.
 **Done when:** scoped `pytest tests/test_views.py` green; `/prawduct:critic` (cumulative, by launching session).
 
-#### Chunk 02: STH-2J9F — regen-views returns exit 1 on ImportError
+### Chunk 02: STH-2J9F — regen-views returns exit 1 on ImportError
 **Type:** code
 **Acceptance criteria:**
 - `cmd_regen_views`'s `except ImportError:` branch returns **1** (honest-failure), matching
@@ -96,7 +96,7 @@ N/A — edits land in existing trees: `lib/views.py`, `lib/advisory_store.py`, `
 - Test asserts ImportError path → exit 1 (in `tests/test_views.py`).
 **Done when:** scoped tests green; cumulative Critic.
 
-#### Chunk 03: VWS-8M2Q — harden views.py tag/frontmatter parsers
+### Chunk 03: VWS-8M2Q — harden views.py tag/frontmatter parsers
 **Type:** code
 **Acceptance criteria:**
 - `parse_tag_line` (or the scope-rollup formatter) no longer emits unparseable YAML when a chunk
@@ -109,9 +109,9 @@ N/A — edits land in existing trees: `lib/views.py`, `lib/advisory_store.py`, `
 - Tests in `tests/test_views.py` for both corners.
 **Done when:** scoped tests green; cumulative Critic.
 
-### Lane HOOK-B (owns bin/prawduct-hook gate/trivial/evidence regions, tests/test_plugin_runtime.py, tests/test_trivial_fileset_gate.py)
+**Lane HOOK-B (owns bin/prawduct-hook gate/trivial/evidence regions, tests/test_plugin_runtime.py, tests/test_trivial_fileset_gate.py)**
 
-#### Chunk 04: STH-6B4R — gate freshness timestamp comparison precision + tie rule
+### Chunk 04: STH-6B4R — gate freshness timestamp comparison precision + tie rule
 **Type:** code
 **Acceptance criteria:**
 - The stop-hook Critic gate (`findings_mtime > session_start`, ~L1796–1804) and the
@@ -125,7 +125,7 @@ N/A — edits land in existing trees: `lib/views.py`, `lib/advisory_store.py`, `
 NOTE: Do not change the evidence-freshness `>=` site (`_test_status`, ~L466–477) unless needed —
 its `>=` is a deliberately different convention; if touched, preserve its semantics and test it.
 
-#### Chunk 05: STH-1W5N — centralize trivial-change protected-path bounds
+### Chunk 05: STH-1W5N — centralize trivial-change protected-path bounds
 **Type:** code
 **Acceptance criteria:**
 - The Type:trivial / doc-only fileset bounds (skills/, methodology/, templates/, CLAUDE.md,
@@ -137,7 +137,7 @@ its `>=` is a deliberately different convention; if touched, preserve its semant
   of truth (the bound list is non-empty and contains the documented paths).
 **Done when:** scoped `pytest tests/test_trivial_fileset_gate.py tests/test_plugin_runtime.py` green; cumulative Critic.
 
-#### Chunk 06: TST-1D5W — tighten _validate_evidence_schema against bool-as-int
+### Chunk 06: TST-1D5W — tighten _validate_evidence_schema against bool-as-int
 **Type:** code
 **Acceptance criteria:**
 - `_validate_evidence_schema` (~L535) rejects a bool where an int is required (Python `bool` is a
@@ -147,7 +147,7 @@ its `>=` is a deliberately different convention; if touched, preserve its semant
   `tests/test_plugin_runtime.py`.
 **Done when:** scoped tests green; cumulative Critic.
 
-#### Chunk 07: TST-7Q3D — stop-gate regression coverage gaps (test-only)
+### Chunk 07: TST-7Q3D — stop-gate regression coverage gaps (test-only)
 **Type:** code
 **Acceptance criteria:** add three regression cases to `TestPluginStopGate`
 (`tests/test_plugin_runtime.py`), NO runtime change:
@@ -157,9 +157,9 @@ its `>=` is a deliberately different convention; if touched, preserve its semant
 - (c) gate-waiver unknown key → assert stderr diagnostic WITHOUT blocking.
 **Done when:** scoped `pytest tests/test_plugin_runtime.py` green; cumulative Critic.
 
-### Lane ADV (owns lib/advisory_store.py, tests/test_advisory_store.py)
+**Lane ADV (owns lib/advisory_store.py, tests/test_advisory_store.py)**
 
-#### Chunk 08: ADV-9K2T — advisory_store surfaces corruption via a .corrupt sentinel
+### Chunk 08: ADV-9K2T — advisory_store surfaces corruption via a .corrupt sentinel
 **Type:** code
 **Acceptance criteria:**
 - In `read_store`, when an EXISTING `.advisories.json` fails to parse (`json.JSONDecodeError`) or
@@ -173,12 +173,12 @@ its `>=` is a deliberately different convention; if touched, preserve its semant
   no sentinel; valid file → no sentinel.
 **Done when:** scoped `pytest tests/test_advisory_store.py` green; cumulative Critic.
 
-### Lane MIG (owns tests/test_plugin_migrate.py)
+**Lane MIG (owns tests/test_plugin_migrate.py)**
 
-#### Chunk 09: TST-4H8M — unit coverage for migrate _collapse_blank_runs edge cases (test-only)
+### Chunk 09: TST-4H8M — unit coverage for migrate _collapse_blank_runs edge cases (test-only)
 **Type:** code
 **Acceptance criteria:** add `TestCollapseBlankRuns` in `tests/test_plugin_migrate.py` exercising
-`lib/migrate_plugin.py::_collapse_blank_runs` directly (NO runtime change): 3/4/5/7+ consecutive
+`_collapse_blank_runs` (in `lib/migrate_plugin.py`) directly (NO runtime change): 3/4/5/7+ consecutive
 newlines collapse to exactly 2; only-newlines input; empty string; and while-loop convergence
 (`a\n\n\nb\n\n\nc` → `a\n\nb\n\nc`).
 **Done when:** scoped `pytest tests/test_plugin_migrate.py` green; cumulative Critic.

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -8,6 +8,20 @@
 ## Open
 
 
+- **[BLD-7P3K]** Guard test: assert the active build plan's chunk headings parse (fail loud on heading-format drift)
+  `effort: S · impact: M · area: build-plan · source: critic · added: 2026-06-04 · status: open · related: VWS-3K7P`
+
+  Recommended by `learnings.md` ("Build-plan chunk headings must use `### Chunk N:` colon form") AND
+  twice by the roi-batch-2 cumulative Critic after the build plan itself shipped with `#### Chunk NN:`
+  (four-hash, under a `### Lane` grouping level) — which silently defeated the `### Chunk ` parsers
+  (`verify-chunk-refs`, `_parse_build_plan_chunk_type`, `lib/critic_mode.py` plan-override) for the
+  WHOLE plan. The degradation is silent: chunk-type fail-closes to `code`, refs stop verifying, and
+  nothing errors. Fix-shape: a test (or a `regen-views`/stop-hook check) that resolves the active
+  build plan via `resolve_build_plan_path` and asserts its `## Status` chunk IDs each map to a
+  parseable `### Chunk <id>:` heading — so a depth/format mismatch fails LOUDLY instead of degrading.
+  Open question: test-only (pins the framework's own plan) vs. a runtime check that fires for any
+  product's active plan. Filed from roi-batch-2 Critic NOTE on 2026-06-04. (critic)
+
 - **[STH-4D2X]** Decide whether the trivial/doc-only file-set gate should also protect a consumer's own `.claude/skills/`
   `effort: M · impact: M · area: stop-hook · source: builder · added: 2026-06-03 · status: open`
 

--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -460,13 +460,17 @@ views_enabled: true
 # artifacts/build-plan.md. Unset → falls back to artifacts/build-plan.md.
 # The v2.0.0, M4 (v2.0.3), and waiver-pragma/2.0-rock-solid (v2.0.4) plans are
 # complete and released; their build-plan files are retained as historical
-# artifacts alongside the prior vN plans. The active plan is the roi-batch (9 ROI
-# backlog fixes), merged to develop via #58 and RELEASE-PENDING: its change-log
-# entry is status=merged and stays here so the next develop→main release can run
-# regen-views to flip the plan's checkboxes, then clear this pointer (see
-# docs/release-process.md + learnings.md "KEEP the build plan" — do NOT clear at
-# develop-merge).
-active_build_plan: artifacts/build-plan-roi-batch.md
+# artifacts alongside the prior vN plans.
+#
+# TWO plans are now release-pending for the next develop→main release:
+#   1. build-plan-roi-batch.md   (scope=roi-batch,   chunks 01–05, status=merged, via #58)
+#   2. build-plan-roi-batch-2.md (scope=roi-batch-2, chunks 01–09, status=merged) ← this pointer
+# The pointer names roi-batch-2 (the in-progress plan) to arm THIS session's stop-hook Critic
+# gate. Both are RELEASE-PENDING: at the develop→main release, `regen-views` must run once per
+# plan/scope (it resolves a single plan via this pointer) — point it at roi-batch, regen, then at
+# roi-batch-2, regen — before clearing this pointer. See docs/release-process.md + learnings.md
+# "KEEP the build plan" — do NOT clear at develop-merge.
+active_build_plan: artifacts/build-plan-roi-batch-2.md
 
 # =============================================================================
 # COVERAGE EVIDENCE (opt-in, v1.4+)

--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -3779,8 +3779,9 @@ def cmd_regen_views(project_dir: Path) -> int:
         ):
             print(f"WARNING: {warning}", file=sys.stderr)
     except OSError:
-        # Best-effort advisory only — plan_regen already succeeded above, so a
-        # read hiccup here must not fail the command.
+        # Best-effort advisory only — the regen computation (plan_regen) already
+        # succeeded above and apply_regen still runs below, so a change-log read
+        # hiccup here must not fail the warning-emitting command.
         pass
 
     try:

--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -559,10 +559,20 @@ def _validate_evidence_schema(evidence: dict) -> tuple[bool, str]:
         if field not in evidence:
             missing.append(field)
             continue
-        if not isinstance(evidence[field], allowed_types):
+        value = evidence[field]
+        # TST-1D5W: bool is a subclass of int, so a writer that emits
+        # ``{"passed": true}`` would slip through ``isinstance(value, int)`` and
+        # be silently read as the integer 1. Reject a bool wherever the field
+        # does not explicitly allow it (none of the numeric fields do) — a JSON
+        # boolean in a count/duration slot is always writer drift, not a real
+        # test count.
+        bool_in_int_slot = (
+            isinstance(value, bool) and bool not in allowed_types
+        )
+        if bool_in_int_slot or not isinstance(value, allowed_types):
             wrong_type.append(
                 f"{field} must be {' | '.join(t.__name__ for t in allowed_types)}, "
-                f"got {type(evidence[field]).__name__}"
+                f"got {type(value).__name__}"
             )
     if missing:
         return False, f"evidence missing required field(s): {', '.join(sorted(missing))}"
@@ -1798,6 +1808,17 @@ def _check_previous_session_gates(project_dir: Path) -> list[str]:
         if critic_findings.is_file() and session_start_file.is_file():
             try:
                 session_start = session_start_file.read_text().strip()
+                # STH-6B4R: format findings_mtime to the SAME whole-second
+                # %Y-%m-%dT%H:%M:%SZ shape `.session-start` is written in (see
+                # cmd_clear's `stamp`), so the comparison is identical-precision
+                # lexicographic (== order-preserving for fixed-width second
+                # strings) — no fractional/format mismatch on either side.
+                # Tie rule: findings_mtime == session_start is NOT fresh
+                # (rejected). Strict `>` means a findings file whose mtime lands
+                # in the same whole second as session-start does not clear the
+                # gate — consistent with the cumulative-critic site's `<= ->
+                # stale`. Both Critic-gate sites use the strict convention; only
+                # `_test_status`'s evidence-freshness uses `>=` (deliberately).
                 findings_mtime = datetime.fromtimestamp(
                     critic_findings.stat().st_mtime, tz=timezone.utc
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -2579,6 +2600,12 @@ def cmd_stop(project_dir: Path) -> int:
         if critic_findings.is_file() and session_start_file.is_file():
             try:
                 session_start = session_start_file.read_text().strip()
+                # STH-6B4R: identical-precision compare — findings_mtime is
+                # formatted to the same whole-second %Y-%m-%dT%H:%M:%SZ shape
+                # `.session-start` is written in, so this is order-preserving
+                # lexicographic with no format mismatch. Tie rule (mirrors the
+                # cmd_clear gate above): findings_mtime == session_start is NOT
+                # fresh — the strict `>` rejects a same-whole-second tie.
                 findings_mtime = datetime.fromtimestamp(
                     critic_findings.stat().st_mtime, tz=timezone.utc
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -3108,6 +3135,32 @@ def _parse_build_plan_chunk_trivial_rationale(
     return rationale, None
 
 
+# STH-1W5N — single source of truth for the unconditional ``Type: trivial`` /
+# doc-only protected-path bounds. Each entry is ``(path, is_exact, reason_label)``:
+# a change touching ``path`` (prefix match unless ``is_exact``) is a
+# catastrophic-blast-radius edit that a trivial/doc-only chunk may never make,
+# and the violation is reported as ``"<reason_label>: <path>"``. Centralized
+# here (was inline in ``_classify_trivial_change``) so the stop-hook gate and
+# the PR-boundary gate share one provably-identical list — and so the bound set
+# is testable as data. The conditional bounds (test-file removals, newly-tracked
+# files) stay in ``_classify_trivial_change`` because they depend on the change
+# verb, not just the path.
+#   skills/       — the critic/pr/etc. SKILL definitions + bundled protocols ARE
+#                   the governance; editing one changes the framework itself.
+#   methodology/  — the build/discovery/planning/reflection guides Claude reads
+#                   as operating instructions; a "trivial" rewrite is never trivial.
+#   templates/    — the artifact templates every product's specs are generated
+#                   from; a silent change propagates to all downstream output.
+#   CLAUDE.md     — the project's top-level operating contract (exact match —
+#                   a nested ``foo/CLAUDE.md`` is ordinary product doc).
+_TRIVIAL_PROTECTED_PATHS: frozenset[tuple[str, bool, str]] = frozenset({
+    ("skills/", False, "skill-file-edited"),
+    ("methodology/", False, "methodology-edited"),
+    ("templates/", False, "template-edited"),
+    ("CLAUDE.md", True, "claude-md-edited"),
+})
+
+
 def _classify_trivial_change(
     *,
     path: str,
@@ -3122,6 +3175,12 @@ def _classify_trivial_change(
     per-commit name-status diff). Centralizing the rule set prevents
     the stop-hook gate and the PR-boundary gate from drifting apart
     silently.
+
+    The unconditional path bounds live in the module-level
+    ``_TRIVIAL_PROTECTED_PATHS`` constant (STH-1W5N — single source of
+    truth, referenced from this one call site). The conditional bounds
+    (test-file removals, newly-tracked files) stay inline below because
+    they depend on the change verb, not just the path.
 
     Metadata paths (``.prawduct/``, ``.claude/settings.json``, etc. —
     see ``_is_metadata_path``) are treated as out-of-scope and return
@@ -3142,14 +3201,14 @@ def _classify_trivial_change(
         return None
     if src_path is not None and _is_metadata_path(src_path):
         return None
-    if path == "CLAUDE.md":
-        return f"claude-md-edited: {path}"
-    if path.startswith("skills/"):
-        return f"skill-file-edited: {path}"
-    if path.startswith("methodology/"):
-        return f"methodology-edited: {path}"
-    if path.startswith("templates/"):
-        return f"template-edited: {path}"
+    # Unconditional path bounds — driven by the _TRIVIAL_PROTECTED_PATHS
+    # constant so this gate and the PR-boundary gate share one list. The
+    # classes are mutually exclusive (a path matches at most one), so the
+    # frozenset's unordered iteration is behavior-preserving.
+    for protected, is_exact, reason_label in _TRIVIAL_PROTECTED_PATHS:
+        matched = path == protected if is_exact else path.startswith(protected)
+        if matched:
+            return f"{reason_label}: {path}"
     if is_deletion and path.startswith("tests/"):
         return f"test-file-deleted: {path}"
     if src_path is not None and src_path.startswith("tests/"):
@@ -3614,9 +3673,13 @@ def cmd_check_cumulative_critic(project_dir: Path) -> int:
         )
         return 1
     # Lexicographic compare on whole-second %Y-%m-%dT%H:%M:%SZ strings is
-    # order-preserving — same convention as cmd_clear's gate check around
-    # line 1874. Adding fractional seconds to the format would break both
+    # order-preserving — same identical-precision convention as cmd_clear's
+    # gate check. Adding fractional seconds to the format would break both
     # sides; keep them in lockstep.
+    # STH-6B4R tie rule: findings_mtime == session_start is NOT fresh (stale).
+    # `<=` rejects the same-whole-second tie, matching the Critic-gate sites'
+    # strict `>` (which clears the gate only when findings_mtime is strictly
+    # greater). The two phrasings express the identical tie semantics.
     if findings_mtime <= session_start:
         print(
             f"stale: cumulative findings ({findings_mtime}) "
@@ -3661,6 +3724,9 @@ def cmd_regen_views(project_dir: Path) -> int:
 
     Exit codes:
       0 - success (views disabled, no changes needed, or regen applied cleanly)
+      1 - the plugin lib/ could not be imported (incomplete install) — a
+          state-mutating command must not report success on a broken install
+          (mirrors accept/verify-operator-verification's ImportError handling)
       2 - I/O or schema error (missing change-log or build-plan)
     """
     # Ensure the plugin root is on sys.path so `from lib import views` resolves
@@ -3671,16 +3737,16 @@ def cmd_regen_views(project_dir: Path) -> int:
     try:
         from lib import views  # noqa: PLC0415 — lazy import keeps top-level cheap
     except ImportError:
-        # The bundled governance lib/ should always import in the plugin (it
-        # ships alongside this script under ${CLAUDE_PLUGIN_ROOT}). Degrade
-        # gracefully rather than crash if the install is incomplete; views
-        # derivation is a convenience, and Status can be updated by hand.
+        # Honest failure: regen-views mutates state (build-plan checkboxes,
+        # release-notes, scope_rollups), so it must not claim success when its
+        # machinery is absent (an incomplete plugin install). Matches
+        # accept/verify-operator-verification — exit 1, not a silent exit 0.
         print(
-            "NOTE: regen-views could not import the plugin lib/ from "
+            "error: regen-views could not import the plugin lib/ from "
             "${CLAUDE_PLUGIN_ROOT}; Status not auto-regenerated.",
             file=sys.stderr,
         )
-        return 0
+        return 1
 
     prawduct_dir = get_prawduct_dir(project_dir)
     try:
@@ -3701,6 +3767,21 @@ def cmd_regen_views(project_dir: Path) -> int:
     if not enabled:
         print("Views disabled (set views_enabled: true in project-state.yaml).")
         return 0
+
+    # Surface change-log status= typos (e.g. status=shippd) as NON-fatal
+    # warnings on stderr — an unrecognized status silently fails to flip a
+    # checkbox, so we warn rather than letting the typo pass unnoticed. This
+    # does NOT change the exit code or the flip rule (only status==shipped flips).
+    try:
+        change_log_text = (prawduct_dir / "change-log.md").read_text(encoding="utf-8")
+        for warning in views.validate_status_values(
+            views.parse_change_log(change_log_text)
+        ):
+            print(f"WARNING: {warning}", file=sys.stderr)
+    except OSError:
+        # Best-effort advisory only — plan_regen already succeeded above, so a
+        # read hiccup here must not fail the command.
+        pass
 
     try:
         views.apply_regen(prawduct_dir, results)

--- a/lib/advisory_store.py
+++ b/lib/advisory_store.py
@@ -280,20 +280,47 @@ def _migrate_store(data: dict) -> dict:
     return data
 
 
+def _preserve_corrupt(path: Path, raw: str) -> None:
+    """Best-effort: stash corrupt store bytes aside as ``<path>.corrupt``.
+
+    Surfaces corruption for user recovery instead of silently swallowing it
+    (a returned empty store would otherwise be indistinguishable from a clean
+    first run). Best-effort by design — the read path must stay non-raising, so
+    a failed preservation is swallowed rather than propagated.
+    """
+    try:
+        path.with_name(path.name + ".corrupt").write_text(raw)
+    except OSError:
+        pass  # best-effort: never let preservation break the (non-raising) read
+
+
 def read_store(product_dir) -> dict:
     """Read the nag log. Missing/unreadable/malformed → empty default (no raise).
 
     A lower/absent ``schema_version`` is migrated forward on read (spec A7);
     the migrated version persists on the next :func:`write_store`.
+
+    Corruption handling (ADV-9K2T): an EXISTING file that fails to parse or
+    parses to the wrong shape is preserved aside as ``.advisories.json.corrupt``
+    BEFORE the empty default is returned, so corruption is surfaced for recovery
+    rather than silently swallowed. A MISSING file is the normal first-run empty
+    path (no sentinel). An ``OSError`` (genuinely unreadable) stays empty with no
+    sentinel — the bytes can't be read, so there's nothing to preserve.
     """
     path = _store_path(product_dir)
     if not path.is_file():
-        return _empty_store()
+        return _empty_store()  # first run — not corruption, no sentinel
     try:
-        data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+        raw = path.read_text()
+    except OSError:
+        return _empty_store()  # unreadable — can't read it to preserve it
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        _preserve_corrupt(path, raw)  # readable but unparseable → surface it
         return _empty_store()
     if not isinstance(data, dict) or not isinstance(data.get("advisories"), list):
+        _preserve_corrupt(path, raw)  # parsed but wrong shape → surface it
         return _empty_store()
     return _migrate_store(data)
 

--- a/lib/views.py
+++ b/lib/views.py
@@ -16,7 +16,10 @@ Recognized keys:
 
 * ``chunks``  comma-separated chunk IDs (zero-padded, matching build-plan headers)
 * ``release`` version string (used by release-notes view, Chunk 06)
-* ``status``  ``shipped`` | ``in-progress`` | ``deferred``
+* ``status``  ``shipped`` | ``merged`` — the two recognized values. Only
+  ``shipped`` flips a checkbox to ``[x]``; ``merged`` is the release-pending
+  intermediate (PR merged to develop, develop→main release still pending) and
+  does NOT flip a checkbox.
 * ``scope``   rollup identifier, e.g., ``v1.4``
 
 Entries without a tag line are ignored — untagged historical entries coexist
@@ -38,6 +41,12 @@ H2_RE = re.compile(r"^##\s+(.+?)\s*$")
 CHUNK_LINE_RE = re.compile(
     r"^(?P<prefix>\s*-\s+)\[(?P<state>[ xX])\](?P<rest>\s+Chunk\s+(?P<id>[A-Za-z0-9_-]+):.*)$"
 )
+# Safe charset for a chunk ID, mirroring CHUNK_LINE_RE's `id` group. A chunk ID
+# is only ever a build-plan header token, so anything outside this set (a quote,
+# `}`, `:`, whitespace) is malformed and — left unquoted/quoted naively — would
+# corrupt the generated scope_rollups YAML (e.g. `chunks: ["0"a]`). Such IDs are
+# dropped before they reach a derived view.
+CHUNK_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 @dataclass
@@ -115,6 +124,36 @@ def parse_change_log(content: str) -> list[ChangeLogEntry]:
     return entries
 
 
+VALID_STATUS_VALUES = frozenset({"shipped", "merged"})
+
+
+def validate_status_values(entries: list[ChangeLogEntry]) -> list[str]:
+    """Return a warning string for each entry with an unrecognized ``status=`` tag.
+
+    A change-log ``status=`` typo (e.g. ``status=shippd``) silently fails to flip
+    a checkbox — the entry parses fine but ``shipped_chunks`` returns ``[]``, so
+    the chunk never marks complete and the release driver sees no error. This
+    pure helper surfaces those typos as non-fatal warnings: it flags every entry
+    whose ``status=`` tag is PRESENT but not in ``{shipped, merged}``. Entries
+    with no ``status=`` tag (untagged historical entries) are not flagged.
+
+    Returns ``[]`` when every status value is valid or absent.
+    """
+    warnings: list[str] = []
+    for entry in entries:
+        status = entry.tags.get("status")
+        if status is None:
+            continue
+        if status not in VALID_STATUS_VALUES:
+            warnings.append(
+                f"change-log entry {entry.title!r} (line {entry.line_number}) "
+                f"has unrecognized status={status!r} — expected one of "
+                f"{sorted(VALID_STATUS_VALUES)}; this entry will not flip any "
+                f"checkbox. Likely a typo."
+            )
+    return warnings
+
+
 def collect_shipped_chunks(
     entries: list[ChangeLogEntry], scope: str | None = None
 ) -> set[str]:
@@ -153,8 +192,13 @@ def _parse_build_plan_frontmatter_scope(content: str) -> tuple[bool, str | None]
       opt-out* form: the author is saying "do not scope-filter," and inference
       MUST be suppressed rather than silently inheriting a change-log scope.
     * ``(False, None)``  — key absent, nested inside another key, outside the
-      frontmatter, or the file lacks a frontmatter entirely. Here inference may
-      legitimately fall back to the change-log.
+      frontmatter, the file lacks a frontmatter entirely, OR a leading HTML
+      comment header is never closed (no ``-->``). The unclosed-comment case is
+      handled LENIENTLY: the comment scan walks to EOF without finding ``-->``,
+      so no ``---`` opener is located and the result is ``(False, None)`` — a
+      safe "absent" reading that lets inference fall back to the change-log
+      rather than raising on a malformed file. A real build-plan always closes
+      its header, so this only affects hand-corrupted input.
     """
     lines = content.splitlines()
     i = 0
@@ -163,7 +207,10 @@ def _parse_build_plan_frontmatter_scope(content: str) -> tuple[bool, str | None]
     while i < len(lines) and not lines[i].strip():
         i += 1
     if i < len(lines) and lines[i].lstrip().startswith("<!--"):
-        # Walk to the closing `-->` (inclusive).
+        # Walk to the closing `-->` (inclusive). If the comment is UNCLOSED,
+        # this walks to EOF; `i` then lands past the last line so the consume
+        # below is skipped and the `i >= len(lines)` guard returns (False, None)
+        # — a deliberately lenient reading of a malformed header (see docstring).
         while i < len(lines) and "-->" not in lines[i]:
             i += 1
         if i < len(lines):
@@ -352,7 +399,13 @@ def _collect_scope_rollups(
         rec = raw.setdefault(scope, {"chunks": set(), "releases": set()})
         chunks = entry.tags.get("chunks")
         if isinstance(chunks, list):
-            rec["chunks"].update(c for c in chunks if isinstance(c, str))
+            # Drop any chunk ID outside the safe charset so a malformed ID
+            # (quote / brace / colon) cannot corrupt the scope_rollups YAML.
+            rec["chunks"].update(
+                c
+                for c in chunks
+                if isinstance(c, str) and CHUNK_ID_SAFE_RE.match(c)
+            )
         release = entry.tags.get("release")
         if isinstance(release, str) and release:
             rec["releases"].add(release)

--- a/tests/test_advisory_store.py
+++ b/tests/test_advisory_store.py
@@ -109,11 +109,48 @@ class TestStoreIO:
         store = read_store(tmp_path)
         assert store["advisories"] == []
 
+    def test_corrupt_file_preserves_bytes_in_sentinel(self, tmp_path: Path):
+        """ADV-9K2T: an existing unparseable store is stashed aside as
+        ``.advisories.json.corrupt`` (carrying the original bytes) before the
+        empty default is returned — corruption is surfaced, not swallowed."""
+        (tmp_path / ".prawduct").mkdir()
+        original = "not json{{{"
+        (tmp_path / ".prawduct" / ".advisories.json").write_text(original)
+        store = read_store(tmp_path)
+        assert store == {"schema_version": SCHEMA_VERSION, "advisories": []}
+        sentinel = tmp_path / ".prawduct" / ".advisories.json.corrupt"
+        assert sentinel.is_file()
+        assert sentinel.read_text() == original
+
     def test_wrong_shape_returns_empty(self, tmp_path: Path):
         (tmp_path / ".prawduct").mkdir()
         (tmp_path / ".prawduct" / ".advisories.json").write_text(json.dumps({"advisories": "nope"}))
         store = read_store(tmp_path)
         assert store["advisories"] == []
+
+    def test_wrong_shape_writes_sentinel(self, tmp_path: Path):
+        """ADV-9K2T: a store that parses but has the wrong shape (advisories not
+        a list / not a dict) is also preserved aside before returning empty."""
+        (tmp_path / ".prawduct").mkdir()
+        original = json.dumps({"advisories": "nope"})
+        (tmp_path / ".prawduct" / ".advisories.json").write_text(original)
+        store = read_store(tmp_path)
+        assert store["advisories"] == []
+        sentinel = tmp_path / ".prawduct" / ".advisories.json.corrupt"
+        assert sentinel.is_file()
+        assert sentinel.read_text() == original
+
+    def test_missing_file_writes_no_sentinel(self, tmp_path: Path):
+        """A missing store is the normal first-run empty path — never corruption,
+        so no ``.corrupt`` sentinel is written."""
+        read_store(tmp_path)
+        assert not (tmp_path / ".prawduct" / ".advisories.json.corrupt").exists()
+
+    def test_valid_file_writes_no_sentinel(self, tmp_path: Path):
+        """A valid store reads cleanly with no ``.corrupt`` sentinel written."""
+        write_store(tmp_path, {"schema_version": SCHEMA_VERSION, "advisories": [{"id": "x", "state": "active"}]})
+        read_store(tmp_path)
+        assert not (tmp_path / ".prawduct" / ".advisories.json.corrupt").exists()
 
     def test_roundtrip(self, tmp_path: Path):
         store = {"schema_version": SCHEMA_VERSION, "advisories": [{"id": "x", "state": "active"}]}

--- a/tests/test_plugin_migrate.py
+++ b/tests/test_plugin_migrate.py
@@ -31,6 +31,15 @@ import pytest
 ROOT = Path(__file__).resolve().parent.parent
 HOOK = ROOT / "bin" / "prawduct-hook"
 
+# TestCollapseBlankRuns imports the engine DIRECTLY (in-process), unlike the rest
+# of this file which subprocesses bin/prawduct-hook. The direct import keeps the
+# pure-helper unit tests isolated and fast; sys.path + ``from lib import ...``
+# mirrors the established pattern in the sibling lib tests (test_advisory_store.py).
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from lib import migrate_plugin as _migrate_plugin  # noqa: E402 — sys.path mutated above
+
 # The 7 framework skills (registry-derived; mirrored here so the fixture is
 # realistic — the engine derives this set itself, the test must not).
 FRAMEWORK_SKILLS = [
@@ -535,3 +544,45 @@ def test_migrate_nudges_point_at_existing_skill():
     # Chunk 8's nudges reference /prawduct:migrate — the skill must now back them.
     assert (ROOT / "skills" / "migrate" / "SKILL.md").is_file()
     assert "/prawduct:migrate" in (ROOT / "bin" / "prawduct-hook").read_text()
+
+
+# =============================================================================
+# Unit — _collapse_blank_runs (pure helper, imported in-process)
+# =============================================================================
+
+
+class TestCollapseBlankRuns:
+    """Unit coverage for ``_collapse_blank_runs`` edge cases (TST-4H8M).
+
+    Exercises the helper DIRECTLY (no subprocess) — it is a pure str→str
+    function, so a subprocess round-trip would only add noise and couple these
+    cases to the migrate dispatch wiring the other tests already cover.
+    """
+
+    @pytest.mark.parametrize(
+        "n",
+        [3, 4, 5, 7, 8, 12],
+        ids=["run3", "run4", "run5", "run7", "run8", "run12"],
+    )
+    def test_run_of_n_newlines_collapses_to_two(self, n):
+        # Any run of 3+ consecutive newlines (3, 4, 5, and 7+) collapses to
+        # exactly two newlines (one blank line) regardless of run length.
+        text = "a" + ("\n" * n) + "b"
+        assert _migrate_plugin._collapse_blank_runs(text) == "a\n\nb"
+
+    def test_only_newlines_input_collapses_to_two(self):
+        # A string that is nothing but a long newline run collapses to exactly two.
+        assert _migrate_plugin._collapse_blank_runs("\n" * 9) == "\n\n"
+
+    def test_empty_string_is_unchanged(self):
+        assert _migrate_plugin._collapse_blank_runs("") == ""
+
+    def test_no_blank_run_is_unchanged(self):
+        # A single blank line (two newlines) is already at the floor — untouched.
+        assert _migrate_plugin._collapse_blank_runs("a\n\nb") == "a\n\nb"
+
+    def test_while_loop_converges_across_multiple_runs(self):
+        # The while-loop must collapse EVERY run, not just the first — two
+        # separate triple-newline runs each reduce to a double newline.
+        text = "a\n\n\nb\n\n\nc"
+        assert _migrate_plugin._collapse_blank_runs(text) == "a\n\nb\n\nc"

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -267,6 +267,114 @@ class TestPluginStopGate:
         result = run_plugin_hook("stop", tmp_path, git_status=" M src/app.py")
         assert result.returncode == 0, (result.stdout, result.stderr)
 
+    def test_stop_blocks_when_findings_mtime_exactly_ties_session_start(self, tmp_path):
+        """STH-6B4R tie rule: findings_mtime == session_start is NOT fresh.
+
+        The Critic gate clears only on a strict `findings_mtime > session_start`
+        at identical (whole-second) precision. A findings file whose mtime lands
+        in the exact same whole second as session-start must NOT clear the gate
+        — so this otherwise-valid, blocking-free findings file still blocks
+        (exit 2). Pins the tie semantics against a future `>=` regression.
+        """
+        prawduct = self._active_plan_repo(tmp_path)
+        findings = prawduct / ".critic-findings.json"
+        findings.write_text(json.dumps({
+            "findings": [], "files_reviewed": ["src/app.py"], "summary": "No issues found.",
+        }))
+        # Force the findings mtime to a fixed whole second, then write
+        # session-start to that SAME whole-second string -> an exact tie.
+        tie = datetime(2026, 6, 4, 12, 0, 0, tzinfo=timezone.utc)
+        epoch = tie.timestamp()
+        os.utime(findings, (epoch, epoch))
+        (prawduct / ".session-start").write_text(tie.strftime("%Y-%m-%dT%H:%M:%SZ"))
+        result = run_plugin_hook("stop", tmp_path, git_status=" M src/app.py")
+        assert result.returncode == 2, (result.stdout, result.stderr)
+        assert "CRITIC" in result.stderr
+
+
+class TestPluginStopGateRegressions:
+    """TST-7Q3D: regression coverage for three previously-untested stop-gate
+    branches — verify-resolutions out-of-scope blocking, Type:trivial fileset
+    violations, and the unknown-gate-waiver-key diagnostic. Mirrors
+    TestPluginStopGate's fixtures (active plan + session markers + fresh findings).
+    """
+
+    # The verbose persisted form of the verify-resolutions mode (the bare
+    # `verify-resolutions` token is the caller-side input, rejected on disk).
+    _VERIFY_RESOLUTIONS_MODE = "verify-resolutions (delta review, prior findings only)"
+
+    def _active_plan_repo(self, tmp_path) -> Path:
+        prawduct = tmp_path / ".prawduct"
+        artifacts = prawduct / "artifacts"
+        artifacts.mkdir(parents=True)
+        (artifacts / "build-plan.md").write_text("# Build Plan\n\n## Status\n- [ ] Chunk 1\n")
+        (prawduct / ".session-reflected").write_text(
+            "Session reflection: implemented the chunk and verified all tests pass cleanly."
+        )
+        (prawduct / ".session-git-baseline").write_text("")
+        _make_session_start(prawduct)
+        return prawduct
+
+    def test_verify_resolutions_out_of_scope_file_blocks(self, tmp_path):
+        # (a) Findings declare files_reviewed=[a.py] in verify-resolutions mode,
+        # but the current diff also modifies b.py — out of the verify pass's
+        # declared scope, so the (fresh, valid) findings must NOT clear the gate.
+        prawduct = self._active_plan_repo(tmp_path)
+        (prawduct / ".critic-findings.json").write_text(json.dumps({
+            "findings": [],
+            "files_reviewed": ["a.py"],
+            "summary": "Resolutions verified.",
+            "mode": self._VERIFY_RESOLUTIONS_MODE,
+        }))
+        result = run_plugin_hook(
+            "stop", tmp_path, git_status=" M a.py\n M b.py",
+        )
+        assert result.returncode == 2, (result.stdout, result.stderr)
+        assert "verify-resolutions" in result.stderr
+        # The blocker names the out-of-scope widening (b.py is outside scope).
+        assert "outside scope" in result.stderr
+        assert "b.py" in result.stderr
+
+    def test_trivial_chunk_outside_fileset_bounds_blocks(self, tmp_path):
+        # (b) A chunk declaring Type: trivial that edits skills/ (a catastrophic-
+        # blast-radius bound) must block with the fileset reason, even though the
+        # rationale is present.
+        prawduct = tmp_path / ".prawduct"
+        artifacts = prawduct / "artifacts"
+        artifacts.mkdir(parents=True)
+        (artifacts / "build-plan.md").write_text(
+            "# Build Plan\n\n## Status\n- [ ] Chunk 01: tweak a skill\n\n"
+            "## Build Chunks\n\n"
+            "### Chunk 01: tweak a skill\n"
+            "**Type:** trivial\n"
+            "**Trivial because:** a one-word typo fix in a skill doc.\n"
+        )
+        (prawduct / ".session-reflected").write_text(
+            "Session reflection: edited the skill doc and confirmed the change reads cleanly."
+        )
+        (prawduct / ".session-git-baseline").write_text("")
+        _make_session_start(prawduct)
+        result = run_plugin_hook(
+            "stop", tmp_path, git_status=" M skills/critic/SKILL.md",
+        )
+        assert result.returncode == 2, (result.stdout, result.stderr)
+        assert "TYPE: TRIVIAL" in result.stderr
+        assert "skill-file-edited" in result.stderr
+
+    def test_unknown_gate_waiver_key_warns_without_blocking(self, tmp_path):
+        # (c) An unknown key in .gates-waived emits a stderr diagnostic but never
+        # blocks — unknown keys simply have no effect. Use a no-build-plan repo so
+        # nothing else would block: exit 0, with the diagnostic present.
+        prawduct = tmp_path / ".prawduct"
+        prawduct.mkdir()
+        (prawduct / ".session-git-baseline").write_text("")
+        _make_session_start(prawduct)
+        (prawduct / ".gates-waived").write_text(json.dumps({"bogus": "not a real gate"}))
+        result = run_plugin_hook("stop", tmp_path, git_status=" M src/app.py")
+        assert result.returncode == 0, (result.stdout, result.stderr)
+        assert "unknown keys" in result.stderr
+        assert "bogus" in result.stderr
+
 
 class TestStopGateAttribution:
     """Design §5a: a blocking message names the version + gate that caused it,
@@ -528,6 +636,20 @@ class TestValidateEvidenceSchema:
         # Names the now-required F4a fields so the writer bug is obvious.
         assert "verifier" in result.stderr
         assert "coverage_level" in result.stderr
+
+    def test_bool_rejected_for_int_field(self, tmp_path):
+        # TST-1D5W: bool is a subclass of int, so `{"passed": true}` would slip
+        # through a bare isinstance(v, int) check and be read as the integer 1.
+        # The schema must reject a JSON boolean in an int-typed count field —
+        # it is always writer drift, never a real test count.
+        evidence = dict(self._COMPLETE)
+        evidence["passed"] = True  # JSON bool where an int count is required
+        repo = self._write_evidence(tmp_path, evidence)
+        result = _run_in(repo, "validate-evidence")
+        assert result.returncode == 1, result.stdout
+        # The violation names the offending field and the bool type it got.
+        assert "passed" in result.stderr
+        assert "bool" in result.stderr
 
 
 class TestWriteIsolationInvariant:

--- a/tests/test_trivial_fileset_gate.py
+++ b/tests/test_trivial_fileset_gate.py
@@ -86,3 +86,38 @@ class TestNonProtectedChanges:
         reason = _classify("skills/critic/SKILL.md")
         assert reason is not None and reason.startswith("skill-file-edited")
         assert "agent-file-edited" not in reason
+
+
+class TestProtectedPathsConstant:
+    """STH-1W5N: the unconditional protected-path bounds are centralized in the
+    module-level `_TRIVIAL_PROTECTED_PATHS` constant — the single source of truth
+    referenced by `_classify_trivial_change`. These assertions pin that the
+    constant (not a stale inline literal) is what the classifier consults."""
+
+    def test_constant_is_non_empty_frozenset(self):
+        assert isinstance(_hook._TRIVIAL_PROTECTED_PATHS, frozenset)
+        assert _hook._TRIVIAL_PROTECTED_PATHS, "the protected-path bound list must be non-empty"
+
+    def test_constant_contains_documented_paths(self):
+        # The four catastrophic-blast-radius classes the bound has always covered.
+        paths = {entry[0] for entry in _hook._TRIVIAL_PROTECTED_PATHS}
+        assert {"skills/", "methodology/", "templates/", "CLAUDE.md"} <= paths
+
+    def test_claude_md_is_exact_match_not_prefix(self):
+        # CLAUDE.md is an exact-match bound (a nested foo/CLAUDE.md is ordinary
+        # product doc); the others are prefix bounds. The flag in the constant
+        # is what drives that distinction.
+        by_path = {entry[0]: entry[1] for entry in _hook._TRIVIAL_PROTECTED_PATHS}
+        assert by_path["CLAUDE.md"] is True
+        assert by_path["skills/"] is False
+
+    def test_classifier_reads_the_constant(self):
+        # Every entry in the constant must actually produce a violation from the
+        # classifier with the constant's own reason label — proving the constant
+        # is the source of truth, not a parallel copy that could drift.
+        for protected, is_exact, reason_label in _hook._TRIVIAL_PROTECTED_PATHS:
+            sample = protected if is_exact else protected + "x.md"
+            reason = _classify(sample)
+            assert reason == f"{reason_label}: {sample}", (
+                f"constant entry {protected!r} did not drive the classifier"
+            )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -217,6 +217,58 @@ class TestCollectShippedChunks:
         assert views.collect_shipped_chunks(entries, scope="v1.5") == {"01"}
 
 
+class TestValidateStatusValues:
+    """VWS-3K7P: surface change-log `status=` typos as non-fatal warnings.
+
+    An unrecognized status (e.g. `status=shippd`) parses fine but silently fails
+    to flip any checkbox — the typo guard turns that into a visible warning.
+    """
+
+    def test_typo_yields_one_warning(self):
+        entries = [
+            views.ChangeLogEntry(
+                title="2026-06-04: typo", tags={"chunks": ["01"], "status": "shippd"}
+            )
+        ]
+        warnings = views.validate_status_values(entries)
+        assert len(warnings) == 1
+        assert "shippd" in warnings[0]
+
+    def test_valid_shipped_yields_none(self):
+        entries = [
+            views.ChangeLogEntry(
+                title="2026-06-04: ok", tags={"chunks": ["01"], "status": "shipped"}
+            )
+        ]
+        assert views.validate_status_values(entries) == []
+
+    def test_valid_merged_yields_none(self):
+        entries = [
+            views.ChangeLogEntry(
+                title="2026-06-04: ok", tags={"chunks": ["01"], "status": "merged"}
+            )
+        ]
+        assert views.validate_status_values(entries) == []
+
+    def test_absent_status_yields_none(self):
+        entries = [
+            views.ChangeLogEntry(title="2026-06-04: untagged", tags={}),
+            views.ChangeLogEntry(
+                title="2026-06-04: chunks-only", tags={"chunks": ["02"]}
+            ),
+        ]
+        assert views.validate_status_values(entries) == []
+
+    def test_one_warning_per_bad_entry(self):
+        entries = [
+            views.ChangeLogEntry(title="a", tags={"status": "shippd"}),
+            views.ChangeLogEntry(title="b", tags={"status": "shipped"}),
+            views.ChangeLogEntry(title="c", tags={"status": "in-progress"}),
+        ]
+        warnings = views.validate_status_values(entries)
+        assert len(warnings) == 2  # shippd + in-progress (shipped is valid)
+
+
 class TestParseBuildPlanFrontmatterScope:
     def test_scope_field_present(self):
         content = (
@@ -296,6 +348,29 @@ class TestParseBuildPlanFrontmatterScope:
     def test_html_comment_without_frontmatter_is_absent(self):
         """Comment header but no frontmatter at all → key absent."""
         content = "<!-- header -->\n# Plan\nNo frontmatter.\n"
+        assert views._parse_build_plan_frontmatter_scope(content) == (False, None)
+
+    def test_unclosed_html_comment_is_handled_leniently(self):
+        """VWS-8M2Q (v1.5.1 R5): a leading HTML comment that is never closed
+        (no ``-->``) must not raise or misparse. The comment scan walks to EOF,
+        no ``---`` opener is found, and the result is the safe ``(False, None)``
+        absent reading — the documented lenient handling of malformed input."""
+        content = (
+            "<!-- Build Plan: this header is never closed\n"
+            "     no terminator on any line\n"
+            "---\n"
+            "scope: v9.9\n"
+            "---\n"
+            "## Status\n"
+        )
+        # The `---`/`scope:` lines are swallowed by the unterminated comment scan,
+        # so the frontmatter is unreachable → (False, None), no exception.
+        assert views._parse_build_plan_frontmatter_scope(content) == (False, None)
+
+    def test_unclosed_html_comment_only_input(self):
+        """An input that is nothing but an unclosed comment also degrades to
+        absent rather than raising (empty/EOF edge of the lenient path)."""
+        content = "<!-- open and never closed\nstill open\n"
         assert views._parse_build_plan_frontmatter_scope(content) == (False, None)
 
 
@@ -803,6 +878,43 @@ class TestBuildScopeView:
         _, scopes = views.build_scope_view(change_log, self.BASE_STATE)
         assert scopes["v1.4"]["chunks"] == ["01", "02", "03"]
 
+    def test_malformed_chunk_id_does_not_corrupt_yaml(self):
+        """VWS-8M2Q: a chunk ID with a quote/special char must NOT produce
+        unparseable scope_rollups YAML. The unsafe ID is dropped (it falls
+        outside the CHUNK_ID_SAFE charset); the well-formed sibling survives and
+        the emitted block round-trips through a real YAML parser."""
+        import yaml
+
+        # `01"a` (embedded quote) and `0 2` (space) are malformed; `03` is fine.
+        change_log = (
+            '## 2026-06-04: malformed\n'
+            '<!-- prawduct: chunks=01"a,0 2,03 | status=shipped | scope=v1.4 -->\n'
+        )
+        new, scopes = views.build_scope_view(change_log, self.BASE_STATE)
+        # Only the safe ID survived into the aggregated mapping.
+        assert scopes == {"v1.4": {"chunks": ["03"], "releases": []}}
+        assert new is not None
+        # The emitted project-state.yaml (with the scope_rollups block) is valid
+        # YAML — the embedded quote did not corrupt the document.
+        parsed = yaml.safe_load(new)
+        assert parsed["scope_rollups"]["v1.4"]["chunks"] == ["03"]
+
+    def test_collect_scope_rollups_drops_unsafe_ids_directly(self):
+        """Unit-level guard on the collector: unsafe chunk IDs are filtered out
+        before they ever reach the formatter."""
+        entries = [
+            views.ChangeLogEntry(
+                title="x",
+                tags={
+                    "chunks": ['"', "}", "ok-1", "ok_2"],
+                    "status": "shipped",
+                    "scope": "s",
+                },
+            )
+        ]
+        rollups = views._collect_scope_rollups(entries)
+        assert rollups == {"s": {"chunks": ["ok-1", "ok_2"], "releases": []}}
+
 
 class TestBuildReleaseNotesView:
     def test_none_when_no_releases(self):
@@ -1223,3 +1335,97 @@ class TestRegenViewsAllThree:
         assert (product / ".prawduct" / "artifacts" / "build-plan.md").read_text() == plan_after_first
         # And output reflects no work done.
         assert "up to date" in second.stdout.lower() or "no changes" in second.stdout.lower()
+
+
+class TestRegenViewsImportError:
+    """STH-2J9F: a broken/incomplete install (lib/ unimportable) must fail
+    honestly with exit 1 — a state-mutating command must not report success
+    when its machinery is absent (mirrors accept/verify-operator-verification).
+    """
+
+    def test_import_error_returns_exit_1(self, tmp_path: Path):
+        product = _make_product_repo(
+            tmp_path,
+            views_enabled=True,
+            change_log=(
+                "## 2026-05-18: rel\n"
+                "<!-- prawduct: chunks=00 | status=shipped -->\n"
+            ),
+            build_plan="## Status\n- [ ] Chunk 00: A\n",
+        )
+        # Point CLAUDE_PLUGIN_ROOT at an empty dir with no lib/ package so
+        # `from lib import views` raises ImportError. The script's own dir is
+        # bin/, which has no lib/ either, so the import genuinely fails.
+        empty_root = tmp_path / "empty_plugin_root"
+        empty_root.mkdir()
+        env = {
+            **os.environ,
+            "CLAUDE_PROJECT_DIR": str(product),
+            "CLAUDE_PLUGIN_ROOT": str(empty_root),
+        }
+        result = subprocess.run(
+            ["python3", str(HOOK_PATH), "regen-views"],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(product),
+            timeout=20,
+        )
+        assert result.returncode == 1, (result.stdout, result.stderr)
+        assert "could not import" in result.stderr.lower()
+        # Build plan was NOT silently regenerated under the broken install.
+        assert (
+            "- [ ] Chunk 00: A"
+            in (product / ".prawduct" / "artifacts" / "build-plan.md").read_text()
+        )
+
+
+class TestRegenViewsStatusTypoWarning:
+    """VWS-3K7P: a change-log `status=` typo is surfaced on stderr as a
+    NON-fatal warning — regen still succeeds (exit 0) and still flips the
+    valid entries; only the typoed entry fails to flip (as it always did)."""
+
+    def test_typo_warns_on_stderr_non_fatal(self, tmp_path: Path):
+        product = _make_product_repo(
+            tmp_path,
+            views_enabled=True,
+            change_log=(
+                "## 2026-06-04: good entry\n"
+                "<!-- prawduct: chunks=00 | status=shipped -->\n"
+                "\n"
+                "## 2026-06-04: typoed entry\n"
+                "<!-- prawduct: chunks=01 | status=shippd -->\n"
+            ),
+            build_plan=(
+                "## Status\n"
+                "- [ ] Chunk 00: A\n"
+                "- [ ] Chunk 01: B\n"
+            ),
+        )
+        result = _run_regen(product)
+        # Non-fatal: command still succeeds.
+        assert result.returncode == 0, result.stderr
+        # Warning surfaced on stderr, naming the bad value.
+        assert "shippd" in result.stderr
+        assert "warning" in result.stderr.lower()
+        new_plan = (product / ".prawduct" / "artifacts" / "build-plan.md").read_text()
+        # Valid entry flipped; typoed entry did NOT flip (flip rule unchanged).
+        assert "- [x] Chunk 00: A" in new_plan
+        assert "- [ ] Chunk 01: B" in new_plan
+
+    def test_no_warning_when_all_valid(self, tmp_path: Path):
+        product = _make_product_repo(
+            tmp_path,
+            views_enabled=True,
+            change_log=(
+                "## 2026-06-04: shipped entry\n"
+                "<!-- prawduct: chunks=00 | status=shipped -->\n"
+                "\n"
+                "## 2026-06-04: merged entry\n"
+                "<!-- prawduct: chunks=01 | status=merged -->\n"
+            ),
+            build_plan="## Status\n- [ ] Chunk 00: A\n- [ ] Chunk 01: B\n",
+        )
+        result = _run_regen(product)
+        assert result.returncode == 0, result.stderr
+        assert "WARNING" not in result.stderr


### PR DESCRIPTION
Nine independent high-ROI backlog fixes — the 2026-06-04 rough-edges hunt (verified-real before filing) plus one older re-verified item — built by one workflow across three file-disjoint lanes (HOOK A→B sequential, ADV, MIG concurrent).

## Fixes
- **VWS-3K7P** — `validate_status_values()` warns on change-log `status=` typos in `regen-views` (non-fatal); `views.py` docstring reconciled to `{shipped, merged}`. *(release-process typo footgun)*
- **STH-2J9F** — `cmd_regen_views` returns exit 1 (not 0) on ImportError — honest failure on a broken install. *(silent-degradation bug)*
- **VWS-8M2Q** — drop unsafe chunk IDs from `scope_rollups` YAML (`CHUNK_ID_SAFE_RE`); document the frontmatter unclosed-comment leniency + add the malformed-frontmatter test.
- **STH-6B4R** — gate-freshness sites were already identical-precision (`%Y-%m-%dT%H:%M:%SZ`); documented the invariant + tie rule (`findings_mtime == session_start` is NOT fresh) and pinned it with an exact-tie regression test. *(docs + test only)*
- **STH-1W5N** — extract `_TRIVIAL_PROTECTED_PATHS` frozenset (single source of truth for the trivial/doc-only protected-path bounds); behavior-preserving.
- **TST-1D5W** — `_validate_evidence_schema` rejects a bool in an int field (bool is an int subclass).
- **TST-7Q3D** — `TestPluginStopGateRegressions`: verify-resolutions out-of-scope, trivial-fileset-bounds, and unknown-waiver-key cases.
- **ADV-9K2T** — `read_store` preserves a `.advisories.json.corrupt` sentinel on parse/shape failure of an existing store (surfaces corruption instead of a silent reset).
- **TST-4H8M** — `TestCollapseBlankRuns` unit coverage for migrate `_collapse_blank_runs`.

## Verification
- **749 passed** (+35), 0 failed.
- Cumulative Critic: **0 blocking / 0 warning / 2 notes** (a build-plan heading-depth WARNING was caught and resolved).
- Independent PR review: **0 blocking / 0 warning / 1 note** (an accepted cross-class fixture mirror).

## Deferred to merge time (dual release-pending model)
This is the **second** release-pending plan (after `roi-batch`). Adding the `scope=roi-batch-2 / status=merged` change-log entry, archiving the 9 backlog items, and keeping `active_build_plan` are done at merge; the develop→main release runs `regen-views` once per scope. Files BLD-7P3K (a guard test so build-plan heading drift fails loud).