### PR TITLE
refactor: extract lib/buildplan_refs from hook (STH-9V4K ch.3)

### DIFF
--- a/.prawduct/artifacts/build-plan-hook-decomposition.md
+++ b/.prawduct/artifacts/build-plan-hook-decomposition.md
@@ -89,15 +89,18 @@ each PR merges via `/prawduct:pr` + regen-views.*
 - [ ] Chunk 6: Extract `lib/gates.py` — stop-gate logic + test-evidence commands. **Critic mode:** chunk
 - [ ] Chunk 7: Extract `lib/briefing.py` — staleness + session/subagent briefing + handoff. **Critic mode:** final
 
-Context: Chunks 1-2 built + committed + Critic-clean (0 findings each), stacked off develop:
-`refactor/hook-decomp-lib-init` (b28cd57, ch.1 __init__ slim) → `refactor/hook-decomp-gitstate`
-(57351e2, ch.2 gitstate). Each is its own PR (one module per PR) — PR ch.1 → develop, rebase ch.2,
-PR it, then continue. Not yet PR'd (built autonomously). Full suite 884 green; both hot paths
-(clear/stop) smoke-clean. **Next: Chunk 3 (buildplan_refs)** off the gitstate branch — extract the
-chunk-ref/trivial-classification cluster AND reassign `_parse_build_plan_status` out of the briefing
-region (the cycle-break); repoint `test_build_plan_resolution.py` + `test_trivial_fileset_gate.py`.
-The proven pattern: write `lib/<mod>.py` (verbatim move) → add/extend the lazy accessor → rewire
-resident call sites → repoint coupled tests → full suite + CLI smoke → `/prawduct:critic chunk`.
+Context: Chunks 1-3 built + Critic-clean (0 findings each). Ch.1-2 merged to develop via #74; ch.3
+(`lib/buildplan_refs.py`) committed on `refactor/hook-decomp-buildplan-refs` off develop — extracted
+the chunk-ref/Type/Trivial parsers + `_classify_trivial_change` AND reassigned `_parse_build_plan_status`
+out of the briefing region (the cycle-break done). Hook now 4,226 lines (was 4,942 at plan start).
+Full suite 884 green; `verify-chunk-refs`/`clear`/`stop` smoke-clean via the real CLI. Not yet PR'd
+(built autonomously). Checkboxes stay `[ ]` until release (status=shipped); develop-merge is tracked
+by the change-log entry per ch.1/ch.2 convention. **Next: Chunk 4 (`lib/compliance.py`)** off develop
+— compliance canary + `_check_broad_exceptions`/`_check_invalid_waivers`/`_waivers_module` + the file
+classifiers (`_is_source_file`/`_is_test_file`/`_is_dependency_file`); imports `gitstate`; repoint
+`test_waivers.py`. The proven pattern: write `lib/<mod>.py` (verbatim move, AST-verify identical) →
+add the lazy accessor → rewire resident call sites → repoint coupled tests → full suite + CLI smoke
+→ `/prawduct:critic chunk`. Enabled follow-up filed: STH-2K8R (critic_mode mirror consolidation).
 
 ## Chunk detail
 

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -8,6 +8,22 @@
 ## Open
 
 
