### PR TITLE
onboard: split repo onboarding out of /prawduct:doctor into /prawduct:onboard + lean README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ When someone opens this directory, route based on context:
 → This repo is a Prawduct product in active development. Read `.prawduct/project-state.yaml` for framework state and `.prawduct/learnings.md` for accumulated wisdom. Apply the methodology to framework changes — principles, proportional review, reflection.
 
 **Onboarding another product** ("let's work on ../my-app", "set up prawduct for ../foo")
-→ Use `/prawduct:doctor <target-path>` (Onboard). For a brand-new repo it scaffolds the product-owned state (`prawduct-hook init-product`); for an existing v1 file-sync repo it routes to `/prawduct:migrate` (one reversible commit). Either way the repo commits only the install reference — no framework files. Tell the user to open the target in a new Claude Code session for governance: `claude <target-path>`.
+→ Use `/prawduct:onboard <target-path>`. For a new or existing repo it scaffolds the product-owned state (`prawduct-hook init-product`); for a pre-2.0 file-sync repo it routes to `/prawduct:migrate` (one reversible commit). Either way the repo commits only the install reference — no framework files. Tell the user to open the target in a new Claude Code session for governance: `claude <target-path>`. (For an already-onboarded repo, `/prawduct:doctor` is health-check/repair.)
 
 **Ad-hoc work outside this repo** ("build me X in ../foo", "create a CLI that does Y")
 → The user wants Claude to do work that isn't part of this framework and isn't being onboarded as a Prawduct product. Proceed with the work, applying principles as engineering judgment — not as a formal process. At session end, reflect on what was built and note any methodology observations (did the process help, hinder, or feel irrelevant?).
@@ -60,7 +60,7 @@ When someone opens this directory, route based on context:
 → Scan known product directories for `.prawduct/learnings.md`. Look for methodology friction or process feedback. Summarize and propose framework updates.
 
 **First contact** ("hello", "what is this?", "what can you do?")
-→ Briefly explain: Prawduct helps you build software by guiding structured discovery, producing quality specifications, governing the build, and learning from experience. It installs as a Claude Code plugin; product repos onboard via `/prawduct:doctor` and commit only a small install reference — no framework files.
+→ Briefly explain: Prawduct helps you build software by guiding structured discovery, producing quality specifications, governing the build, and learning from experience. It installs as a Claude Code plugin; product repos onboard via `/prawduct:onboard` and commit only a small install reference — no framework files.
 
 ## Sessions and Work Cycles
 
@@ -146,7 +146,7 @@ Session-end becomes a quick synthesis scan, not a from-scratch write. Read `meth
 
 ## Project Layout
 
-**Product repos** (onboarded via `/prawduct:doctor`, plugin-governed — they commit only their own state plus a small install reference, no framework files):
+**Product repos** (onboarded via `/prawduct:onboard`, plugin-governed — they commit only their own state plus a small install reference, no framework files):
 ```
 my-product/
 ├── CLAUDE.md                    # product instructions + a thin static governance anchor (PRAWDUCT:ANCHOR)

