### PR TITLE
feat: add /prawduct:repo-disable to turn the plugin off per-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Anyone who clones the repo gets the same governance (the plugin auto-installs on
 open). Already onboarded? `/prawduct:doctor` health-checks the repo. Moving a pre-2.0 file-sync
 repo? `/prawduct:onboard` routes it to [`/prawduct:migrate`](documentation/MIGRATION.md).
 
+### Turn Prawduct off in a specific repo
+
+Because the plugin installs for your whole machine, its commands and hooks load in every repo you
+open. To switch it off in one repo — `/prawduct:*` commands, hooks, and banner — run
+**`/prawduct:repo-disable`**. It writes a per-repo `enabledPlugins` override (`committed` for the
+whole team, or `local` just for you), preserving your other settings; it takes effect after
+`/reload-plugins` or a restart. There's intentionally no re-enable command — once disabled, the
+plugin's own commands no longer load — so re-enable by editing the settings file's
+`enabledPlugins` back to `"prawduct@prawduct": true` (or via Claude Code's native `/plugin` menu).
+
 ## How Prawduct Works
 
 You describe what you want to build, either a net-new product or enhancements to an existing one. Prawduct scales governance to match the work:

--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -4678,6 +4678,68 @@ def cmd_audit_learnings(project_dir: Path, argv: list[str]) -> int:
     return 0
 
 
+def cmd_repo_disable(project_dir: Path, argv: list[str]) -> int:
+    """Disable the Prawduct plugin for the current repo (``/prawduct:repo-disable``).
+
+    Writes ``"enabledPlugins": {"prawduct@prawduct": false}`` into
+    ``.claude/settings.json`` (committed; default) or ``.claude/settings.local.json``
+    (``--local``; auto-gitignored), preserving every other setting. Dry-run by
+    default; ``--apply`` writes; ``--json`` emits the structured plan/result.
+
+    There is no enable counterpart: a disabled plugin's own skills do not load, so
+    re-enabling is a documented manual edit (set the value to ``true`` or delete the
+    key). Fail-safe: if the bundled lib/ cannot be imported, print a clear message
+    and return 1 rather than crashing.
+    """
+    local = "--local" in argv
+    apply = "--apply" in argv
+    as_json = "--json" in argv
+
+    lib_root = _plugin_root()
+    if lib_root not in sys.path:
+        sys.path.insert(0, lib_root)
+    try:
+        from lib.repo_toggle import set_repo_disabled  # noqa: PLC0415 — lazy keeps top-level cheap
+    except ImportError:
+        print(
+            "error: repo-disable could not import the plugin lib/ from "
+            "${CLAUDE_PLUGIN_ROOT}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    result = set_repo_disabled(project_dir, local=local, apply=apply)
+
+    if as_json:
+        print(json.dumps(result, indent=2))
+        return 1 if "error" in result else 0
+
+    if "error" in result:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+
+    target = result["target"]
+    if result["already_disabled"]:
+        print(f"Prawduct is already disabled for this repo in {target} — nothing to do.")
+        return 0
+
+    if not apply:
+        print(
+            f'DRY RUN: would set "enabledPlugins": {{"prawduct@prawduct": false}} in '
+            f"{target} (all other settings preserved). Re-run with --apply to write it."
+        )
+        return 0
+
+    print(
+        f'Disabled Prawduct for this repo: wrote "prawduct@prawduct": false to {target}.\n'
+        "  • Takes effect after you run /reload-plugins (this session) or restart Claude Code\n"
+        "    — until then Prawduct stays active.\n"
+        "  • Once disabled, the /prawduct:* commands won't load here. To RE-ENABLE later, edit\n"
+        f'    {target}: set "prawduct@prawduct": true (or remove the line), then /reload-plugins.'
+    )
+    return 0
+
+
 _USAGE = (
     "Usage: prawduct-hook "
     "{clear|stop|test-status|validate-evidence|test-evidence record [-- pytest args]|"
@@ -4688,7 +4750,7 @@ _USAGE = (
     "check-pr-doc-only|check-pr-trivial|regen-views|infer-critic-mode [args]|"
     "compute-verify-resolutions-scope|resolve-base|advisory <subcmd> [args]|"
     "migrate-plugin [--apply] [--json]|init-product <target> --name <name> [--apply] [--json]|"
-    "audit-learnings [--apply] [--json]}"
+    "audit-learnings [--apply] [--json]|repo-disable [--local] [--apply] [--json]}"
 )
 
 
@@ -4746,6 +4808,8 @@ def main() -> int:
         return cmd_init_product(sys.argv[2:])
     elif command == "audit-learnings":
         return cmd_audit_learnings(project_dir, sys.argv[2:])
+    elif command == "repo-disable":
+        return cmd_repo_disable(project_dir, sys.argv[2:])
     else:
         print(_USAGE, file=sys.stderr)
         return 1

--- a/lib/repo_toggle.py
+++ b/lib/repo_toggle.py
@@ -1,0 +1,120 @@
+"""Per-repo plugin enable/disable toggle — the writer behind ``/prawduct:repo-disable``.
+
+The Prawduct plugin installs at **user** scope, so its hooks and skills load in
+every repo the user opens. v2.0.11 made the SessionStart hooks silent in repos
+without a ``.prawduct/`` directory, but the ``/prawduct:*`` commands and the
+one-line version banner still appear everywhere. To turn Prawduct OFF entirely in
+a specific repo — commands included — a project-scope (or local-scope)
+``enabledPlugins`` override is the native lever (it beats the user-scope enable).
+
+This module writes that override the safe way:
+
+  * It merges ``"enabledPlugins": {"prawduct@prawduct": false}`` into the chosen
+    settings file, **preserving every other key** (permissions, env, hooks, other
+    plugins/marketplaces, and prawduct's own install reference under
+    ``extraKnownMarketplaces`` — left intact so re-enabling is a one-line edit).
+  * Unlike ``migrate_plugin.transform_settings`` (which runs in a migration where a
+    reset is acceptable), this **aborts** if the target file exists but is not
+    valid JSON, or is not a JSON object — it must never clobber a user's settings.
+  * It is idempotent: a file already pinning the plugin to ``false`` is a no-op.
+
+There is deliberately no enable counterpart here: once the plugin is disabled in a
+repo, its own skills do not load, so a ``/prawduct:repo-enable`` skill could never
+run there. Re-enabling is a documented manual edit (set the value back to ``true``
+or delete the key) — see ``skills/repo-disable/SKILL.md``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# The plugin identifier as it appears under ``enabledPlugins`` — ``<plugin>@<marketplace>``.
+# Matches ``migrate_plugin.INSTALL_REFERENCE``'s ``enabledPlugins`` key.
+PLUGIN_ID = "prawduct@prawduct"
+
+# Settings file per scope. Project = committed (team-wide); local = auto-gitignored
+# by Claude Code (just-me). Local wins over project wins over user in the settings
+# hierarchy, so either reliably overrides the user-scope enable.
+_SCOPE_FILES = {
+    "project": ".claude/settings.json",
+    "local": ".claude/settings.local.json",
+}
+
+
+def set_repo_disabled(
+    project_dir: str | Path, *, local: bool = False, apply: bool = False
+) -> dict:
+    """Plan or apply disabling the Prawduct plugin for ``project_dir``.
+
+    ``local=True`` targets ``.claude/settings.local.json`` (auto-gitignored, just
+    this user); otherwise ``.claude/settings.json`` (committed, whole team).
+    ``apply=False`` (default) computes the plan without writing.
+
+    Returns a summary dict. On an unreadable/malformed target it returns
+    ``{"error": ...}`` and writes nothing. Keys:
+
+      * ``scope`` / ``target`` — chosen scope and its repo-relative file
+      * ``file_existed`` — whether the settings file was already present
+      * ``previous_value`` — prior ``enabledPlugins["prawduct@prawduct"]``
+        (``True`` / ``False`` / ``None`` if unset)
+      * ``already_disabled`` — prior value was already ``False`` (no-op)
+      * ``change_needed`` — the write would change state (the dry-run signal)
+      * ``applied`` — a write actually happened (only true when ``apply`` and
+        ``change_needed``)
+    """
+    scope = "local" if local else "project"
+    rel = _SCOPE_FILES[scope]
+    path = Path(project_dir) / rel
+    existed = path.is_file()
+
+    if existed:
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return {"scope": scope, "target": rel, "error": f"could not read {rel}: {exc}"}
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            # Never clobber a user's settings: a malformed file is a fix-it-first
+            # condition, not a reset-to-default one.
+            return {
+                "scope": scope,
+                "target": rel,
+                "error": f"{rel} is not valid JSON ({exc}); fix it manually, then retry",
+            }
+        if not isinstance(data, dict):
+            return {
+                "scope": scope,
+                "target": rel,
+                "error": f"{rel} is not a JSON object; refusing to overwrite",
+            }
+    else:
+        data = {}
+
+    enabled = data.get("enabledPlugins")
+    previous = enabled.get(PLUGIN_ID) if isinstance(enabled, dict) else None
+    already = previous is False
+
+    result = {
+        "scope": scope,
+        "target": rel,
+        "path": str(path),
+        "file_existed": existed,
+        "previous_value": previous,
+        "already_disabled": already,
+        "change_needed": not already,
+        "applied": False,
+    }
+
+    if already or not apply:
+        return result
+
+    if not isinstance(enabled, dict):
+        enabled = {}
+    enabled[PLUGIN_ID] = False
+    data["enabledPlugins"] = enabled
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    result["applied"] = True
+    return result

--- a/skills/repo-disable/SKILL.md
+++ b/skills/repo-disable/SKILL.md
@@ -1,0 +1,68 @@
+---
+description: Disable the Prawduct plugin for THIS repo — write a per-repo enabledPlugins override (committed for the whole team, or local just for you) that turns off the /prawduct:* commands, hooks, and banner here. Re-enabling is a manual file edit. Use when a repo shouldn't be governed by Prawduct.
+argument-hint: "[local|committed]"
+user-invocable: true
+disable-model-invocation: true
+allowed-tools: Bash(prawduct-hook repo-disable *), Read
+---
+
+You are turning Prawduct **off in the current repo only**. Prawduct installs at the
+**user** level, so its hooks and `/prawduct:*` commands load in every repo the user
+opens. A per-repo `enabledPlugins` override disables it just here — it beats the
+user-scope enable in Claude Code's settings hierarchy.
+
+(As of v2.0.11 the SessionStart hooks are already silent in a repo with no
+`.prawduct/`. This skill goes further: it removes the `/prawduct:*` commands and the
+version banner too, by disabling the plugin outright for this repo.)
+
+## Flow
+
+### 1. Pick the scope
+Two choices — confirm which the user wants (use the `local`/`committed` argument if
+given; otherwise ask):
+
+- **committed** → `.claude/settings.json` (git-committed). Disables Prawduct for
+  **everyone** who clones this repo. Use when "this repo isn't a Prawduct project."
+- **local** → `.claude/settings.local.json` (Claude Code auto-gitignores it).
+  Disables Prawduct **just for this user**, leaving any committed install reference
+  intact for teammates. Use when "I personally don't want it here."
+
+If the repo is onboarded (has `.prawduct/` and a committed install reference),
+flag that committed-scope disable turns governance off for the whole team —
+**local** is usually what's wanted there.
+
+### 2. Dry-run and confirm
+Show the plan without writing (add `--local` for local scope):
+
+```
+prawduct-hook repo-disable [--local]
+```
+
+Present the target file. Confirm with the user.
+
+### 3. Apply
+```
+prawduct-hook repo-disable [--local] --apply
+```
+
+The command preserves every other setting in the file (permissions, env, hooks,
+other plugins, and prawduct's own marketplace reference — left intact so re-enabling
+is a one-line edit). It aborts without writing if the file exists but isn't valid
+JSON.
+
+### 4. Tell the user what happens next — REQUIRED
+After applying, relay both of these clearly:
+
+- **It takes effect after `/reload-plugins` (this session) or a restart.** Until
+  then Prawduct stays active.
+- **There is no `/prawduct:repo-enable`** — once disabled, the `/prawduct:*`
+  commands (including this one) won't load in this repo, so nothing inside Prawduct
+  could turn it back on. **To re-enable later, edit the file by hand:**
+  1. Open the settings file you chose (`.claude/settings.json` or
+     `.claude/settings.local.json`).
+  2. Under `"enabledPlugins"`, set `"prawduct@prawduct": true` — or delete that
+     entry entirely (which falls back to the user-scope setting).
+  3. Run `/reload-plugins`, or restart Claude Code.
+
+  (Alternatively, Claude Code's native `/plugin` menu can re-enable it from the
+  Installed tab.)

--- a/tests/test_repo_disable.py
+++ b/tests/test_repo_disable.py
@@ -1,0 +1,192 @@
+"""Tests for /prawduct:repo-disable — the per-repo plugin-disable toggle.
+
+Two surfaces:
+  * `lib.repo_toggle.set_repo_disabled` — the safe settings merge (preserve every
+    other key; abort, never clobber, on malformed JSON; idempotent).
+  * `prawduct-hook repo-disable` — the CLI the skill calls (dry-run/apply/json),
+    whose applied output MUST carry the take-effect-on-reload + manual-re-enable
+    guidance (there is no enable counterpart, so dropping it silently strands users).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HOOK = ROOT / "bin" / "prawduct-hook"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+from lib.repo_toggle import PLUGIN_ID, set_repo_disabled  # noqa: E402
+
+PROJECT_FILE = ".claude/settings.json"
+LOCAL_FILE = ".claude/settings.local.json"
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# =============================================================================
+# lib.repo_toggle.set_repo_disabled — the merge
+# =============================================================================
+
+
+class TestSetRepoDisabledFreshRepo:
+    def test_apply_creates_committed_settings(self, tmp_path):
+        result = set_repo_disabled(tmp_path, apply=True)
+        assert result["applied"] is True
+        assert result["scope"] == "project"
+        assert result["target"] == PROJECT_FILE
+        assert result["file_existed"] is False
+        assert result["previous_value"] is None
+        data = _read(tmp_path / PROJECT_FILE)
+        assert data == {"enabledPlugins": {PLUGIN_ID: False}}
+
+    def test_local_scope_targets_gitignored_file(self, tmp_path):
+        result = set_repo_disabled(tmp_path, local=True, apply=True)
+        assert result["scope"] == "local"
+        assert result["target"] == LOCAL_FILE
+        assert (tmp_path / LOCAL_FILE).is_file()
+        # The committed file is NOT created for a local-scope disable.
+        assert not (tmp_path / PROJECT_FILE).exists()
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        result = set_repo_disabled(tmp_path, apply=False)
+        assert result["applied"] is False
+        assert result["change_needed"] is True
+        assert not (tmp_path / PROJECT_FILE).exists(), "dry run must not write"
+
+
+class TestSetRepoDisabledPreservesSettings:
+    def _seed(self, tmp_path, payload: dict) -> Path:
+        path = tmp_path / PROJECT_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return path
+
+    def test_unrelated_keys_preserved(self, tmp_path):
+        self._seed(
+            tmp_path,
+            {
+                "permissions": {"allow": ["Bash(ls *)"]},
+                "env": {"FOO": "bar"},
+                "extraKnownMarketplaces": {"prawduct": {"source": "x"}},
+            },
+        )
+        set_repo_disabled(tmp_path, apply=True)
+        data = _read(tmp_path / PROJECT_FILE)
+        # Everything kept; only enabledPlugins added.
+        assert data["permissions"] == {"allow": ["Bash(ls *)"]}
+        assert data["env"] == {"FOO": "bar"}
+        assert data["extraKnownMarketplaces"] == {"prawduct": {"source": "x"}}
+        assert data["enabledPlugins"][PLUGIN_ID] is False
+
+    def test_flips_existing_true_and_keeps_sibling_plugins(self, tmp_path):
+        self._seed(
+            tmp_path,
+            {"enabledPlugins": {PLUGIN_ID: True, "other@mkt": True}},
+        )
+        result = set_repo_disabled(tmp_path, apply=True)
+        assert result["previous_value"] is True
+        data = _read(tmp_path / PROJECT_FILE)
+        assert data["enabledPlugins"][PLUGIN_ID] is False
+        assert data["enabledPlugins"]["other@mkt"] is True, "sibling plugin dropped"
+
+    def test_previous_value_none_when_no_enabled_plugins_key(self, tmp_path):
+        self._seed(tmp_path, {"env": {"A": "1"}})
+        result = set_repo_disabled(tmp_path, apply=False)
+        assert result["previous_value"] is None
+        assert result["change_needed"] is True
+
+
+class TestSetRepoDisabledIdempotent:
+    def test_already_false_is_noop(self, tmp_path):
+        path = tmp_path / PROJECT_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        original = json.dumps({"enabledPlugins": {PLUGIN_ID: False}}, indent=2) + "\n"
+        path.write_text(original, encoding="utf-8")
+        result = set_repo_disabled(tmp_path, apply=True)
+        assert result["already_disabled"] is True
+        assert result["change_needed"] is False
+        assert result["applied"] is False
+        assert path.read_text(encoding="utf-8") == original, "no-op must not rewrite the file"
+
+
+class TestSetRepoDisabledNeverClobbers:
+    def test_malformed_json_aborts_without_writing(self, tmp_path):
+        path = tmp_path / PROJECT_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ this is not json", encoding="utf-8")
+        result = set_repo_disabled(tmp_path, apply=True)
+        assert "error" in result
+        assert result.get("applied") is not True, "an abort must not report a write"
+        assert path.read_text(encoding="utf-8") == "{ this is not json", "must not overwrite"
+
+    def test_non_object_json_aborts(self, tmp_path):
+        path = tmp_path / PROJECT_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        result = set_repo_disabled(tmp_path, apply=True)
+        assert "error" in result
+        assert path.read_text(encoding="utf-8") == "[1, 2, 3]"
+
+
+# =============================================================================
+# prawduct-hook repo-disable — the CLI the skill calls
+# =============================================================================
+
+
+def _run(project_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    home = project_dir.parent / "_home"
+    home.mkdir(exist_ok=True)
+    env = {
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(project_dir),
+        "CLAUDE_PLUGIN_ROOT": str(ROOT),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    return subprocess.run(
+        ["python3", str(HOOK), "repo-disable", *args],
+        capture_output=True, text=True, env=env, timeout=20,
+    )
+
+
+class TestRepoDisableCli:
+    def test_dry_run_json_plan(self, tmp_path):
+        r = _run(tmp_path, "--json")
+        assert r.returncode == 0, r.stderr
+        plan = json.loads(r.stdout)
+        assert plan["scope"] == "project"
+        assert plan["change_needed"] is True
+        assert plan["applied"] is False
+        assert not (tmp_path / PROJECT_FILE).exists()
+
+    def test_apply_writes_and_emits_reenable_guidance(self, tmp_path):
+        r = _run(tmp_path, "--apply")
+        assert r.returncode == 0, r.stderr
+        assert _read(tmp_path / PROJECT_FILE)["enabledPlugins"][PLUGIN_ID] is False
+        # The applied output must carry the load-bearing guidance — there is no
+        # /prawduct:repo-enable, so this text is the user's only re-enable path.
+        out = r.stdout
+        assert "/reload-plugins" in out
+        assert "true" in out and PLUGIN_ID in out, "must show how to re-enable"
+        assert PROJECT_FILE in out
+
+    def test_apply_local_scope(self, tmp_path):
+        r = _run(tmp_path, "--local", "--apply")
+        assert r.returncode == 0, r.stderr
+        assert (tmp_path / LOCAL_FILE).is_file()
+        assert LOCAL_FILE in r.stdout
+
+    def test_malformed_settings_exits_nonzero(self, tmp_path):
+        path = tmp_path / PROJECT_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ broken", encoding="utf-8")
+        r = _run(tmp_path, "--apply")
+        assert r.returncode == 1
+        assert path.read_text(encoding="utf-8") == "{ broken"


### PR DESCRIPTION
## What & why

The plugin installs at **user** scope, so its commands, hooks, and banner load in every repo. v2.0.11 silenced the SessionStart *hooks* in non-onboarded repos; this adds a clean way to disable the plugin **outright** in a chosen repo — `/prawduct:*` commands included.

`/prawduct:repo-disable` writes `"enabledPlugins": {"prawduct@prawduct": false}` into:
- `.claude/settings.json` (**committed** — whole team), or
- `.claude/settings.local.json` (**`--local`** — auto-gitignored, just you)

…preserving every other setting. There is deliberately **no `repo-enable`**: a disabled plugin's own skills don't load, so such a skill could never run where it's needed — re-enabling is a documented manual file edit (set the value back to `true`, then `/reload-plugins`).

## Changes
- `lib/repo_toggle.py` (new) — `set_repo_disabled()`: idempotent shallow-merge that preserves all keys (incl. `extraKnownMarketplaces`, sibling plugins) and **aborts without writing on malformed/non-object JSON** (never clobbers user settings — unlike `migrate`'s `transform_settings`, which resets in a context where that's acceptable).
- `bin/prawduct-hook` — `cmd_repo_disable` (dry-run default · `--apply` · `--local` · `--json`); applied output carries the `/reload-plugins`-or-restart caveat and manual re-enable steps.
- `skills/repo-disable/SKILL.md` (new) — manual-only skill; frames committed-vs-local scope, relays the re-enable path.
- `tests/test_repo_disable.py` (new) — 13 tests: merge preservation, idempotency, never-clobber, scope routing, CLI guidance.
- `README.md` — "Turn Prawduct off in a specific repo".

## Review
- Cumulative Critic: **0 blocking / 0 warning / 1 note** (note = release-prep owed, handled as a separate `chore(release)` commit).
- Independent PR review: **0 blocking / 0 warning / 0 note** (reviewer ran the CLI against a malformed settings file to confirm non-clobber).
- Full suite: **849 passed**, 1 skipped.

Version bump (patch → v2.0.12) follows as a separate `chore(release)` commit per this repo's release pattern.