+- **[STH-2K8R]** `lib/critic_mode` could consume `lib/buildplan_refs` directly instead of mirroring its build-plan helpers
+  `effort: S · impact: S · area: refactor · source: builder · added: 2026-06-07 · status: open · related: STH-9V4K`
+
+  `lib/critic_mode.py` carries independent re-implementations of `_current_chunk_id_from_status`,
+  the chunk-`Type:` parser, and `_is_metadata_path` (and references `_parse_build_plan_status`),
+  whose stated rationale is "no dependency on `bin/prawduct-hook` — re-implemented to stay importable
+  from the slash-command shim" (critic_mode.py docstring ~L46). STH-9V4K ch.2–3 moved those helpers
+  into `lib/gitstate` + `lib/buildplan_refs`, which `critic_mode` *already* imports siblings from
+  (`from .core import resolve_build_plan_path`). So the mirror's reason-to-exist is now gone:
+  `critic_mode` could `from .buildplan_refs import _current_chunk_id_from_status` (etc.) and
+  `from .gitstate import _is_metadata_path`, deleting the duplicate bodies + their manual-sync
+  docstrings. Defer until the decomposition (ch.4–7) lands so the lib surface is stable. NOT a
+  behavior-preserving move (it changes critic_mode's structure + collapses a parity relationship),
+  so it needs its own tests + Critic pass — kept out of ch.3 for scope discipline. Filed from the
+  ch.3 buildplan_refs extraction on 2026-06-07. (builder)
+
 - **[ADR-7X2M]** Adversarial review agent (4th review-agent role) — RFC: systematic edge-case / attack-surface generation
   `effort: L · impact: M · area: methodology · source: user · added: 2026-06-06 · status: open · related: CRT-9V4T, PRR-4M9T, JAN-4F7M`
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,41 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-06-07: extract lib/buildplan_refs.py — build-plan ref parsing + trivial classification (STH-9V4K ch.3)
+
+<!-- prawduct: chunks=3 | type=refactor | scope=hook-decomp -->
+
+**Why:** Chunk 3 of the hook decomposition (STH-9V4K). The build-plan-parsing cluster (chunk-ref /
+`Type:` / `Trivial because:` parsers + the `Type: trivial` file-set classifier) is the next layer up
+from the ch.2 `gitstate` leaf. Moving it out also performs the **cycle-break** the plan's dependency
+analysis identified (constraint 2): `_parse_build_plan_status` was mis-homed in the briefing cluster
+(it is build-plan parsing, not briefing assembly); reassigning it here turns the six concern clusters
+into an acyclic DAG (`gitstate ← buildplan_refs ← coverage ← gates ← briefing`).
+
+**What:** New `lib/buildplan_refs.py` (524 lines) holds 8 functions + 6 constants moved **verbatim**:
+`_parse_build_plan_status`, `_looks_like_file_path`, `_parse_build_plan_chunk_refs`,
+`_parse_build_plan_chunk_type`, `_parse_build_plan_chunk_trivial_rationale`, `_classify_trivial_change`,
+`_current_chunk_id_from_status`, `_verify_chunk_refs`; constants `_BUILD_PLAN_PATH_RE` /
+`_BUILD_PLAN_NEW_QUALIFIER_RE` / `_BUILD_PLAN_TYPE_RE` / `_BUILD_PLAN_ALLOWED_TYPES` /
+`_BUILD_PLAN_TRIVIAL_RATIONALE_RE` / `_TRIVIAL_PROTECTED_PATHS`. Two sanctioned internal rewrites: the
+module reaches the canonical resolver via `from .core import resolve_build_plan_path` (the established
+lib idiom — `critic_mode`/`views` do the same; avoids a third copy of the hook's parity-pinned inline
+mirror, which stays in the hook for its import-light hot path) and `_is_metadata_path` via
+`from . import gitstate`. The hook gains a lazy `_buildplan_refs()` accessor (mirrors `_gitstate()`)
+and rewires its 11 resident call sites; its top level stays lib-free (ch.1 isolation invariant
+preserved). `_count_build_plan_chunks` / `_pr_diff_is_trivial` / `_is_trivial_fileset_eligible` /
+`cmd_verify_chunk_refs` stay in the hook (Chunk 5–6 work) and now delegate via the accessor.
+
+**Tests:** `test_build_plan_resolution.py` (`_parse_build_plan_chunk_refs`, `_verify_chunk_refs`) and
+`test_trivial_fileset_gate.py` (`_classify_trivial_change`, `_TRIVIAL_PROTECTED_PATHS`) repointed to
+`from lib import buildplan_refs` — tested where the code now lives, assertions unchanged. One stale
+doc pointer fixed (the chunk-heading-rule location in `test_build_plan_resolution.py`). Full suite 884
+passed (count unchanged — behavior-preserving); `verify-chunk-refs`/`clear`/`stop` smoke-clean via the
+real CLI (the stop `trivial-declaration` gate fired end-to-end). Critic (chunk): 0 findings —
+AST-verified all 8 moved bodies byte-identical to HEAD + 6 constants value-identical. Hook: −464 lines
+net (4,690 → 4,226). Enabled follow-up STH-2K8R filed (critic_mode could now consume buildplan_refs
+instead of mirroring it).
+
 ## 2026-06-07: extract lib/gitstate.py — read-only git/state probes (STH-9V4K ch.2)
 
 <!-- prawduct: chunks=2 | type=refactor | scope=hook-decomp -->

--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -75,6 +75,19 @@ def _gitstate():
     return gitstate
 
 
+def _buildplan_refs():
+    """Lazy-import the build-plan reference parser + trivial-change classifier
+    (lib/buildplan_refs). Same lazy idiom as _gitstate() — seeds sys.path so the
+    hook's top level stays lib-free; after the ch.1 __init__ slim this loads only
+    buildplan_refs.py (+ its light siblings gitstate, core), isolated."""
+    lib_root = _plugin_root()
+    if lib_root not in sys.path:
+        sys.path.insert(0, lib_root)
+    from lib import buildplan_refs  # noqa: PLC0415 — lazy keeps top-level cheap + lib-free
+
+    return buildplan_refs
+
+
 # --- New-gate attribution (design §5a) -----------------------------------
 # A blocking message names the version + gate that caused it, so a surprise
 # block (e.g. a gate a recent plugin update introduced) is always traceable to
@@ -558,7 +571,7 @@ def staleness_scan(project_dir: Path) -> list[str]:
     build_plan_label = f".prawduct/{build_plan_path.relative_to(prawduct_dir).as_posix()}"
     if build_plan_path.is_file():
         try:
-            status = _parse_build_plan_status(prawduct_dir)
+            status = _buildplan_refs()._parse_build_plan_status(prawduct_dir)
             if status.get("current_chunk"):
                 pass  # Active work — not stale
             elif status.get("_has_status_items"):
@@ -768,85 +781,10 @@ def _parse_all_wip_branches(prawduct_dir: Path) -> dict[str, dict[str, str]]:
         return {}
 
 
-def _parse_build_plan_status(prawduct_dir: Path) -> dict[str, str]:
-    """Parse work context from build-plan.md Status section.
-
-    Returns dict with keys matching _parse_wip output:
-    description, size, type, current_chunk, context, governance_level.
-    Returns empty dict if no build plan or no Status section.
-    """
-    plan_path = _resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        return {}
-    try:
-        content = plan_path.read_text()
-        result: dict[str, str] = {}
-
-        # Extract title from header: "# Build Plan — Title (date)"
-        for line in content.splitlines():
-            if line.startswith("# Build Plan"):
-                title = line.lstrip("# ").removeprefix("Build Plan").strip()
-                if title.startswith("—") or title.startswith("-"):
-                    title = title.lstrip("—- ").strip()
-                # Remove trailing date in parens
-                if title.endswith(")") and "(" in title:
-                    title = title[:title.rfind("(")].strip()
-                if title:
-                    result["description"] = title
-                break
-
-        # Extract Size and Type from metadata line: **Size**: X | **Type**: Y
-        for line in content.splitlines():
-            if "**Size**:" in line:
-                for segment in line.split("|"):
-                    segment = segment.strip()
-                    if segment.startswith("**Size**:"):
-                        result["size"] = segment.removeprefix("**Size**:").strip()
-                    elif segment.startswith("**Type**:"):
-                        result["type"] = segment.removeprefix("**Type**:").strip()
-                    elif segment.startswith("**Governance**:"):
-                        result["governance_level"] = segment.removeprefix("**Governance**:").strip()
-                break
-
-        # Parse Status section for current chunk and context
-        in_status = False
-        in_comment = False
-        has_any_items = False
-        for line in content.splitlines():
-            stripped = line.strip()
-            if stripped == "## Status":
-                in_status = True
-                continue
-            if not in_status:
-                continue
-            # Exit on next section
-            if stripped.startswith("## ") and stripped != "## Status":
-                break
-            # Track HTML comments (multi-line)
-            if "<!--" in stripped:
-                in_comment = True
-            if "-->" in stripped:
-                in_comment = False
-                continue
-            if in_comment:
-                continue
-            # Current chunk = first unchecked item
-            if stripped.startswith("- [ ]") and "current_chunk" not in result:
-                has_any_items = True
-                result["current_chunk"] = stripped[5:].strip()
-            elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
-                has_any_items = True
-            # Context line
-            if stripped.startswith("Context:"):
-                result["context"] = stripped.removeprefix("Context:").strip()
-
-        # Mark whether Status section had items (for staleness detection)
-        if has_any_items:
-            result["_has_status_items"] = "true"
-
-        return result
-    except Exception:  # prawduct:allow prawduct/broad-except -- build plan parsing is best-effort
-        return {}
+# _parse_build_plan_status moved to lib/buildplan_refs.py (STH-9V4K ch.3) —
+# reassigned out of the briefing cluster (it is build-plan parsing, not briefing
+# assembly), which makes the hook's concern clusters an acyclic DAG. The hook's
+# briefing/gate callers reach it via _buildplan_refs()._parse_build_plan_status().
 
 
 def _has_active_build_plan_file(prawduct_dir: Path) -> bool:
@@ -855,13 +793,13 @@ def _has_active_build_plan_file(prawduct_dir: Path) -> bool:
     A completed plan (all [x]) or a missing file both return False — only an
     in-progress plan with remaining work triggers governance gates.
     """
-    status = _parse_build_plan_status(prawduct_dir)
+    status = _buildplan_refs()._parse_build_plan_status(prawduct_dir)
     return bool(status.get("current_chunk"))
 
 
 def _get_active_work(prawduct_dir: Path) -> dict[str, str]:
     """Get active work context, preferring build plan Status over project-state.yaml WIP."""
-    work = _parse_build_plan_status(prawduct_dir)
+    work = _buildplan_refs()._parse_build_plan_status(prawduct_dir)
     if work.get("description"):
         return work
     return _parse_wip(prawduct_dir)
@@ -2385,9 +2323,9 @@ def cmd_stop(project_dir: Path) -> int:
     # trivial-declaration contract is independent.
     trivial_block_reason = ""
     if has_changes and has_build_plan:
-        current_chunk_id = _current_chunk_id_from_status(prawduct_dir)
+        current_chunk_id = _buildplan_refs()._current_chunk_id_from_status(prawduct_dir)
         if current_chunk_id is not None:
-            chunk_type, type_error = _parse_build_plan_chunk_type(prawduct_dir, current_chunk_id)
+            chunk_type, type_error = _buildplan_refs()._parse_build_plan_chunk_type(prawduct_dir, current_chunk_id)
             # v1.5.1 Chunk 04(a): surface typo'd Type values. Pre-fix, the
             # parser's "unknown type: ..." message was discarded so the author
             # never saw it. Surfacing in waiver_notes makes the typo visible
@@ -2408,7 +2346,7 @@ def cmd_stop(project_dir: Path) -> int:
                 if not fileset_ok:
                     trivial_block_reason = fileset_reason
                 else:
-                    _, rationale_error = _parse_build_plan_chunk_trivial_rationale(
+                    _, rationale_error = _buildplan_refs()._parse_build_plan_chunk_trivial_rationale(
                         prawduct_dir, current_chunk_id
                     )
                     if rationale_error:
@@ -2833,382 +2771,12 @@ def cmd_test_evidence(project_dir: Path, argv: list[str]) -> int:
 # =============================================================================
 
 
-_BUILD_PLAN_PATH_RE = re.compile(r"`([^`\s]+)`")
-_BUILD_PLAN_NEW_QUALIFIER_RE = re.compile(r"\bnew\s+`([^`\s]+)`")
-# Per-chunk Type declaration (v1.4 F6 — proportional Critic via chunk type).
-# Matches `- **Type:** <token>` or `**Type:** <token>` as a list item; trailing
-# parenthetical prose is allowed and ignored.
-_BUILD_PLAN_TYPE_RE = re.compile(r"^[\s\-\*]*\*\*Type:\*\*\s*([A-Za-z][\w\-]*)")
-# v1.5 Chunk 04 — `trivial` joins the allowed set. File-set bounds (no
-# edits under skills/, methodology/, templates/; no CLAUDE.md edit; no
-# test deletion; no new files) + required `**Trivial because:**`
-# rationale are enforced structurally; semantic-fit is Critic Goal 3 in
-# Chunk 05. Size is unbounded — trivial is a semantic claim, not a LOC
-# metric.
-_BUILD_PLAN_ALLOWED_TYPES = frozenset(
-    {"code", "doc-only", "cleanup", "designer-handoff", "cumulative-final", "trivial"}
-)
-# `**Trivial because:** <rationale>` — first line; continuation lines (no
-# list-item / heading prefix) are joined onto the rationale until the next
-# field. Empty after the colon → missing-rationale.
-_BUILD_PLAN_TRIVIAL_RATIONALE_RE = re.compile(
-    r"^[\s\-\*]*\*\*Trivial because:\*\*\s*(.*)$"
-)
-
-
-def _looks_like_file_path(token: str) -> bool:
-    """A backticked token is a precise file-path reference only when it
-    contains ``/`` — i.e. the chunk author wrote a specific relative path.
-    Bare filenames in prose (e.g. ``backlog.md``, ``SKILL.md``) are usually
-    conceptual references whose actual location varies, so they're not
-    verifiable in a useful way.
-
-    Slash-commands (``/prawduct:pr``, ``/prawduct:learnings``, ``/prawduct:critic``) also contain
-    ``/`` but are not file paths. Exclude tokens that start with ``/``,
-    have no further ``/``, and contain no ``.`` — that shape is a single
-    slash-command identifier, not a path.
-
-    Glob patterns written in prose (e.g. ``docs/requirements/*.md`` in a Tests
-    bullet) also contain ``/`` but name a *set*, not a literal file — a literal
-    source path never contains the shell-glob metacharacters ``*``, ``?``, or
-    ``[``, so a token carrying one is a glob to skip rather than a missing file
-    to flag (BLD-2R9X). Sibling of the ``path::symbol`` carveout the chunk-ref
-    parser applies before calling this."""
-    if "/" not in token:
-        return False
-    if token.startswith("/") and "/" not in token[1:] and "." not in token:
-        return False
-    if any(ch in token for ch in "*?["):
-        return False
-    return True
-
-
-def _parse_build_plan_chunk_refs(prawduct_dir: Path, chunk_id: str) -> dict:
-    """Extract backticked file-path references from a single chunk's section
-    in ``.prawduct/artifacts/build-plan.md``.
-
-    The section is located by name (``### Chunk <chunk_id>:`` prefix, leading
-    zeros tolerant), and parsing stops at the next ``### `` or ``## `` heading
-    — sibling chunks' refs are NOT returned. Fenced code blocks (```...```)
-    are skipped because project-structure diagrams aren't load-bearing prose.
-    Paths preceded by the word ``new`` on the same line are skipped as
-    intra-chunk forward references (files the chunk creates rather than
-    modifies).
-
-    Returns ``{"file_paths": [{"line_num": int, "ref": str}, ...],
-    "error": str | None}``. For a ``path::symbol`` token the stored ``ref`` is
-    the pre-``::`` path only (existence-checked), and the symbol is ignored —
-    symbol and backlog-ID verification remain deferred (BLD-5V8F).
-    """
-    result: dict = {"file_paths": [], "error": None}
-    plan_path = _resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        result["error"] = f"missing build-plan: {plan_path}"
-        return result
-    try:
-        content = plan_path.read_text()
-    except OSError as exc:
-        result["error"] = f"unreadable build-plan: {exc}"
-        return result
-
-    # Normalize chunk_id: strip leading zeros for matching ("02" matches
-    # "### Chunk 2:" and vice versa) but report the original in errors.
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    section_lines: list[tuple[int, str]] = []
-    for line_num, line in enumerate(content.splitlines(), start=1):
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            # Heading format: "### Chunk NN: Name"
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                # Entered a sibling chunk; stop accumulating.
-                break
-            if head_norm == target:
-                in_section = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            # Left the Build Chunks section entirely.
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        section_lines.append((line_num, line))
-
-    if not in_section and not section_lines:
-        result["error"] = f"chunk {chunk_id!r} not found in build-plan"
-        return result
-
-    seen: set[tuple[str, int]] = set()
-    for line_num, line in section_lines:
-        # Collect spans preceded by "new " — these get filtered out.
-        excluded_spans: list[tuple[int, int]] = [
-            m.span(1) for m in _BUILD_PLAN_NEW_QUALIFIER_RE.finditer(line)
-        ]
-        for match in _BUILD_PLAN_PATH_RE.finditer(line):
-            token = match.group(1)
-            # A `path::symbol` token (e.g. `lib/views.py::is_views_enabled`) is
-            # verified by its FILE path only — existence-check the pre-`::` part,
-            # not the whole token, so a valid file isn't reported missing
-            # (BLD-8F2Q). The symbol half stays deferred (BLD-5V8F).
-            path_part = token.split("::", 1)[0]
-            if not _looks_like_file_path(path_part):
-                continue
-            # The `new ` forward-ref exclusion keys on the token START offset,
-            # which a trailing `::symbol` does not move, so it still composes.
-            if any(start == match.start(1) for start, _ in excluded_spans):
-                continue
-            key = (path_part, line_num)
-            if key in seen:
-                continue
-            seen.add(key)
-            result["file_paths"].append({"line_num": line_num, "ref": path_part})
-    return result
-
-
-def _parse_build_plan_chunk_type(
-    prawduct_dir: Path, chunk_id: str
-) -> tuple[str | None, str | None]:
-    """Extract the `Type:` declaration from a chunk's build-plan section.
-
-    Returns ``(chunk_type, error)``. ``chunk_type`` is one of
-    ``code | doc-only | cleanup | designer-handoff | cumulative-final | trivial``.
-    Default (field absent) is ``code`` — fail-closed so a missing declaration
-    runs the full Critic protocol rather than silently triggering a carveout
-    (learnings: "escape hatches in classification create silent failures").
-    Unknown values surface as ``(None, "unknown type: <value>")`` so the
-    author fixes the typo instead of getting silent fall-through.
-
-    Section discovery mirrors ``_parse_build_plan_chunk_refs`` — name-anchored
-    on ``### Chunk <chunk_id>:`` with leading-zero tolerance; fenced code
-    blocks are skipped.
-    """
-    plan_path = _resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        return None, f"missing build-plan: {plan_path}"
-    try:
-        content = plan_path.read_text()
-    except OSError as exc:
-        return None, f"unreadable build-plan: {exc}"
-
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    section_found = False
-    declared: str | None = None
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                break  # hit sibling chunk
-            if head_norm == target:
-                in_section = True
-                section_found = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        m = _BUILD_PLAN_TYPE_RE.match(line)
-        if m:
-            declared = m.group(1)
-            break
-
-    if not section_found:
-        return None, f"chunk {chunk_id!r} not found in build-plan"
-
-    if declared is None:
-        return "code", None  # fail-closed default
-    if declared not in _BUILD_PLAN_ALLOWED_TYPES:
-        allowed = ", ".join(sorted(_BUILD_PLAN_ALLOWED_TYPES))
-        return None, f"unknown type: {declared!r} (allowed: {allowed})"
-    return declared, None
-
-
-def _parse_build_plan_chunk_trivial_rationale(
-    prawduct_dir: Path, chunk_id: str
-) -> tuple[str | None, str | None]:
-    """Extract the ``**Trivial because:**`` rationale from a chunk's section.
-
-    Returns ``(rationale, error)``. Empty or absent field → ``(None,
-    "missing-rationale: Type: trivial requires non-empty **Trivial
-    because:** field")``. Multi-line rationale (continuation lines without
-    a list-item / heading prefix) is joined into a single string until the
-    next field.
-
-    Section discovery mirrors ``_parse_build_plan_chunk_type`` —
-    name-anchored on ``### Chunk <chunk_id>:`` with leading-zero
-    tolerance; fenced code blocks are skipped.
-    """
-    plan_path = _resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        return None, f"missing build-plan: {plan_path}"
-    try:
-        content = plan_path.read_text()
-    except OSError as exc:
-        return None, f"unreadable build-plan: {exc}"
-
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    section_found = False
-    capturing = False
-    rationale_lines: list[str] = []
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                break  # hit sibling chunk
-            if head_norm == target:
-                in_section = True
-                section_found = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        m = _BUILD_PLAN_TRIVIAL_RATIONALE_RE.match(line)
-        if m:
-            capturing = True
-            first = m.group(1).strip()
-            if first:
-                rationale_lines.append(first)
-            continue
-        if capturing:
-            # Stop at the next list-item field, bolded label, or sub-heading.
-            if (
-                stripped.startswith("- **")
-                or stripped.startswith("* **")
-                or stripped.startswith("**")
-                or stripped.startswith("#")
-            ):
-                break
-            if stripped:
-                rationale_lines.append(stripped)
-
-    if not section_found:
-        return None, f"chunk {chunk_id!r} not found in build-plan"
-    if not capturing:
-        return None, (
-            "missing-rationale: Type: trivial requires non-empty "
-            "**Trivial because:** field"
-        )
-    rationale = " ".join(rationale_lines).strip()
-    if not rationale:
-        return None, (
-            "missing-rationale: Type: trivial requires non-empty "
-            "**Trivial because:** field"
-        )
-    return rationale, None
-
-
-# STH-1W5N — single source of truth for the unconditional ``Type: trivial`` /
-# doc-only protected-path bounds. Each entry is ``(path, is_exact, reason_label)``:
-# a change touching ``path`` (prefix match unless ``is_exact``) is a
-# catastrophic-blast-radius edit that a trivial/doc-only chunk may never make,
-# and the violation is reported as ``"<reason_label>: <path>"``. Centralized
-# here (was inline in ``_classify_trivial_change``) so the stop-hook gate and
-# the PR-boundary gate share one provably-identical list — and so the bound set
-# is testable as data. The conditional bounds (test-file removals, newly-tracked
-# files) stay in ``_classify_trivial_change`` because they depend on the change
-# verb, not just the path.
-#   skills/       — the critic/pr/etc. SKILL definitions + bundled protocols ARE
-#                   the governance; editing one changes the framework itself.
-#   methodology/  — the build/discovery/planning/reflection guides Claude reads
-#                   as operating instructions; a "trivial" rewrite is never trivial.
-#   templates/    — the artifact templates every product's specs are generated
-#                   from; a silent change propagates to all downstream output.
-#   CLAUDE.md     — the project's top-level operating contract (exact match —
-#                   a nested ``foo/CLAUDE.md`` is ordinary product doc).
-_TRIVIAL_PROTECTED_PATHS: frozenset[tuple[str, bool, str]] = frozenset({
-    ("skills/", False, "skill-file-edited"),
-    ("methodology/", False, "methodology-edited"),
-    ("templates/", False, "template-edited"),
-    ("CLAUDE.md", True, "claude-md-edited"),
-})
-
-
-def _classify_trivial_change(
-    *,
-    path: str,
-    src_path: str | None,
-    is_addition: bool,
-    is_deletion: bool,
-) -> str | None:
-    """Single-file path-rule check for the ``Type: trivial`` file-set
-    bounds. Returns the violation reason or ``None`` when the change
-    is eligible. Shared by ``_is_trivial_fileset_eligible`` (Chunk 04 —
-    working-tree porcelain) and ``_pr_diff_is_trivial`` (Chunk 05 —
-    per-commit name-status diff). Centralizing the rule set prevents
-    the stop-hook gate and the PR-boundary gate from drifting apart
-    silently.
-
-    The unconditional path bounds live in the module-level
-    ``_TRIVIAL_PROTECTED_PATHS`` constant (STH-1W5N — single source of
-    truth, referenced from this one call site). The conditional bounds
-    (test-file removals, newly-tracked files) stay inline below because
-    they depend on the change verb, not just the path.
-
-    Metadata paths (``.prawduct/``, ``.claude/settings.json``, etc. —
-    see ``_is_metadata_path``) are treated as out-of-scope and return
-    ``None``. The check applies to BOTH ``path`` (rename dst / single-
-    file change) AND ``src_path`` (rename src) — without that
-    symmetry, a rename FROM a metadata path that landed somewhere
-    interesting would silently be classified, and a rename TO a
-    metadata path would be classified differently depending on which
-    gate ran (the callers previously did dst-only filtering before
-    calling this helper — v1.5.1 Chunk 04(b) consolidates).
-
-    The caller translates its status format into the boolean inputs
-    (porcelain handles 2-char codes; name-status handles single-char).
-    Path bounds are catastrophic-blast-radius classes regardless of
-    size — size is intentionally not a bound.
-    """
-    if _gitstate()._is_metadata_path(path):
-        return None
-    if src_path is not None and _gitstate()._is_metadata_path(src_path):
-        return None
-    # Unconditional path bounds — driven by the _TRIVIAL_PROTECTED_PATHS
-    # constant so this gate and the PR-boundary gate share one list. The
-    # classes are mutually exclusive (a path matches at most one), so the
-    # frozenset's unordered iteration is behavior-preserving.
-    for protected, is_exact, reason_label in _TRIVIAL_PROTECTED_PATHS:
-        matched = path == protected if is_exact else path.startswith(protected)
-        if matched:
-            return f"{reason_label}: {path}"
-    if is_deletion and path.startswith("tests/"):
-        return f"test-file-deleted: {path}"
-    if src_path is not None and src_path.startswith("tests/"):
-        return f"test-file-deleted: {src_path} (renamed out)"
-    if is_addition:
-        return f"new-file: {path}"
-    return None
+# Build-plan reference parsing + trivial-change classification moved to
+# lib/buildplan_refs.py (STH-9V4K ch.3): the chunk-ref/Type/Trivial-rationale
+# parsers, _looks_like_file_path, _classify_trivial_change, and the
+# _TRIVIAL_PROTECTED_PATHS / _BUILD_PLAN_* constants. Resident callers below
+# (_is_trivial_fileset_eligible, _pr_diff_is_trivial, cmd_verify_chunk_refs, the
+# stop gate) reach them via _buildplan_refs().<fn>().
 
 
 def _is_trivial_fileset_eligible(project_dir: Path) -> tuple[bool, str]:
@@ -3284,7 +2852,7 @@ def _is_trivial_fileset_eligible(project_dir: Path) -> tuple[bool, str]:
         # and `_pr_diff_is_trivial`.
         is_addition = status[0] == "A" or status == "??"
         is_deletion = "D" in status
-        violation = _classify_trivial_change(
+        violation = _buildplan_refs()._classify_trivial_change(
             path=path,
             src_path=src_path,
             is_addition=is_addition,
@@ -3296,41 +2864,9 @@ def _is_trivial_fileset_eligible(project_dir: Path) -> tuple[bool, str]:
     return True, ""
 
 
-def _current_chunk_id_from_status(prawduct_dir: Path) -> str | None:
-    """Extract the chunk id of the first `- [ ]` item in the build-plan Status
-    section, e.g. ``"03"`` for ``- [ ] Chunk 03: Foo``. Returns ``None`` if
-    Status is missing, has no current chunk (all complete), or the chunk text
-    isn't in the expected ``Chunk NN:`` form.
-
-    Mirrors the resolution logic in ``cmd_verify_chunk_refs`` so the stop
-    hook and the Critic helper agree on "which chunk is current."
-    """
-    status = _parse_build_plan_status(prawduct_dir)
-    current = status.get("current_chunk", "")
-    if not current.startswith("Chunk "):
-        return None
-    rest = current[len("Chunk "):]
-    chunk_id = rest.split(":", 1)[0].strip()
-    return chunk_id or None
-
-
-def _verify_chunk_refs(project_dir: Path, refs: dict) -> list[dict]:
-    """Verify each file-path ref exists relative to ``project_dir``.
-    Returns a list of ``{"kind", "ref", "line_num", "reason"}`` for missing
-    entries. Empty list = all refs resolved.
-    """
-    missing: list[dict] = []
-    for entry in refs.get("file_paths", []):
-        ref = entry["ref"]
-        target = project_dir / ref
-        if not target.exists():
-            missing.append({
-                "kind": "file_path",
-                "ref": ref,
-                "line_num": entry["line_num"],
-                "reason": "file does not exist",
-            })
-    return missing
+# _current_chunk_id_from_status + _verify_chunk_refs moved to
+# lib/buildplan_refs.py (STH-9V4K ch.3); cmd_verify_chunk_refs below delegates
+# via _buildplan_refs().
 
 
 def cmd_verify_chunk_refs(project_dir: Path, chunk_id: str | None) -> int:
@@ -3349,7 +2885,7 @@ def cmd_verify_chunk_refs(project_dir: Path, chunk_id: str | None) -> int:
     if chunk_id is None:
         chunk_id = os.environ.get("PRAWDUCT_VERIFY_CHUNK_ID")
     if chunk_id is None:
-        status = _parse_build_plan_status(prawduct_dir)
+        status = _buildplan_refs()._parse_build_plan_status(prawduct_dir)
         current = status.get("current_chunk", "")
         # current is e.g. "Chunk 02: F3 — …"
         if not current.startswith("Chunk "):
@@ -3358,11 +2894,11 @@ def cmd_verify_chunk_refs(project_dir: Path, chunk_id: str | None) -> int:
         rest = current[len("Chunk "):]
         chunk_id = rest.split(":", 1)[0].strip()
 
-    refs = _parse_build_plan_chunk_refs(prawduct_dir, chunk_id)
+    refs = _buildplan_refs()._parse_build_plan_chunk_refs(prawduct_dir, chunk_id)
     if refs["error"]:
         print(f"error: {refs['error']}", file=sys.stderr)
         return 1
-    missing = _verify_chunk_refs(project_dir, refs)
+    missing = _buildplan_refs()._verify_chunk_refs(project_dir, refs)
     if missing:
         for m in missing:
             print(
@@ -4135,7 +3671,7 @@ def _pr_diff_is_trivial(project_dir: Path) -> tuple[bool, str]:
         # stop-hook gate in `_is_trivial_fileset_eligible`.
         is_addition = status == "A"
         is_deletion = status == "D"
-        violation = _classify_trivial_change(
+        violation = _buildplan_refs()._classify_trivial_change(
             path=path,
             src_path=src_path,
             is_addition=is_addition,

--- a/lib/buildplan_refs.py
+++ b/lib/buildplan_refs.py
@@ -1,0 +1,524 @@
+"""Build-plan reference parsing + trivial-change classification for the runtime.
+
+Extracted from ``bin/prawduct-hook`` (STH-9V4K, Chunk 3) — the build-plan
+parsing cluster: it reads the active build plan's Status section and per-chunk
+sections (file-path refs, ``Type:`` declaration, ``Trivial because:`` rationale)
+and classifies a single file change against the ``Type: trivial`` / doc-only
+file-set bounds. Pure parsing + path inspection — no git mutation, no network.
+
+Depends only on its lib siblings ``gitstate`` (for ``_is_metadata_path``) and
+``core`` (for ``resolve_build_plan_path``) plus the stdlib — a clean DAG node
+(``gitstate`` ← ``buildplan_refs``). The hook's inline build-plan-resolution
+mirror (``_resolve_build_plan_path``) stays in the hook for its import-light hot
+path; this module is a lib citizen and reaches the canonical resolver in
+``lib.core`` directly, exactly as ``critic_mode`` and ``views`` do.
+
+``_parse_build_plan_status`` was reassigned here from the briefing cluster (it is
+build-plan parsing, not briefing assembly) — that reassignment turns the hook's
+concern clusters into an acyclic dependency graph (STH-9V4K constraint 2). The
+hook calls these lazily via ``_buildplan_refs()``, keeping its top level lib-free.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import gitstate
+from .core import resolve_build_plan_path
+
+
+def _parse_build_plan_status(prawduct_dir: Path) -> dict[str, str]:
+    """Parse work context from build-plan.md Status section.
+
+    Returns dict with keys matching _parse_wip output:
+    description, size, type, current_chunk, context, governance_level.
+    Returns empty dict if no build plan or no Status section.
+    """
+    plan_path = resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return {}
+    try:
+        content = plan_path.read_text()
+        result: dict[str, str] = {}
+
+        # Extract title from header: "# Build Plan — Title (date)"
+        for line in content.splitlines():
+            if line.startswith("# Build Plan"):
+                title = line.lstrip("# ").removeprefix("Build Plan").strip()
+                if title.startswith("—") or title.startswith("-"):
+                    title = title.lstrip("—- ").strip()
+                # Remove trailing date in parens
+                if title.endswith(")") and "(" in title:
+                    title = title[:title.rfind("(")].strip()
+                if title:
+                    result["description"] = title
+                break
+
+        # Extract Size and Type from metadata line: **Size**: X | **Type**: Y
+        for line in content.splitlines():
+            if "**Size**:" in line:
+                for segment in line.split("|"):
+                    segment = segment.strip()
+                    if segment.startswith("**Size**:"):
+                        result["size"] = segment.removeprefix("**Size**:").strip()
+                    elif segment.startswith("**Type**:"):
+                        result["type"] = segment.removeprefix("**Type**:").strip()
+                    elif segment.startswith("**Governance**:"):
+                        result["governance_level"] = segment.removeprefix("**Governance**:").strip()
+                break
+
+        # Parse Status section for current chunk and context
+        in_status = False
+        in_comment = False
+        has_any_items = False
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped == "## Status":
+                in_status = True
+                continue
+            if not in_status:
+                continue
+            # Exit on next section
+            if stripped.startswith("## ") and stripped != "## Status":
+                break
+            # Track HTML comments (multi-line)
+            if "<!--" in stripped:
+                in_comment = True
+            if "-->" in stripped:
+                in_comment = False
+                continue
+            if in_comment:
+                continue
+            # Current chunk = first unchecked item
+            if stripped.startswith("- [ ]") and "current_chunk" not in result:
+                has_any_items = True
+                result["current_chunk"] = stripped[5:].strip()
+            elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
+                has_any_items = True
+            # Context line
+            if stripped.startswith("Context:"):
+                result["context"] = stripped.removeprefix("Context:").strip()
+
+        # Mark whether Status section had items (for staleness detection)
+        if has_any_items:
+            result["_has_status_items"] = "true"
+
+        return result
+    except Exception:  # prawduct:allow prawduct/broad-except -- build plan parsing is best-effort
+        return {}
+
+
+_BUILD_PLAN_PATH_RE = re.compile(r"`([^`\s]+)`")
+_BUILD_PLAN_NEW_QUALIFIER_RE = re.compile(r"\bnew\s+`([^`\s]+)`")
+# Per-chunk Type declaration (v1.4 F6 — proportional Critic via chunk type).
+# Matches `- **Type:** <token>` or `**Type:** <token>` as a list item; trailing
+# parenthetical prose is allowed and ignored.
+_BUILD_PLAN_TYPE_RE = re.compile(r"^[\s\-\*]*\*\*Type:\*\*\s*([A-Za-z][\w\-]*)")
+# v1.5 Chunk 04 — `trivial` joins the allowed set. File-set bounds (no
+# edits under skills/, methodology/, templates/; no CLAUDE.md edit; no
+# test deletion; no new files) + required `**Trivial because:**`
+# rationale are enforced structurally; semantic-fit is Critic Goal 3 in
+# Chunk 05. Size is unbounded — trivial is a semantic claim, not a LOC
+# metric.
+_BUILD_PLAN_ALLOWED_TYPES = frozenset(
+    {"code", "doc-only", "cleanup", "designer-handoff", "cumulative-final", "trivial"}
+)
+# `**Trivial because:** <rationale>` — first line; continuation lines (no
+# list-item / heading prefix) are joined onto the rationale until the next
+# field. Empty after the colon → missing-rationale.
+_BUILD_PLAN_TRIVIAL_RATIONALE_RE = re.compile(
+    r"^[\s\-\*]*\*\*Trivial because:\*\*\s*(.*)$"
+)
+
+
+def _looks_like_file_path(token: str) -> bool:
+    """A backticked token is a precise file-path reference only when it
+    contains ``/`` — i.e. the chunk author wrote a specific relative path.
+    Bare filenames in prose (e.g. ``backlog.md``, ``SKILL.md``) are usually
+    conceptual references whose actual location varies, so they're not
+    verifiable in a useful way.
+
+    Slash-commands (``/prawduct:pr``, ``/prawduct:learnings``, ``/prawduct:critic``) also contain
+    ``/`` but are not file paths. Exclude tokens that start with ``/``,
+    have no further ``/``, and contain no ``.`` — that shape is a single
+    slash-command identifier, not a path.
+
+    Glob patterns written in prose (e.g. ``docs/requirements/*.md`` in a Tests
+    bullet) also contain ``/`` but name a *set*, not a literal file — a literal
+    source path never contains the shell-glob metacharacters ``*``, ``?``, or
+    ``[``, so a token carrying one is a glob to skip rather than a missing file
+    to flag (BLD-2R9X). Sibling of the ``path::symbol`` carveout the chunk-ref
+    parser applies before calling this."""
+    if "/" not in token:
+        return False
+    if token.startswith("/") and "/" not in token[1:] and "." not in token:
+        return False
+    if any(ch in token for ch in "*?["):
+        return False
+    return True
+
+
+def _parse_build_plan_chunk_refs(prawduct_dir: Path, chunk_id: str) -> dict:
+    """Extract backticked file-path references from a single chunk's section
+    in ``.prawduct/artifacts/build-plan.md``.
+
+    The section is located by name (``### Chunk <chunk_id>:`` prefix, leading
+    zeros tolerant), and parsing stops at the next ``### `` or ``## `` heading
+    — sibling chunks' refs are NOT returned. Fenced code blocks (```...```)
+    are skipped because project-structure diagrams aren't load-bearing prose.
+    Paths preceded by the word ``new`` on the same line are skipped as
+    intra-chunk forward references (files the chunk creates rather than
+    modifies).
+
+    Returns ``{"file_paths": [{"line_num": int, "ref": str}, ...],
+    "error": str | None}``. For a ``path::symbol`` token the stored ``ref`` is
+    the pre-``::`` path only (existence-checked), and the symbol is ignored —
+    symbol and backlog-ID verification remain deferred (BLD-5V8F).
+    """
+    result: dict = {"file_paths": [], "error": None}
+    plan_path = resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        result["error"] = f"missing build-plan: {plan_path}"
+        return result
+    try:
+        content = plan_path.read_text()
+    except OSError as exc:
+        result["error"] = f"unreadable build-plan: {exc}"
+        return result
+
+    # Normalize chunk_id: strip leading zeros for matching ("02" matches
+    # "### Chunk 2:" and vice versa) but report the original in errors.
+    target = chunk_id.lstrip("0") or "0"
+
+    in_section = False
+    in_fence = False
+    section_lines: list[tuple[int, str]] = []
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("### Chunk "):
+            # Heading format: "### Chunk NN: Name"
+            rest = stripped[len("### Chunk "):]
+            head = rest.split(":", 1)[0].strip()
+            head_norm = head.lstrip("0") or "0"
+            if in_section:
+                # Entered a sibling chunk; stop accumulating.
+                break
+            if head_norm == target:
+                in_section = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            # Left the Build Chunks section entirely.
+            break
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        section_lines.append((line_num, line))
+
+    if not in_section and not section_lines:
+        result["error"] = f"chunk {chunk_id!r} not found in build-plan"
+        return result
+
+    seen: set[tuple[str, int]] = set()
+    for line_num, line in section_lines:
+        # Collect spans preceded by "new " — these get filtered out.
+        excluded_spans: list[tuple[int, int]] = [
+            m.span(1) for m in _BUILD_PLAN_NEW_QUALIFIER_RE.finditer(line)
+        ]
+        for match in _BUILD_PLAN_PATH_RE.finditer(line):
+            token = match.group(1)
+            # A `path::symbol` token (e.g. `lib/views.py::is_views_enabled`) is
+            # verified by its FILE path only — existence-check the pre-`::` part,
+            # not the whole token, so a valid file isn't reported missing
+            # (BLD-8F2Q). The symbol half stays deferred (BLD-5V8F).
+            path_part = token.split("::", 1)[0]
+            if not _looks_like_file_path(path_part):
+                continue
+            # The `new ` forward-ref exclusion keys on the token START offset,
+            # which a trailing `::symbol` does not move, so it still composes.
+            if any(start == match.start(1) for start, _ in excluded_spans):
+                continue
+            key = (path_part, line_num)
+            if key in seen:
+                continue
+            seen.add(key)
+            result["file_paths"].append({"line_num": line_num, "ref": path_part})
+    return result
+
+
+def _parse_build_plan_chunk_type(
+    prawduct_dir: Path, chunk_id: str
+) -> tuple[str | None, str | None]:
+    """Extract the `Type:` declaration from a chunk's build-plan section.
+
+    Returns ``(chunk_type, error)``. ``chunk_type`` is one of
+    ``code | doc-only | cleanup | designer-handoff | cumulative-final | trivial``.
+    Default (field absent) is ``code`` — fail-closed so a missing declaration
+    runs the full Critic protocol rather than silently triggering a carveout
+    (learnings: "escape hatches in classification create silent failures").
+    Unknown values surface as ``(None, "unknown type: <value>")`` so the
+    author fixes the typo instead of getting silent fall-through.
+
+    Section discovery mirrors ``_parse_build_plan_chunk_refs`` — name-anchored
+    on ``### Chunk <chunk_id>:`` with leading-zero tolerance; fenced code
+    blocks are skipped.
+    """
+    plan_path = resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return None, f"missing build-plan: {plan_path}"
+    try:
+        content = plan_path.read_text()
+    except OSError as exc:
+        return None, f"unreadable build-plan: {exc}"
+
+    target = chunk_id.lstrip("0") or "0"
+
+    in_section = False
+    in_fence = False
+    section_found = False
+    declared: str | None = None
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("### Chunk "):
+            rest = stripped[len("### Chunk "):]
+            head = rest.split(":", 1)[0].strip()
+            head_norm = head.lstrip("0") or "0"
+            if in_section:
+                break  # hit sibling chunk
+            if head_norm == target:
+                in_section = True
+                section_found = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            break
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _BUILD_PLAN_TYPE_RE.match(line)
+        if m:
+            declared = m.group(1)
+            break
+
+    if not section_found:
+        return None, f"chunk {chunk_id!r} not found in build-plan"
+
+    if declared is None:
+        return "code", None  # fail-closed default
+    if declared not in _BUILD_PLAN_ALLOWED_TYPES:
+        allowed = ", ".join(sorted(_BUILD_PLAN_ALLOWED_TYPES))
+        return None, f"unknown type: {declared!r} (allowed: {allowed})"
+    return declared, None
+
+
+def _parse_build_plan_chunk_trivial_rationale(
+    prawduct_dir: Path, chunk_id: str
+) -> tuple[str | None, str | None]:
+    """Extract the ``**Trivial because:**`` rationale from a chunk's section.
+
+    Returns ``(rationale, error)``. Empty or absent field → ``(None,
+    "missing-rationale: Type: trivial requires non-empty **Trivial
+    because:** field")``. Multi-line rationale (continuation lines without
+    a list-item / heading prefix) is joined into a single string until the
+    next field.
+
+    Section discovery mirrors ``_parse_build_plan_chunk_type`` —
+    name-anchored on ``### Chunk <chunk_id>:`` with leading-zero
+    tolerance; fenced code blocks are skipped.
+    """
+    plan_path = resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return None, f"missing build-plan: {plan_path}"
+    try:
+        content = plan_path.read_text()
+    except OSError as exc:
+        return None, f"unreadable build-plan: {exc}"
+
+    target = chunk_id.lstrip("0") or "0"
+
+    in_section = False
+    in_fence = False
+    section_found = False
+    capturing = False
+    rationale_lines: list[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("### Chunk "):
+            rest = stripped[len("### Chunk "):]
+            head = rest.split(":", 1)[0].strip()
+            head_norm = head.lstrip("0") or "0"
+            if in_section:
+                break  # hit sibling chunk
+            if head_norm == target:
+                in_section = True
+                section_found = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            break
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _BUILD_PLAN_TRIVIAL_RATIONALE_RE.match(line)
+        if m:
+            capturing = True
+            first = m.group(1).strip()
+            if first:
+                rationale_lines.append(first)
+            continue
+        if capturing:
+            # Stop at the next list-item field, bolded label, or sub-heading.
+            if (
+                stripped.startswith("- **")
+                or stripped.startswith("* **")
+                or stripped.startswith("**")
+                or stripped.startswith("#")
+            ):
+                break
+            if stripped:
+                rationale_lines.append(stripped)
+
+    if not section_found:
+        return None, f"chunk {chunk_id!r} not found in build-plan"
+    if not capturing:
+        return None, (
+            "missing-rationale: Type: trivial requires non-empty "
+            "**Trivial because:** field"
+        )
+    rationale = " ".join(rationale_lines).strip()
+    if not rationale:
+        return None, (
+            "missing-rationale: Type: trivial requires non-empty "
+            "**Trivial because:** field"
+        )
+    return rationale, None
+
+
+# STH-1W5N — single source of truth for the unconditional ``Type: trivial`` /
+# doc-only protected-path bounds. Each entry is ``(path, is_exact, reason_label)``:
+# a change touching ``path`` (prefix match unless ``is_exact``) is a
+# catastrophic-blast-radius edit that a trivial/doc-only chunk may never make,
+# and the violation is reported as ``"<reason_label>: <path>"``. Centralized
+# here (was inline in ``_classify_trivial_change``) so the stop-hook gate and
+# the PR-boundary gate share one provably-identical list — and so the bound set
+# is testable as data. The conditional bounds (test-file removals, newly-tracked
+# files) stay in ``_classify_trivial_change`` because they depend on the change
+# verb, not just the path.
+#   skills/       — the critic/pr/etc. SKILL definitions + bundled protocols ARE
+#                   the governance; editing one changes the framework itself.
+#   methodology/  — the build/discovery/planning/reflection guides Claude reads
+#                   as operating instructions; a "trivial" rewrite is never trivial.
+#   templates/    — the artifact templates every product's specs are generated
+#                   from; a silent change propagates to all downstream output.
+#   CLAUDE.md     — the project's top-level operating contract (exact match —
+#                   a nested ``foo/CLAUDE.md`` is ordinary product doc).
+_TRIVIAL_PROTECTED_PATHS: frozenset[tuple[str, bool, str]] = frozenset({
+    ("skills/", False, "skill-file-edited"),
+    ("methodology/", False, "methodology-edited"),
+    ("templates/", False, "template-edited"),
+    ("CLAUDE.md", True, "claude-md-edited"),
+})
+
+
+def _classify_trivial_change(
+    *,
+    path: str,
+    src_path: str | None,
+    is_addition: bool,
+    is_deletion: bool,
+) -> str | None:
+    """Single-file path-rule check for the ``Type: trivial`` file-set
+    bounds. Returns the violation reason or ``None`` when the change
+    is eligible. Shared by ``_is_trivial_fileset_eligible`` (Chunk 04 —
+    working-tree porcelain) and ``_pr_diff_is_trivial`` (Chunk 05 —
+    per-commit name-status diff). Centralizing the rule set prevents
+    the stop-hook gate and the PR-boundary gate from drifting apart
+    silently.
+
+    The unconditional path bounds live in the module-level
+    ``_TRIVIAL_PROTECTED_PATHS`` constant (STH-1W5N — single source of
+    truth, referenced from this one call site). The conditional bounds
+    (test-file removals, newly-tracked files) stay inline below because
+    they depend on the change verb, not just the path.
+
+    Metadata paths (``.prawduct/``, ``.claude/settings.json``, etc. —
+    see ``_is_metadata_path``) are treated as out-of-scope and return
+    ``None``. The check applies to BOTH ``path`` (rename dst / single-
+    file change) AND ``src_path`` (rename src) — without that
+    symmetry, a rename FROM a metadata path that landed somewhere
+    interesting would silently be classified, and a rename TO a
+    metadata path would be classified differently depending on which
+    gate ran (the callers previously did dst-only filtering before
+    calling this helper — v1.5.1 Chunk 04(b) consolidates).
+
+    The caller translates its status format into the boolean inputs
+    (porcelain handles 2-char codes; name-status handles single-char).
+    Path bounds are catastrophic-blast-radius classes regardless of
+    size — size is intentionally not a bound.
+    """
+    if gitstate._is_metadata_path(path):
+        return None
+    if src_path is not None and gitstate._is_metadata_path(src_path):
+        return None
+    # Unconditional path bounds — driven by the _TRIVIAL_PROTECTED_PATHS
+    # constant so this gate and the PR-boundary gate share one list. The
+    # classes are mutually exclusive (a path matches at most one), so the
+    # frozenset's unordered iteration is behavior-preserving.
+    for protected, is_exact, reason_label in _TRIVIAL_PROTECTED_PATHS:
+        matched = path == protected if is_exact else path.startswith(protected)
+        if matched:
+            return f"{reason_label}: {path}"
+    if is_deletion and path.startswith("tests/"):
+        return f"test-file-deleted: {path}"
+    if src_path is not None and src_path.startswith("tests/"):
+        return f"test-file-deleted: {src_path} (renamed out)"
+    if is_addition:
+        return f"new-file: {path}"
+    return None
+
+
+def _current_chunk_id_from_status(prawduct_dir: Path) -> str | None:
+    """Extract the chunk id of the first `- [ ]` item in the build-plan Status
+    section, e.g. ``"03"`` for ``- [ ] Chunk 03: Foo``. Returns ``None`` if
+    Status is missing, has no current chunk (all complete), or the chunk text
+    isn't in the expected ``Chunk NN:`` form.
+
+    Mirrors the resolution logic in ``cmd_verify_chunk_refs`` so the stop
+    hook and the Critic helper agree on "which chunk is current."
+    """
+    status = _parse_build_plan_status(prawduct_dir)
+    current = status.get("current_chunk", "")
+    if not current.startswith("Chunk "):
+        return None
+    rest = current[len("Chunk "):]
+    chunk_id = rest.split(":", 1)[0].strip()
+    return chunk_id or None
+
+
+def _verify_chunk_refs(project_dir: Path, refs: dict) -> list[dict]:
+    """Verify each file-path ref exists relative to ``project_dir``.
+    Returns a list of ``{"kind", "ref", "line_num", "reason"}`` for missing
+    entries. Empty list = all refs resolved.
+    """
+    missing: list[dict] = []
+    for entry in refs.get("file_paths", []):
+        ref = entry["ref"]
+        target = project_dir / ref
+        if not target.exists():
+            missing.append({
+                "kind": "file_path",
+                "ref": ref,
+                "line_num": entry["line_num"],
+                "reason": "file does not exist",
+            })
+    return missing

--- a/tests/test_build_plan_resolution.py
+++ b/tests/test_build_plan_resolution.py
@@ -28,6 +28,11 @@ read_str_yaml_key = _mod.read_str_yaml_key
 BUILD_PLAN_POINTER_KEY = _mod.BUILD_PLAN_POINTER_KEY
 DEFAULT_BUILD_PLAN_REL = _mod.DEFAULT_BUILD_PLAN_REL
 
+# chunk-ref parsing + verification moved to lib/buildplan_refs (STH-9V4K ch.3) —
+# test the parsers where they now live, not via the hook (which only keeps a
+# thin wrapper + the import-light resolver mirror, parity-tested below).
+from lib import buildplan_refs as _bpr  # noqa: E402
+
 # plugin-runtime inline mirror via SourceFileLoader (extensionless shebang script)
 _hook_loader = importlib.machinery.SourceFileLoader("prawduct_hook_res", str(_ROOT / "bin" / "prawduct-hook"))
 _hook_spec = importlib.util.spec_from_loader("prawduct_hook_res", _hook_loader)
@@ -151,9 +156,9 @@ class TestSessionGitignoreMirror:
 # verify-chunk-refs, `_parse_build_plan_chunk_type` (fail-closes the chunk
 # type to `code`), and the `lib/critic_mode.py` plan-override. Nothing errors;
 # governance just quietly stops resolving the chunk. These helpers mirror the
-# production heading rule exactly (``bin/prawduct-hook`` ~line 2910): a heading
-# counts only if it `startswith("### Chunk ")` AND carries a colon, with the
-# leading-zero-tolerant ID before the colon.
+# production heading rule exactly (``lib/buildplan_refs.py`` — moved there in
+# STH-9V4K ch.3): a heading counts only if it `startswith("### Chunk ")` AND
+# carries a colon, with the leading-zero-tolerant ID before the colon.
 
 # Status line: "- [ ] Chunk 01: ..." / "- [x] Chunk 01: ..." (checkbox + colon).
 _STATUS_CHUNK_RE = re.compile(r"^- \[[ xX]\] Chunk (\S+):")
@@ -302,19 +307,19 @@ class TestVerifyChunkRefsPathSymbol:
         )
         (project / "lib").mkdir()
         (project / "lib" / "views.py").write_text("x = 1\n")
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert refs["error"] is None
         # The stored ref is the PATH portion only — not the full `path::symbol`.
         assert [e["ref"] for e in refs["file_paths"]] == ["lib/views.py"]
-        assert _hook._verify_chunk_refs(project, refs) == []
+        assert _bpr._verify_chunk_refs(project, refs) == []
 
     def test_missing_path_symbol_reports_path_portion_only(self, tmp_path: Path):
         project, prawduct = _project_with_chunk(
             tmp_path, "- touches `lib/gone.py::foo`\n"
         )
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert [e["ref"] for e in refs["file_paths"]] == ["lib/gone.py"]
-        missing = _hook._verify_chunk_refs(project, refs)
+        missing = _bpr._verify_chunk_refs(project, refs)
         assert len(missing) == 1
         # The missing-ref message names the path, not `lib/gone.py::foo`.
         assert missing[0]["ref"] == "lib/gone.py"
@@ -324,7 +329,7 @@ class TestVerifyChunkRefsPathSymbol:
         project, prawduct = _project_with_chunk(
             tmp_path, "- creates new `lib/created.py::bar`\n"
         )
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert refs["file_paths"] == []
 
     def test_path_and_path_symbol_same_line_dedup(self, tmp_path: Path):
@@ -333,7 +338,7 @@ class TestVerifyChunkRefsPathSymbol:
         )
         (project / "lib").mkdir()
         (project / "lib" / "views.py").write_text("x = 1\n")
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         # Both collapse to one path existence-check.
         assert [e["ref"] for e in refs["file_paths"]] == ["lib/views.py"]
 
@@ -341,16 +346,16 @@ class TestVerifyChunkRefsPathSymbol:
         project, prawduct = _project_with_chunk(tmp_path, "- see `docs/x.md`\n")
         (project / "docs").mkdir()
         (project / "docs" / "x.md").write_text("doc\n")
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert [e["ref"] for e in refs["file_paths"]] == ["docs/x.md"]
-        assert _hook._verify_chunk_refs(project, refs) == []
+        assert _bpr._verify_chunk_refs(project, refs) == []
 
     def test_symbol_without_slashed_path_skipped(self, tmp_path: Path):
         # No `/` before `::` -> not a path reference (e.g. a bare class::method).
         project, prawduct = _project_with_chunk(
             tmp_path, "- the `SomeClass::method` helper\n"
         )
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert refs["file_paths"] == []
 
 
@@ -370,20 +375,20 @@ class TestVerifyChunkRefsGlobPaths:
         project, prawduct = _project_with_chunk(
             tmp_path, "- Tests: uncaptured + `docs/requirements/*.md` present\n"
         )
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert refs["error"] is None
         assert refs["file_paths"] == []
         # And it produces no missing-ref at verification time.
-        assert _hook._verify_chunk_refs(project, refs) == []
+        assert _bpr._verify_chunk_refs(project, refs) == []
 
     def test_question_mark_glob_is_skipped(self, tmp_path: Path):
         project, prawduct = _project_with_chunk(tmp_path, "- see `src/foo?.py`\n")
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert refs["file_paths"] == []
 
     def test_bracket_glob_is_skipped(self, tmp_path: Path):
         project, prawduct = _project_with_chunk(tmp_path, "- see `src/[abc].py`\n")
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert refs["file_paths"] == []
 
     def test_literal_path_alongside_glob_still_captured(self, tmp_path: Path):
@@ -394,6 +399,6 @@ class TestVerifyChunkRefsGlobPaths:
         )
         (project / "lib").mkdir()
         (project / "lib" / "views.py").write_text("x = 1\n")
-        refs = _hook._parse_build_plan_chunk_refs(prawduct, "01")
+        refs = _bpr._parse_build_plan_chunk_refs(prawduct, "01")
         assert [e["ref"] for e in refs["file_paths"]] == ["lib/views.py"]
-        assert _hook._verify_chunk_refs(project, refs) == []
+        assert _bpr._verify_chunk_refs(project, refs) == []

--- a/tests/test_trivial_fileset_gate.py
+++ b/tests/test_trivial_fileset_gate.py
@@ -13,19 +13,19 @@ literal had nothing pinning it.
 
 from __future__ import annotations
 
-import importlib.machinery
-import importlib.util
+import sys
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
-_loader = importlib.machinery.SourceFileLoader("prawduct_hook_gate", str(_ROOT / "bin" / "prawduct-hook"))
-_spec = importlib.util.spec_from_loader("prawduct_hook_gate", _loader)
-_hook = importlib.util.module_from_spec(_spec)
-_loader.exec_module(_hook)
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+# _classify_trivial_change + _TRIVIAL_PROTECTED_PATHS moved to lib/buildplan_refs
+# (STH-9V4K ch.3); test the code where it now lives, not via the hook.
+from lib import buildplan_refs as _bpr  # noqa: E402
 
 
 def _classify(path, *, src_path=None, is_addition=False, is_deletion=False):
-    return _hook._classify_trivial_change(
+    return _bpr._classify_trivial_change(
         path=path, src_path=src_path, is_addition=is_addition, is_deletion=is_deletion
     )
 
@@ -95,19 +95,19 @@ class TestProtectedPathsConstant:
     constant (not a stale inline literal) is what the classifier consults."""
 
     def test_constant_is_non_empty_frozenset(self):
-        assert isinstance(_hook._TRIVIAL_PROTECTED_PATHS, frozenset)
-        assert _hook._TRIVIAL_PROTECTED_PATHS, "the protected-path bound list must be non-empty"
+        assert isinstance(_bpr._TRIVIAL_PROTECTED_PATHS, frozenset)
+        assert _bpr._TRIVIAL_PROTECTED_PATHS, "the protected-path bound list must be non-empty"
 
     def test_constant_contains_documented_paths(self):
         # The four catastrophic-blast-radius classes the bound has always covered.
-        paths = {entry[0] for entry in _hook._TRIVIAL_PROTECTED_PATHS}
+        paths = {entry[0] for entry in _bpr._TRIVIAL_PROTECTED_PATHS}
         assert {"skills/", "methodology/", "templates/", "CLAUDE.md"} <= paths
 
     def test_claude_md_is_exact_match_not_prefix(self):
         # CLAUDE.md is an exact-match bound (a nested foo/CLAUDE.md is ordinary
         # product doc); the others are prefix bounds. The flag in the constant
         # is what drives that distinction.
-        by_path = {entry[0]: entry[1] for entry in _hook._TRIVIAL_PROTECTED_PATHS}
+        by_path = {entry[0]: entry[1] for entry in _bpr._TRIVIAL_PROTECTED_PATHS}
         assert by_path["CLAUDE.md"] is True
         assert by_path["skills/"] is False
 
@@ -115,7 +115,7 @@ class TestProtectedPathsConstant:
         # Every entry in the constant must actually produce a violation from the
         # classifier with the constant's own reason label — proving the constant
         # is the source of truth, not a parallel copy that could drift.
-        for protected, is_exact, reason_label in _hook._TRIVIAL_PROTECTED_PATHS:
+        for protected, is_exact, reason_label in _bpr._TRIVIAL_PROTECTED_PATHS:
             sample = protected if is_exact else protected + "x.md"
             reason = _classify(sample)
             assert reason == f"{reason_label}: {sample}", (


### PR DESCRIPTION
## Chunk 3 of the `bin/prawduct-hook` decomposition (STH-9V4K)

Behavior-preserving refactor. Extracts the build-plan-parsing cluster out of the hook monolith into a new `lib/buildplan_refs.py`, and reassigns the one mis-homed helper (`_parse_build_plan_status`) out of the briefing region to break the concern-cluster dependency cycle (constraint 2 of the build plan).

### What moved
8 functions + 6 module constants → `lib/buildplan_refs.py` (524 lines):
`_looks_like_file_path`, `_parse_build_plan_chunk_refs`, `_parse_build_plan_chunk_type`, `_parse_build_plan_chunk_trivial_rationale`, `_classify_trivial_change` (+`_TRIVIAL_PROTECTED_PATHS`), `_current_chunk_id_from_status`, `_verify_chunk_refs`, **and `_parse_build_plan_status`** (the cycle-break).

The hook drops to **4,226 lines** (was 4,942 at plan start; 4,690 before this chunk). Resident call sites delegate via a new lazy `_buildplan_refs()` accessor mirroring ch.2's `_gitstate()` — keeps the hook's top level lib-free, preserving the ch.1 isolation invariant.

### Sanctioned internal rewrites (only deviations from a verbatim move)
- `_resolve_build_plan_path` → `lib.core.resolve_build_plan_path` (the established lib pattern; avoids a third copy of the resolver — the hook's parity-pinned inline mirror stays)
- `_gitstate()._is_metadata_path` → `gitstate._is_metadata_path` (direct sibling import)

All 8 moved bodies AST-verified byte-identical to HEAD modulo those two rewrites; the 6 constants moved verbatim.

### Tests
`test_build_plan_resolution.py` + `test_trivial_fileset_gate.py` repointed to `lib.buildplan_refs` — import repoint only, assertions unchanged (test where the code lives, not a back-shim). Full suite **884 passed / 0 failed**.

### Follow-up (filed, deferred — scope discipline)
STH-2K8R: `critic_mode`'s independent re-implementations of these parsers could now `from .buildplan_refs import …`, eliminating the mirrors. That's a design change beyond a behavior-preserving move — backlogged, not smuggled in here.

### Review gates
- ✅ Full suite: 884 passed, 0 failed (evidence anchored to HEAD)
- ✅ Cumulative-Critic: 0 findings (covers HEAD, clean)
- ✅ Independent PR reviewer: 0 blocking / 0 warning / 0 note
- Next: Chunk 4 (`lib/compliance.py`)