--- a/README.md
+++ b/README.md
@@ -30,58 +30,38 @@ Claude Code is fantastic at writing code, but without discipline it makes assump
 - Python 3 (the plugin's governance hooks are Python, zero external dependencies)
 - git
 
-Prawduct v2 is distributed as a **Claude Code plugin**. A product repo commits only a
-small install *reference* — never framework files. (See [MIGRATION](documentation/MIGRATION.md)
-to move an existing v1 file-sync repo onto the plugin.)
+Prawduct is a **Claude Code plugin**: install it **once at the user level**, then **onboard each
+repo** you want governed — the same command for a new or existing repo. A project commits only a
+tiny install *reference*, never framework files.
 
-### Install the plugin
-
-Prawduct is published as a Claude Code plugin from its own marketplace (this repo, pinned to
-`main`). Add the marketplace and install the plugin:
+### 1. Install the plugin (once, for your machine)
 
 ```bash
 claude plugin marketplace add brookstalley/prawduct
 claude plugin install prawduct@prawduct
 ```
 
-The `/prawduct:*` skills and governance are then available in your sessions. To onboard a repo
-so it self-governs for everyone who clones it, run `/prawduct:doctor` (below) — it commits a
-small install reference (marketplace + enabled plugin); no framework files land in your tree.
+`/prawduct:*` is now available in every Claude Code session.
 
-> **Developing the framework itself?** Load your working copy instead of the released plugin
-> with `claude --plugin-dir /path/to/prawduct --add-dir /path/to/prawduct` — the `--add-dir`
-> (same path) lets methodology-reading skills (`/prawduct:building`, `/prawduct:critic`,
-> `/prawduct:planning`) load their bundled guides from the out-of-tree plugin. See
-> [Develop the framework itself](#develop-the-framework-itself).
-
-### Start a new product
+### 2. Onboard a repo — new or existing, same command
 
 ```bash
-mkdir ~/my-product && cd ~/my-product && git init
+cd ~/my-repo          # new repo? `mkdir ~/my-repo && cd "$_" && git init` first
 claude
-> /prawduct:doctor .
+> /prawduct:onboard .
 ```
 
-`/prawduct:doctor` (Onboard) scaffolds the product-owned state — `.prawduct/`, a thin
-governance anchor in `CLAUDE.md`, and the committed install reference — with **zero**
-framework files in your tree. Then describe what you want to build:
+This scaffolds `.prawduct/`, a thin `CLAUDE.md` anchor, and the committed install reference — zero
+framework files in your tree. Then describe what you want:
 
 ```
-> I want to build a meal planning app for families with dietary restrictions
+> build a meal-planning app for families with dietary restrictions
+> add OAuth login to the existing API
 ```
 
-### Add Prawduct to an existing repo
-
-```bash
-cd ~/existing-repo
-claude
-> /prawduct:doctor .
-```
-
-For a brand-new `.prawduct/`, doctor scaffolds it; for a repo that still carries v1
-file-sync framework files, it routes you to `/prawduct:migrate` (one reversible commit).
-
-Prawduct will ask the obvious questions and also the non-obvious questions before getting started. It analyzes existing code (if any) to infer project conventions (language, test framework, code style) and records them for future reference.
+Anyone who clones the repo gets the same governance (the plugin auto-installs on first trusted
+open). Already onboarded? `/prawduct:doctor` health-checks the repo. Moving a pre-2.0 file-sync
+repo? `/prawduct:onboard` routes it to [`/prawduct:migrate`](documentation/MIGRATION.md).
 
 ## How Prawduct Works
 
@@ -160,10 +140,10 @@ It validates the committed install reference, confirms the repo is on the plugin
 
 ```bash
 cd prawduct
-claude --plugin-dir .
+claude --plugin-dir . --add-dir .
 ```
 
-This repo is governed by its own plugin — it dogfoods itself. See [docs/release-process.md](docs/release-process.md) for the gitflow release model and the release checklist.
+This repo is governed by its own plugin — it dogfoods itself. The `--add-dir .` (same path) lets methodology-reading skills (`/prawduct:building`, `/prawduct:critic`, `/prawduct:planning`) load their bundled guides from the out-of-tree plugin; a real marketplace install grants that automatically. See [docs/release-process.md](docs/release-process.md) for the gitflow release model and the release checklist.
 
 ## Q&A
 
@@ -250,7 +230,7 @@ prawduct/
 │   ├── plugin.json             # name: prawduct, version (mirrors VERSION)
 │   └── marketplace.json        # single-plugin marketplace entry (plugin source "./", consumers pin ref: main)
 ├── hooks/hooks.json            # SessionStart (banner + briefing + guidance digest), Stop (Critic + reflection gates)
-├── skills/                     # framework skills → /prawduct:* (critic, pr, doctor, migrate, building, …)
+├── skills/                     # framework skills → /prawduct:* (onboard, doctor, critic, pr, migrate, building, …)
 ├── bin/prawduct-hook           # runtime governance (Python; reads/writes only ${CLAUDE_PROJECT_DIR}/.prawduct/)
 ├── lib/                        # governance + scaffolding/migration modules (init_product, migrate_plugin, …)
 ├── methodology/ docs/ templates/  # bundled; read by skills/hooks via ${CLAUDE_PLUGIN_ROOT}
@@ -280,7 +260,7 @@ Full history is in [CHANGELOG.md](CHANGELOG.md). Highlights:
 - `/prawduct:*` namespaced skills; governance via the plugin's SessionStart (banner + briefing + guidance digest) and Stop (Critic + reflection gates) hooks
 - **Version-delta banner** (shows what changed + newly-active gates on update); marketplace `autoUpdate` for always-latest
 - **`/prawduct:migrate`** — one-command, reversible v1 file-sync → plugin cutover (see [MIGRATION](documentation/MIGRATION.md))
-- Plugin-native new-product scaffolding via `/prawduct:doctor`
+- Plugin-native onboarding/scaffolding via `/prawduct:onboard` (health-check/repair stays `/prawduct:doctor`)
 - Gitflow release model (see [docs/release-process.md](docs/release-process.md))
 - Backward compatible: existing v1 file-sync repos migrate onto the plugin via `/prawduct:migrate` (one reversible, revertable commit)
 

--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -4461,7 +4461,7 @@ def cmd_migrate_plugin(project_dir: Path, argv: list[str]) -> int:
 
 
 def cmd_init_product(argv: list[str]) -> int:
-    """Scaffold a NEW plugin-governed product repo (``/prawduct:doctor`` Onboard).
+    """Scaffold a new or existing plugin-governed product repo (``/prawduct:onboard``).
 
     Thin wrapper around the plugin-native ``lib.init_product.run``. Unlike the other
     subcommands it operates on a TARGET path passed in ``argv`` (the new repo),

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,55 +1,28 @@
 ---
-description: Product repo setup, health check, and repair
-argument-hint: "[target-path]"
+description: Health-check, repair, and maintain an already-onboarded Prawduct repo (enable gates, verify, audit learnings)
+argument-hint: "[no args — runs in the product repo]"
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: Bash(prawduct-hook init-product *), Bash(prawduct-hook verify-operator-verification *), Bash(prawduct-hook audit-learnings *), Read, Glob
+allowed-tools: Bash(prawduct-hook verify-operator-verification *), Bash(prawduct-hook audit-learnings *), Read, Glob
 ---
 
 You are managing prawduct product-repo health under the **plugin** distribution model. Prawduct is installed as a Claude Code plugin (dev-time governance); a product commits only the install *reference* plus its own `.prawduct/` state — no framework files. Every flow operates on the consumer's own repo: there is no framework checkout to call back to.
 
+This skill is for a repo that is **already onboarded**. To set up a new or existing repo, use **`/prawduct:onboard`** instead.
+
 ## Context Detection
 
-1. If an explicit target path was provided as an argument → **Onboard** that target.
+1. If an explicit target path was provided that is NOT yet a product repo (no `.prawduct/`) → onboarding lives in **`/prawduct:onboard <path>`**; point the user there and stop.
 2. Else if the current directory has `.prawduct/` (is a product repo) → **Health Check**, and route to Enable-Gate / Verify / Audit-Learnings on explicit request.
 3. Else → ask the user what they want to do.
 
 | Request | Action |
 |---|---|
-| Explicit target path provided | **Onboard**: see Onboard Flow |
+| Set up a new or existing repo | **Use `/prawduct:onboard`** (not this skill) |
 | Current dir is a product repo (has `.prawduct/`) | **Health Check**: see Health Check Flow |
 | "enable coverage" / "turn on F4" / "enable operator verification" / "turn on F10" / similar | **Enable a gate**: see Enable-Gate Flow |
 | "verify VRF-NN" / "drain operator verification" / "mark verified" | **Verify**: see Verify Flow |
 | "audit learnings" / "retire structurally-enforced learnings" / "check lifecycle metadata" / similar | **Audit Learnings**: see Audit-Learnings Flow |
-
-## Onboard Flow (target path provided)
-
-Onboarding under the plugin model is plugin-native — there is no file-sync setup script. Pick the shape by inspecting the target:
-
-### A. Brand-new product (no `.prawduct/` yet) → **scaffold it**
-
-`prawduct-hook init-product` creates the product-owned state for a plugin repo: `.prawduct/` (project-state.yaml with `distribution: plugin`, learnings.md, backlog.md, change-log.md, artifacts/), the thin static CLAUDE.md anchor, and the committed install reference — and **none** of the file-sync machinery (no `tools/`, no committed skills, no sync-manifest).
-
-1. Confirm the target directory with the user (it should be a git repo).
-2. **Dry-run** the scaffold and present the plan: `prawduct-hook init-product <target> --name "<Product Name>" --json` (no `--apply`). Surface that it creates only product-owned state + the install reference.
-3. **Confirm**, then apply: `prawduct-hook init-product <target> --name "<Product Name>" --apply`.
-4. Tell the user to commit the result.
-
-### B. Existing file-sync repo (committed `tools/product-hook`, framework `.claude/skills/`, `.prawduct/sync-manifest.json`) → **migrate it**
-
-Have them run **`/prawduct:migrate`** in the target: it commits the install reference, strips the committed framework files, drops the legacy hook wiring, and records `distribution: plugin` — one reversible commit.
-
-### Either way
-
-- The committed install *reference* (project scope) in `.claude/settings.json` is the only prawduct content the repo commits, and it never drifts — `init-product` writes it for new repos, `/prawduct:migrate` for existing ones:
-  ```json
-  {
-    "extraKnownMarketplaces": { "prawduct": { "source": { "source": "github", "repo": "brookstalley/prawduct", "ref": "main" }, "autoUpdate": true } },
-    "enabledPlugins": { "prawduct@prawduct": true }
-  }
-  ```
-  On first trusted open, Claude Code prompts each developer to install the marketplace + plugin (one-time, skippable).
-- Governance activates only in the target's OWN session: **"Open `<target>` in a new Claude Code session — the hooks and the session briefing won't fire until then."**
 
 ## Health Check Flow (current dir is a product repo)
 
@@ -113,7 +86,7 @@ The audit is read-only by default. Promotion is always advisory — `learnings.m
 
 ## Important Notes
 
-- Onboarding is plugin-native: **`prawduct-hook init-product`** scaffolds a brand-new repo (product-owned state + install reference, no framework files); **`/prawduct:migrate`** converts an existing file-sync repo. There is no file-sync `setup` script in the plugin model.
+- Onboarding lives in **`/prawduct:onboard`** (scaffold a new or existing repo via `prawduct-hook init-product`, or route a pre-2.0 file-sync repo to `/prawduct:migrate`). This skill (`doctor`) covers an already-onboarded repo: health-check, enable-gate, verify, audit-learnings.
 - Health Check and Audit-Learnings decide from the consumer's OWN `.prawduct/` — no framework checkout, no sync.
 - Enabling a gate is a `project-state.yaml` flag flip; the BLOCKING consequence is immediate on the next relevant gate (governance is modeled as CI — see `/prawduct:methodology`).
 - Hooks and governance activate in the target's own Claude Code session, not the current one.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -12,7 +12,7 @@ This skill is for a repo that is **already onboarded**. To set up a new or exist
 
 ## Context Detection
 
-1. If an explicit target path was provided that is NOT yet a product repo (no `.prawduct/`) → onboarding lives in **`/prawduct:onboard <path>`**; point the user there and stop.
+1. If an explicit target path was provided → `doctor` runs in the *current* product repo, not on a target path. If they meant to **set up** that path, send them to **`/prawduct:onboard <path>`**; if they meant to **health-check a different** repo, have them `cd` there and re-run. Either way, stop here.
 2. Else if the current directory has `.prawduct/` (is a product repo) → **Health Check**, and route to Enable-Gate / Verify / Audit-Learnings on explicit request.
 3. Else → ask the user what they want to do.
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,0 +1,41 @@
+---
+description: Onboard a repo to Prawduct — scaffold a new or existing repo onto the plugin (the install/setup entry point)
+argument-hint: "[target-path]"
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: Bash(prawduct-hook init-product *), Read, Glob
+---
+
+You are onboarding a repo onto Prawduct under the **plugin** distribution model. Prawduct is installed as a Claude Code plugin (dev-time governance); a product commits only the install *reference* plus its own `.prawduct/` state — no framework files. Onboarding is the same whether the repo is brand-new or an existing codebase, and it operates on the consumer's own repo — there is no framework checkout to call back to.
+
+(For an already-onboarded repo, health-check / repair / maintenance lives in **`/prawduct:doctor`**, not here.)
+
+## Onboard Flow
+
+Onboarding under the plugin model is plugin-native — there is no file-sync setup script. Pick the shape by inspecting the target:
+
+### A. New or existing repo with no `.prawduct/` yet → **scaffold it**
+
+`prawduct-hook init-product` creates the product-owned state for a plugin repo: `.prawduct/` (project-state.yaml with `distribution: plugin`, learnings.md, backlog.md, change-log.md, artifacts/), the thin static CLAUDE.md anchor, and the committed install reference — and **none** of the file-sync machinery (no `tools/`, no committed skills, no sync-manifest). It works identically for an empty repo and one with years of existing code (for existing code, discovery later reads it to infer conventions).
+
+1. Confirm the target directory with the user (it should be a git repo).
+2. **Dry-run** the scaffold and present the plan: `prawduct-hook init-product <target> --name "<Product Name>" --json` (no `--apply`). Surface that it creates only product-owned state + the install reference.
+3. **Confirm**, then apply: `prawduct-hook init-product <target> --name "<Product Name>" --apply`.
+4. Tell the user to commit the result.
+
+### B. Existing pre-2.0 file-sync repo (committed `tools/product-hook`, framework `.claude/skills/`, `.prawduct/sync-manifest.json`) → **migrate it**
+
+Have them run **`/prawduct:migrate`** in the target: it commits the install reference, strips the committed framework files, drops the legacy hook wiring, and records `distribution: plugin` — one reversible commit.
+
+### Either way
+
+- The committed install *reference* (project scope) in `.claude/settings.json` is the only prawduct content the repo commits, and it never drifts — `init-product` writes it for new repos, `/prawduct:migrate` for existing file-sync ones:
+  ```json
+  {
+    "extraKnownMarketplaces": { "prawduct": { "source": { "source": "github", "repo": "brookstalley/prawduct", "ref": "main" }, "autoUpdate": true } },
+    "enabledPlugins": { "prawduct@prawduct": true }
+  }
+  ```
+  On first trusted open, Claude Code prompts each developer to install the marketplace + plugin (one-time, skippable).
+- Governance activates only in the target's OWN session: **"Open `<target>` in a new Claude Code session — the hooks and the session briefing won't fire until then."**
+- After onboarding, run **`/prawduct:doctor`** in the repo anytime to health-check the install.

--- a/tests/test_plugin_init.py
+++ b/tests/test_plugin_init.py
@@ -193,7 +193,22 @@ def test_subcommand_registered():
     assert "init-product <target> --name" in src  # usage string
 
 
-def test_doctor_skill_invokes_init_product():
-    text = (ROOT / "skills" / "doctor" / "SKILL.md").read_text()
-    assert "init-product" in text, "the doctor Onboard flow must use init-product"
+def test_onboard_skill_invokes_init_product():
+    # Onboarding was split out of `doctor` into its own `/prawduct:onboard` skill
+    # (doctor = health-check/repair of an already-onboarded repo). The init-product
+    # scaffold call now lives in the onboard skill.
+    text = (ROOT / "skills" / "onboard" / "SKILL.md").read_text()
+    assert "init-product" in text, "the onboard flow must use init-product"
     assert "Bash(prawduct-hook init-product" in text, "allowed-tools must permit init-product"
+
+
+def test_doctor_skill_does_not_onboard():
+    # Guard the split: doctor must NOT grant the scaffold capability (the
+    # init-product tool), and must route setup to /prawduct:onboard. A prose
+    # mention of init-product (explaining what onboard does) is fine — the
+    # contract is the tool grant, not the word.
+    text = (ROOT / "skills" / "doctor" / "SKILL.md").read_text()
+    assert "Bash(prawduct-hook init-product" not in text, (
+        "doctor must not grant init-product — scaffolding moved to /prawduct:onboard"
+    )
+    assert "/prawduct:onboard" in text, "doctor must route setup requests to /prawduct:onboard"

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -492,7 +492,7 @@ class TestPluginDocsNamespacing:
     # `/clear` is a Claude Code built-in, not a prawduct skill — deliberately absent.
     BARE_INVOCATION = re.compile(
         r"(?<![\w/:.\-])/(critic|pr|backlog|learnings|janitor|discovery|planning"
-        r"|building|reflection|methodology|doctor|advisory)\b"
+        r"|building|reflection|methodology|doctor|onboard|advisory)\b"
     )
 
     @pytest.mark.parametrize("rel", DOCS)


### PR DESCRIPTION
**Why:** `doctor` connotes health-check (brew/flutter doctor), not setup — so using it as the install/onboard entry point was confusing (raised by the owner). The `doctor` skill was also overloaded with five flows; onboarding is the only one the name doesn't fit.

**What:**
- New **`skills/onboard/SKILL.md`** — the onboarding entry point: scaffold a new *or* existing repo (`prawduct-hook init-product`), or route a pre-2.0 file-sync repo to `/prawduct:migrate`.
- **`skills/doctor/SKILL.md`** narrowed to health-check / repair / enable-gate / verify / audit-learnings — drops the Onboard flow **and** the `init-product` tool grant; a stray path arg now redirects to `/prawduct:onboard`.
- **CLAUDE.md** onboarding routes → `/prawduct:onboard` (health-check refs correctly stay `doctor`); **`bin/prawduct-hook`** `cmd_init_product` docstring repointed.
- **README Quick Start** trimmed to two tight steps — install once at the user level; onboard any repo (new or existing) with the same command. `--add-dir` tip moved to "Develop the framework itself".
- **Tests:** repoint the init-product guard to the onboard skill, add a doctor-does-not-onboard guard (asserts the *tool grant* is gone), add `onboard` to the bare-command namespace regex.

**Governance:** full suite green (804 passed, 1 skipped); cumulative Critic clean (0 blocking, the 2 routing NOTEs + the docstring WARNING resolved in follow-ups); independent PR review clean (0 blocking; its WARNING fixed). Ships as **v2.0.8** (patch).