### PR TITLE
fix: silence SessionStart hooks in non-Prawduct repos

### DIFF
--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -1898,6 +1898,14 @@ def cmd_clear(project_dir: Path) -> int:
     """Reset session state and render the session briefing (plugin runtime: no sync)."""
     prawduct_dir = get_prawduct_dir(project_dir)
 
+    # The plugin is user-scoped, so this SessionStart hook fires in every repo the
+    # user opens. A repo that never onboarded has no .prawduct/ — emit nothing and
+    # touch nothing, mirroring cmd_stop (the Stop gate). Skills like
+    # /prawduct:onboard stay available; this only silences the always-on session
+    # briefing and its session-marker side effects in non-Prawduct repos.
+    if not prawduct_dir.is_dir():
+        return 0
+
     # Check previous session's governance gates (warn, never block)
     try:
         gate_warnings = _check_previous_session_gates(project_dir)
@@ -1948,9 +1956,8 @@ def cmd_clear(project_dir: Path) -> int:
             f.unlink()
 
     # Create session start timestamp
-    if prawduct_dir.is_dir():
-        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        (prawduct_dir / ".session-start").write_text(stamp)
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (prawduct_dir / ".session-start").write_text(stamp)
 
     # Agent-facing messages go to stdout (SessionStart hooks show stdout to the model).
     # stderr is only visible to the user in the terminal, not to the agent.
@@ -2028,38 +2035,35 @@ def cmd_clear(project_dir: Path) -> int:
     # any future feature probe refreshes `.advisories.json` at session start.
     # Local + fail-soft (run_sync_advisories never raises); the broad guard is
     # belt-and-suspenders so a future feature's faulty probe can't block startup.
-    if prawduct_dir.is_dir():
-        try:
-            lib_root = _plugin_root()
-            if lib_root not in sys.path:
-                sys.path.insert(0, lib_root)
-            from lib.advisory_store import run_sync_advisories  # noqa: PLC0415 — lazy keeps top-level import cheap
-            run_sync_advisories(
-                project_dir, sync_version=_plugin_manifest_version() or ""
-            )
-        except Exception as exc:  # prawduct:allow prawduct/broad-except -- advisory probes must never block session start
-            print(f"NOTE: advisory probe step skipped: {exc}", file=sys.stderr)
+    try:
+        lib_root = _plugin_root()
+        if lib_root not in sys.path:
+            sys.path.insert(0, lib_root)
+        from lib.advisory_store import run_sync_advisories  # noqa: PLC0415 — lazy keeps top-level import cheap
+        run_sync_advisories(
+            project_dir, sync_version=_plugin_manifest_version() or ""
+        )
+    except Exception as exc:  # prawduct:allow prawduct/broad-except -- advisory probes must never block session start
+        print(f"NOTE: advisory probe step skipped: {exc}", file=sys.stderr)
 
     # Capture git status baseline so session-start state doesn't trigger
     # spurious stop-hook gates (no sync runs first in the plugin runtime).
-    if prawduct_dir.is_dir():
-        baseline = git_status_output(project_dir)
-        if baseline is not None:
-            (prawduct_dir / ".session-git-baseline").write_text(baseline)
+    baseline = git_status_output(project_dir)
+    if baseline is not None:
+        (prawduct_dir / ".session-git-baseline").write_text(baseline)
 
     # v5: Staleness scan + session briefing + subagent briefing
-    if prawduct_dir.is_dir():
-        try:
-            staleness = staleness_scan(project_dir)
-            briefing = assemble_session_briefing(project_dir, staleness)
-            print(briefing)
-        except Exception as e:  # prawduct:allow prawduct/broad-except -- briefing must never block session start
-            print(f"NOTE: Session briefing failed: {e}", file=sys.stderr)
+    try:
+        staleness = staleness_scan(project_dir)
+        briefing = assemble_session_briefing(project_dir, staleness)
+        print(briefing)
+    except Exception as e:  # prawduct:allow prawduct/broad-except -- briefing must never block session start
+        print(f"NOTE: Session briefing failed: {e}", file=sys.stderr)
 
-        try:
-            generate_subagent_briefing(project_dir)
-        except Exception as e:  # prawduct:allow prawduct/broad-except -- briefing must never block session start
-            print(f"NOTE: Subagent briefing generation failed: {e}", file=sys.stderr)
+    try:
+        generate_subagent_briefing(project_dir)
+    except Exception as e:  # prawduct:allow prawduct/broad-except -- briefing must never block session start
+        print(f"NOTE: Subagent briefing generation failed: {e}", file=sys.stderr)
 
     return 0
 

--- a/hooks/digest.py
+++ b/hooks/digest.py
@@ -53,7 +53,29 @@ def read_digest(root: Path) -> str:
     return (root.joinpath(*DIGEST_RELPATH)).read_text(encoding="utf-8").strip()
 
 
+def in_prawduct_repo() -> bool:
+    """True when the consuming repo is Prawduct-governed — i.e. has a ``.prawduct/``.
+
+    The plugin is user-scoped, so this SessionStart hook fires in *every* repo the
+    user opens. The digest is product-session governance guidance; it must stay
+    silent in repos that never onboarded. This mirrors the gate the banner
+    (``hooks/banner.py``) and the Stop hook (``prawduct-hook`` ``cmd_stop``) already
+    apply — ``.prawduct/`` is the single is-this-a-Prawduct-repo marker.
+
+    The repo is ``CLAUDE_PROJECT_DIR`` (Claude Code sets it for every hook),
+    falling back to cwd for direct invocation. Read-only: only ``.is_dir()``.
+    """
+    proj = Path(os.environ.get("CLAUDE_PROJECT_DIR", ".")).resolve()
+    return (proj / ".prawduct").is_dir()
+
+
 def main() -> int:
+    # Emit the governance digest only in a Prawduct-governed repo; stay silent
+    # (and write nothing) everywhere else. Without this the user-scoped plugin
+    # injects governance context into every repo the user opens (see banner.py /
+    # cmd_stop, which already gate on .prawduct/).
+    if not in_prawduct_repo():
+        return 0
     try:
         digest = read_digest(plugin_root())
     except Exception as exc:  # prawduct:allow prawduct/broad-except -- a digest failure must never break session start

--- a/tests/test_plugin_methodology_digest.py
+++ b/tests/test_plugin_methodology_digest.py
@@ -53,15 +53,23 @@ def _canonical_digest_copies(root: Path = ROOT) -> list[Path]:
     )
 
 
-def _run_digest(plugin_root: Path | None) -> subprocess.CompletedProcess:
+def _run_digest(
+    plugin_root: Path | None, project_dir: Path | None = None
+) -> subprocess.CompletedProcess:
     """Invoke hooks/digest.py as Claude Code would (CLAUDE_PLUGIN_ROOT set), or
     with it absent to exercise the __file__ fallback when plugin_root is None.
+
+    CLAUDE_PROJECT_DIR is set explicitly — defaulting to the plugin repo ROOT,
+    which is itself a Prawduct repo (has .prawduct/) — so the .prawduct/ repo gate
+    is deterministic regardless of the ambient environment. Pass a project_dir
+    without a .prawduct/ to exercise the non-Prawduct-repo silence path.
 
     HOME is kept outside any repo and PYTHONDONTWRITEBYTECODE=1 so the run leaves
     no caches behind (learnings: HOME=repo leaks the pyc cache into the tree).
     """
     env = {k: v for k, v in os.environ.items() if k != "CLAUDE_PLUGIN_ROOT"}
     env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir if project_dir is not None else ROOT)
     if plugin_root is not None:
         env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
     return subprocess.run(
@@ -155,6 +163,39 @@ class TestDigestHook:
 
     def test_hook_has_python_shebang(self):
         assert DIGEST_HOOK.read_text(encoding="utf-8").startswith("#!/usr/bin/env python3")
+
+
+class TestDigestRepoGate:
+    """The plugin is user-scoped, so the digest SessionStart hook fires in every
+    repo the user opens. It must inject the governance digest ONLY in a
+    Prawduct-governed repo (one with a .prawduct/ dir) and stay silent everywhere
+    else — mirroring the banner (hooks/banner.py) and the Stop hook (cmd_stop),
+    which already gate on .prawduct/. This is the fix for the user-scoped plugin
+    leaking governance into unrelated repos.
+    """
+
+    def test_emits_in_prawduct_repo(self, tmp_path):
+        (tmp_path / ".prawduct").mkdir()
+        result = _run_digest(ROOT, project_dir=tmp_path)
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)["hookSpecificOutput"]
+        assert out["hookEventName"] == "SessionStart"
+        assert out["additionalContext"].strip()
+
+    def test_silent_in_non_prawduct_repo(self, tmp_path):
+        # No .prawduct/ -> emit nothing (no additionalContext injected), exit 0.
+        result = _run_digest(ROOT, project_dir=tmp_path)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "", (
+            "digest leaked into a non-Prawduct repo — it must stay silent without .prawduct/"
+        )
+
+    def test_silent_run_writes_nothing(self, tmp_path):
+        # The gate is read-only: a silent run must not scaffold .prawduct/ or any file.
+        before = {p for p in tmp_path.rglob("*")}
+        _run_digest(ROOT, project_dir=tmp_path)
+        assert {p for p in tmp_path.rglob("*")} == before, "gate must not write to the repo"
+        assert not (tmp_path / ".prawduct").exists()
 
 
 class TestDigestWiring:

--- a/tests/test_plugin_runtime.py
+++ b/tests/test_plugin_runtime.py
@@ -221,6 +221,31 @@ class TestPluginClearBriefing:
         assert "/learnings <topic>" not in result.stdout
 
 
+class TestPluginClearNonPrawductRepo:
+    """The clear/briefing SessionStart hook fires in every repo (the plugin is
+    user-scoped). In a repo with no .prawduct/ it must emit nothing and write
+    nothing — no session briefing, no project-preferences CRITICAL, no session
+    markers — mirroring cmd_stop, which already early-returns. Skills like
+    /prawduct:onboard stay available; only the always-on briefing is silenced.
+    This is the fix for the user-scoped plugin leaking governance into unrelated
+    repos.
+    """
+
+    def test_clear_silent_and_inert_without_prawduct_dir(self, tmp_path):
+        # A real codebase (has source) that never onboarded: no .prawduct/. Before
+        # the fix this printed the project-preferences CRITICAL (gated on code).
+        (tmp_path / "app.py").write_text("print('hi')\n")
+        result = run_plugin_hook("clear", tmp_path, git_status=" M app.py")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "", (
+            f"clear hook leaked into a non-Prawduct repo: {result.stdout!r}"
+        )
+        # The loud pre-fix leak specifically: the code-gated prefs CRITICAL.
+        assert "project-preferences.md" not in result.stdout
+        # Wrote nothing — no .prawduct/ scaffolded, no session markers.
+        assert not (tmp_path / ".prawduct").exists()
+
+
 class TestPluginStopGate:
     def _active_plan_repo(self, tmp_path) -> Path:
         prawduct = tmp_path / ".prawduct"


### PR DESCRIPTION
## Problem

Prawduct installs as a **user-scoped** plugin, so its SessionStart hooks fire in *every* repo the user opens. Two of them leaked governance into repos that never onboarded:

- `hooks/digest.py` injected the full governance digest unconditionally (the "This repo is governed by Prawduct…" block).
- `bin/prawduct-hook` `cmd_clear` printed a `CRITICAL: You MUST create .prawduct/artifacts/project-preferences.md` in any repo that has source code.

The design intent was already "be silent where not onboarded" — `hooks/banner.py` (line 207) and the Stop hook `cmd_stop` (line 2508) both early-return when there's no `.prawduct/`. These two SessionStart paths just didn't honor it.

## Fix

Gate both leaking paths on the same `.prawduct/` marker the banner and Stop hook already use:

- `hooks/digest.py` — new `in_prawduct_repo()` gate at the top of `main()`; emits nothing without `.prawduct/`.
- `bin/prawduct-hook` `cmd_clear` — early `return 0` when no `.prawduct/`; the four now-redundant inner `is_dir()` guards collapse into that one gate (de-indented to match `cmd_stop`'s flat style). Behavior-preserving for Prawduct repos.

**Scope note:** this silences the two *governance-injecting* SessionStart hooks. The third SessionStart hook — `banner.py`'s one-line identity banner (`═══ Prawduct vX (plugin) ═══`) — is intentionally retained as the always-on version-visibility safety net. Skills (`/prawduct:onboard`, etc.) also remain available everywhere; only the always-on context injection and session-marker side effects are gated.

## Tests

- `TestDigestRepoGate` — emits-in / silent-in / writes-nothing for the digest hook.
- `TestPluginClearNonPrawductRepo` — clear hook is silent and inert (no prefs CRITICAL, no `.prawduct/` scaffolding) in a non-onboarded repo with source code.
- `_run_digest` now sets `CLAUDE_PROJECT_DIR` explicitly so the gate is deterministic.
- Full suite: 835 passed, 1 skipped.

## Review

- Cumulative Critic: 0 blocking / 0 warning / 0 note.
- Independent PR review: 0 blocking / 0 warning / 1 note (the scope clarification above, now in this description).

Versioning (patch bump to v2.0.11) follows as a separate `chore(release)` commit per this repo's release pattern.