### PR TITLE
refactor: extract lib/compliance from hook (STH-9V4K ch.4)

### DIFF
--- a/.prawduct/artifacts/build-plan-hook-decomposition.md
+++ b/.prawduct/artifacts/build-plan-hook-decomposition.md
@@ -89,18 +89,23 @@ each PR merges via `/prawduct:pr` + regen-views.*
 - [ ] Chunk 6: Extract `lib/gates.py` — stop-gate logic + test-evidence commands. **Critic mode:** chunk
 - [ ] Chunk 7: Extract `lib/briefing.py` — staleness + session/subagent briefing + handoff. **Critic mode:** final
 
-Context: Chunks 1-3 built + Critic-clean (0 findings each). Ch.1-2 merged to develop via #74; ch.3
-(`lib/buildplan_refs.py`) committed on `refactor/hook-decomp-buildplan-refs` off develop — extracted
-the chunk-ref/Type/Trivial parsers + `_classify_trivial_change` AND reassigned `_parse_build_plan_status`
-out of the briefing region (the cycle-break done). Hook now 4,226 lines (was 4,942 at plan start).
-Full suite 884 green; `verify-chunk-refs`/`clear`/`stop` smoke-clean via the real CLI. Not yet PR'd
-(built autonomously). Checkboxes stay `[ ]` until release (status=shipped); develop-merge is tracked
-by the change-log entry per ch.1/ch.2 convention. **Next: Chunk 4 (`lib/compliance.py`)** off develop
-— compliance canary + `_check_broad_exceptions`/`_check_invalid_waivers`/`_waivers_module` + the file
-classifiers (`_is_source_file`/`_is_test_file`/`_is_dependency_file`); imports `gitstate`; repoint
-`test_waivers.py`. The proven pattern: write `lib/<mod>.py` (verbatim move, AST-verify identical) →
-add the lazy accessor → rewire resident call sites → repoint coupled tests → full suite + CLI smoke
-→ `/prawduct:critic chunk`. Enabled follow-up filed: STH-2K8R (critic_mode mirror consolidation).
+Context: Chunks 1-4 built + Critic-clean (0 findings each). Ch.1-2 merged to develop via #74; ch.3
+(`lib/buildplan_refs.py`) PR'd to develop as **#75** (cumulative-Critic + independent PR review both
+clean); ch.4 (`lib/compliance.py`) committed on `refactor/hook-decomp-compliance` **stacked on the ch.3
+branch** (built before #75 merged) — extracted the session-end compliance canary +
+`_check_broad_exceptions`/`_check_invalid_waivers`/`_waivers_module` + the file classifiers
+(`_is_source_file`/`_is_test_file`/`_is_dependency_file`); imports `gitstate`. Hook now 4,058 lines
+(was 4,942 at plan start). Full suite 884 green; the `stop` canary path smoke-clean via the hook's real
+`_compliance()` accessor. Checkboxes stay `[ ]` until release (status=shipped); develop-merge is tracked
+by the change-log entry per ch.1/ch.2 convention. **Next: Chunk 5 (`lib/coverage.py`)** — coverage/base
+resolution (`_read_bool_yaml_key`, `_git_ref_exists`, `_resolve_base_branch`, `_coverage_resolve_base`,
+`_coverage_changed_files`, `_pr_diff_is_doc_only`, `_pr_diff_is_trivial`) + the `cmd_verify_coverage` /
+`cmd_check_cumulative_critic` / `cmd_check_pr_doc_only` / `cmd_check_pr_trivial` bodies (hook keeps thin
+`cmd_*` wrappers); imports `gitstate` + `buildplan_refs`; repoint `test_views.py` (`_read_bool_yaml_key`)
+and the `test_plugin_runtime.py` source-inspection (`_resolve_base_branch`). The proven pattern: write
+`lib/<mod>.py` (verbatim move, AST-verify identical) → add the lazy accessor → rewire resident call
+sites → repoint coupled tests → full suite + CLI smoke → `/prawduct:critic chunk`. Enabled follow-up
+filed: STH-2K8R (critic_mode mirror consolidation). Once #75 merges, rebase the ch.4 branch onto develop.
 
 ## Chunk detail
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,38 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-06-07: extract lib/compliance.py — session-end compliance canary + file classifiers (STH-9V4K ch.4)
+
+<!-- prawduct: chunks=4 | type=refactor | scope=hook-decomp -->
+
+**Why:** Chunk 4 of the hook decomposition (STH-9V4K). The session-end compliance canary — the
+lightweight failure-detection pass `cmd_stop` runs (code-without-tests, dependency-without-manifest,
+broad exception handling, reason-less waivers) — is its own cohesive concern sitting one layer up from
+the ch.2 `gitstate` leaf. Extracting it continues the leaf-first DAG walk
+(`gitstate ← compliance`) and removes another self-contained cluster from the monolith.
+
+**What:** New `lib/compliance.py` holds 7 functions moved **verbatim**: `compliance_canary`,
+`_check_broad_exceptions`, `_check_invalid_waivers`, `_waivers_module`, plus the file classifiers
+`_is_source_file` / `_is_test_file` / `_is_dependency_file` (their only caller is the canary). Two
+sanctioned internal rewrites, both forced by the lib→bin no-back-import rule: `compliance_canary`
+reaches the changed-file probe + prawduct-dir helper via `from . import gitstate`
+(`gitstate._get_session_changed_files` / `gitstate.get_prawduct_dir`, replacing the hook's
+`_gitstate().…` / inline `get_prawduct_dir`), and `_waivers_module` drops the now-redundant
+`_plugin_root()` sys.path seeding for a relative `from . import waivers` (the lib package is already
+importable once `compliance` loads). The fail-open posture is preserved exactly — `_waivers_module`
+still returns `None` on import failure so the canary emits no waiver-dependent finding. The hook gains
+a lazy `_compliance()` accessor (mirrors `_gitstate()`) and rewires the single `cmd_stop` call site to
+`_compliance().compliance_canary(...)`; its top level stays lib-free (ch.1 isolation invariant
+preserved — importing `compliance` pulls in only `gitstate`, with `waivers` still lazy).
+
+**Tests:** `test_waivers.py` repointed to `from lib import compliance` for the two canary helpers it
+exercises (`_check_broad_exceptions`, `_check_invalid_waivers`); the now-dead `SourceFileLoader` hook
+shim and its `importlib` imports were removed (the module no longer needs the hook). Full suite 884
+passed (count unchanged — behavior-preserving); the `stop` canary path is smoke-clean via the hook's
+real `_compliance()` accessor (broad-except flags only the unwaived file; waiver honored end-to-end).
+AST-verified: the 5 pure-move functions are byte-identical to HEAD; the 2 rewritten ones differ only
+by the sanctioned rewrites above. Hook: −168 lines net (4,226 → 4,058).
+
 ## 2026-06-07: extract lib/buildplan_refs.py — build-plan ref parsing + trivial classification (STH-9V4K ch.3)
 
 <!-- prawduct: chunks=3 | type=refactor | scope=hook-decomp -->

--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -88,6 +88,21 @@ def _buildplan_refs():
     return buildplan_refs
 
 
+def _compliance():
+    """Lazy-import the session-end compliance canary + its file classifiers
+    (lib/compliance). Same lazy idiom as _gitstate() — seeds sys.path so the
+    hook's top level stays lib-free; after the ch.1 __init__ slim this loads only
+    compliance.py (+ its light sibling gitstate, and lazily waivers), isolated.
+    The cmd_stop caller wraps the canary in a broad catch, so an import failure
+    here degrades to "canary skipped" and never blocks session end."""
+    lib_root = _plugin_root()
+    if lib_root not in sys.path:
+        sys.path.insert(0, lib_root)
+    from lib import compliance  # noqa: PLC0415 — lazy keeps top-level cheap + lib-free
+
+    return compliance
+
+
 # --- New-gate attribution (design §5a) -----------------------------------
 # A blocking message names the version + gate that caused it, so a surprise
 # block (e.g. a gate a recent plugin update introduced) is always traceable to
@@ -1332,189 +1347,6 @@ def generate_session_handoff(project_dir: Path) -> None:
 
 
 # =============================================================================
-# Compliance Canary (v5: lightweight failure detection at session end)
-# =============================================================================
-
-
-def _is_source_file(filepath: str) -> bool:
-    """Check if a filepath looks like a source code file (not test, not config)."""
-    p = Path(filepath)
-    suffix = p.suffix
-
-    if suffix not in (".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".java", ".rb", ".swift", ".kt", ".c", ".cpp", ".h"):
-        return False
-
-    name = p.name
-    if name.startswith("test_") or name.endswith(("_test.py", ".test.js", ".test.ts", ".test.jsx", ".test.tsx", ".spec.js", ".spec.ts")):
-        return False
-
-    if filepath.startswith(".prawduct/"):
-        return False
-
-    return True
-
-
-def _is_test_file(filepath: str) -> bool:
-    """Check if a filepath looks like a test file."""
-    name = Path(filepath).name
-    return (
-        (name.startswith("test_") and name.endswith(".py"))
-        or name.endswith(("_test.py", ".test.js", ".test.ts", ".test.jsx", ".test.tsx", ".spec.js", ".spec.ts"))
-    )
-
-
-def _is_dependency_file(filepath: str) -> bool:
-    """Check if a filepath is a dependency declaration file."""
-    name = Path(filepath).name
-    return name in ("requirements.txt", "package.json", "Pipfile", "pyproject.toml", "Cargo.toml", "go.mod", "Gemfile")
-
-
-def _waivers_module():
-    """Lazy-import the shared waiver recognizer (``lib/waivers.py``).
-
-    Returns the module, or ``None`` if it can't be imported. The canary is
-    best-effort and must never crash, so callers treat ``None`` as "recognizer
-    unavailable" and fail open (emit no waiver-dependent finding).
-    """
-    try:
-        lib_root = _plugin_root()
-        if lib_root not in sys.path:
-            sys.path.insert(0, lib_root)
-        from lib import waivers  # noqa: PLC0415 — lazy keeps top-level import cheap
-        return waivers
-    except Exception:  # prawduct:allow prawduct/broad-except -- recognizer is best-effort; canary must not crash
-        return None
-
-
-def _check_broad_exceptions(project_dir: Path, source_files: list[str]) -> list[str]:
-    """Check if changed source files contain broad exception patterns.
-
-    Skips lines waived with ``prawduct/broad-except`` (intentional, reviewed),
-    recognized via the shared ``lib.waivers`` recognizer — which honors both the
-    ``prawduct:allow prawduct/broad-except`` form and the legacy
-    ``prawduct:ok-broad-except`` spelling (see docs/waivers.md). For Python, also
-    skips broad catches that re-raise or log within 3 lines.
-    """
-    waivers = _waivers_module()
-    if waivers is None:
-        return []  # recognizer unavailable — fail open (best-effort canary)
-    # Language-specific patterns for overly broad exception handling
-    patterns = {
-        ".py": r"except\s+(?:Exception|BaseException)\s*(?::|,|as\b)",
-        ".js": r"catch\s*\([^)]*\)\s*\{\s*\}",
-        ".jsx": r"catch\s*\([^)]*\)\s*\{\s*\}",
-        ".ts": r"catch\s*\([^)]*\)\s*\{\s*\}",
-        ".tsx": r"catch\s*\([^)]*\)\s*\{\s*\}",
-        ".go": r"_\s*=\s*\w+\.(?:\w+)\(",  # _ = foo.Bar() — ignored errors
-    }
-    flagged = []
-    for filepath in source_files:
-        full_path = project_dir / filepath
-        if not full_path.is_file():
-            continue
-        suffix = Path(filepath).suffix
-        pattern = patterns.get(suffix)
-        if not pattern:
-            continue
-        try:
-            content = full_path.read_text()
-            lines = content.splitlines()
-            has_unflagged = False
-            for i, line in enumerate(lines):
-                if not re.search(pattern, line):
-                    continue
-                # Skip if this line (or the line above) waives broad-except.
-                if waivers.waives(lines, i, "prawduct/broad-except"):
-                    continue
-                # For Python: skip if the except block re-raises or logs
-                if suffix == ".py":
-                    # Check next 3 lines for raise or log/logger calls
-                    following = "\n".join(lines[i + 1 : i + 4])
-                    if re.search(r"\braise\b", following) or re.search(r"\blog(?:ger|ging)?\b", following, re.IGNORECASE):
-                        continue
-                has_unflagged = True
-                break
-            if has_unflagged:
-                flagged.append(filepath)
-        except Exception:  # prawduct:allow prawduct/broad-except -- canary must never crash on a single file
-            pass
-    return flagged
-
-
-def _check_invalid_waivers(project_dir: Path, source_files: list[str]) -> list[str]:
-    """Source files carrying a reason-less ``prawduct:allow`` waiver.
-
-    The reason is mandatory (docs/waivers.md): a waiver without one is malformed
-    and defeats the "reviewed and intentional" contract. Best-effort like the
-    rest of the canary.
-    """
-    waivers = _waivers_module()
-    if waivers is None:
-        return []
-    flagged = []
-    for filepath in source_files:
-        full_path = project_dir / filepath
-        if not full_path.is_file():
-            continue
-        try:
-            lines = full_path.read_text().splitlines()
-            if waivers.invalid_waivers(lines):
-                flagged.append(filepath)
-        except Exception:  # prawduct:allow prawduct/broad-except -- canary must never crash on a single file
-            pass
-    return flagged
-
-
-def compliance_canary(project_dir: Path) -> list[str]:
-    """Lightweight compliance checks at session end. Returns informational findings."""
-    findings: list[str] = []
-    changed = _gitstate()._get_session_changed_files(project_dir)
-
-    if not changed:
-        return findings
-
-    source_changed = [f for f in changed if _is_source_file(f)]
-    test_changed = [f for f in changed if _is_test_file(f)]
-    dep_changed = [f for f in changed if _is_dependency_file(f)]
-
-    # 1. Code changed but no tests
-    if source_changed and not test_changed:
-        preview = ", ".join(source_changed[:3])
-        findings.append(
-            f"CANARY: {len(source_changed)} source file(s) changed but no test files modified. Changed: {preview}"
-        )
-
-    # 2. Dependency file changed without manifest update
-    if dep_changed:
-        prawduct_dir = get_prawduct_dir(project_dir)
-        manifest_path = prawduct_dir / "artifacts" / "dependency-manifest.md"
-        dep_manifest_in_changes = any(f.endswith("dependency-manifest.md") for f in changed)
-        if manifest_path.is_file() and not dep_manifest_in_changes:
-            findings.append(
-                f"CANARY: Dependency file(s) changed ({', '.join(dep_changed)}) "
-                f"but dependency-manifest.md was not updated."
-            )
-
-    # 3. Broad exception handling in changed source files
-    broad_except_files = _check_broad_exceptions(project_dir, source_changed)
-    if broad_except_files:
-        findings.append(
-            f"CANARY: Broad exception handling detected in: {', '.join(broad_except_files)}. "
-            f"Verify exceptions are specific and include logging/re-raising."
-        )
-
-    # 4. Reason-less prawduct:allow waivers (malformed — a waiver must say why)
-    invalid_waiver_files = _check_invalid_waivers(project_dir, source_changed)
-    if invalid_waiver_files:
-        findings.append(
-            f"CANARY: Reason-less prawduct:allow waiver in: {', '.join(invalid_waiver_files)}. "
-            f"A waiver must state why it's intentional (see docs/waivers.md)."
-        )
-
-    return findings
-
-
-# =============================================================================
 # clear command
 # =============================================================================
 
@@ -2210,7 +2042,7 @@ def cmd_stop(project_dir: Path) -> int:
 
     # v5: Compliance canary (informational)
     try:
-        canary_findings = compliance_canary(project_dir)
+        canary_findings = _compliance().compliance_canary(project_dir)
     except Exception:  # prawduct:allow prawduct/broad-except -- canary must never block session end
         pass
 

--- a/lib/compliance.py
+++ b/lib/compliance.py
@@ -1,0 +1,201 @@
+"""Session-end compliance canary + its file classifiers for the runtime.
+
+Extracted from ``bin/prawduct-hook`` (STH-9V4K, Chunk 4) — the lightweight
+failure-detection pass the Stop hook runs at session end: it inspects the
+session's changed files for code-without-tests, dependency-without-manifest,
+broad exception handling, and reason-less ``prawduct:allow`` waivers, returning
+informational ``CANARY:`` findings. Best-effort by design — every probe fails
+open (never crashes, never blocks session end).
+
+Depends only on its lib sibling ``gitstate`` (for ``_get_session_changed_files``
+and ``get_prawduct_dir``) and, lazily, ``waivers`` (the shared pragma
+recognizer), plus the stdlib — a clean DAG node (``gitstate`` ← ``compliance``).
+The hook calls ``compliance_canary`` lazily via ``_compliance()``, keeping its
+top level lib-free; the ``cmd_stop`` call site wraps it in a broad catch so a
+canary failure can never block session end.
+
+The file classifiers (``_is_source_file`` / ``_is_test_file`` /
+``_is_dependency_file``) move with the canary — it is their only caller.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import gitstate
+
+
+def _is_source_file(filepath: str) -> bool:
+    """Check if a filepath looks like a source code file (not test, not config)."""
+    p = Path(filepath)
+    suffix = p.suffix
+
+    if suffix not in (".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".java", ".rb", ".swift", ".kt", ".c", ".cpp", ".h"):
+        return False
+
+    name = p.name
+    if name.startswith("test_") or name.endswith(("_test.py", ".test.js", ".test.ts", ".test.jsx", ".test.tsx", ".spec.js", ".spec.ts")):
+        return False
+
+    if filepath.startswith(".prawduct/"):
+        return False
+
+    return True
+
+
+def _is_test_file(filepath: str) -> bool:
+    """Check if a filepath looks like a test file."""
+    name = Path(filepath).name
+    return (
+        (name.startswith("test_") and name.endswith(".py"))
+        or name.endswith(("_test.py", ".test.js", ".test.ts", ".test.jsx", ".test.tsx", ".spec.js", ".spec.ts"))
+    )
+
+
+def _is_dependency_file(filepath: str) -> bool:
+    """Check if a filepath is a dependency declaration file."""
+    name = Path(filepath).name
+    return name in ("requirements.txt", "package.json", "Pipfile", "pyproject.toml", "Cargo.toml", "go.mod", "Gemfile")
+
+
+def _waivers_module():
+    """Lazy-import the shared waiver recognizer (``lib/waivers.py``).
+
+    Returns the module, or ``None`` if it can't be imported. The canary is
+    best-effort and must never crash, so callers treat ``None`` as "recognizer
+    unavailable" and fail open (emit no waiver-dependent finding).
+    """
+    try:
+        from . import waivers  # noqa: PLC0415 — lazy keeps the canary best-effort
+        return waivers
+    except Exception:  # prawduct:allow prawduct/broad-except -- recognizer is best-effort; canary must not crash
+        return None
+
+
+def _check_broad_exceptions(project_dir: Path, source_files: list[str]) -> list[str]:
+    """Check if changed source files contain broad exception patterns.
+
+    Skips lines waived with ``prawduct/broad-except`` (intentional, reviewed),
+    recognized via the shared ``lib.waivers`` recognizer — which honors both the
+    ``prawduct:allow prawduct/broad-except`` form and the legacy
+    ``prawduct:ok-broad-except`` spelling (see docs/waivers.md). For Python, also
+    skips broad catches that re-raise or log within 3 lines.
+    """
+    waivers = _waivers_module()
+    if waivers is None:
+        return []  # recognizer unavailable — fail open (best-effort canary)
+    # Language-specific patterns for overly broad exception handling
+    patterns = {
+        ".py": r"except\s+(?:Exception|BaseException)\s*(?::|,|as\b)",
+        ".js": r"catch\s*\([^)]*\)\s*\{\s*\}",
+        ".jsx": r"catch\s*\([^)]*\)\s*\{\s*\}",
+        ".ts": r"catch\s*\([^)]*\)\s*\{\s*\}",
+        ".tsx": r"catch\s*\([^)]*\)\s*\{\s*\}",
+        ".go": r"_\s*=\s*\w+\.(?:\w+)\(",  # _ = foo.Bar() — ignored errors
+    }
+    flagged = []
+    for filepath in source_files:
+        full_path = project_dir / filepath
+        if not full_path.is_file():
+            continue
+        suffix = Path(filepath).suffix
+        pattern = patterns.get(suffix)
+        if not pattern:
+            continue
+        try:
+            content = full_path.read_text()
+            lines = content.splitlines()
+            has_unflagged = False
+            for i, line in enumerate(lines):
+                if not re.search(pattern, line):
+                    continue
+                # Skip if this line (or the line above) waives broad-except.
+                if waivers.waives(lines, i, "prawduct/broad-except"):
+                    continue
+                # For Python: skip if the except block re-raises or logs
+                if suffix == ".py":
+                    # Check next 3 lines for raise or log/logger calls
+                    following = "\n".join(lines[i + 1 : i + 4])
+                    if re.search(r"\braise\b", following) or re.search(r"\blog(?:ger|ging)?\b", following, re.IGNORECASE):
+                        continue
+                has_unflagged = True
+                break
+            if has_unflagged:
+                flagged.append(filepath)
+        except Exception:  # prawduct:allow prawduct/broad-except -- canary must never crash on a single file
+            pass
+    return flagged
+
+
+def _check_invalid_waivers(project_dir: Path, source_files: list[str]) -> list[str]:
+    """Source files carrying a reason-less ``prawduct:allow`` waiver.
+
+    The reason is mandatory (docs/waivers.md): a waiver without one is malformed
+    and defeats the "reviewed and intentional" contract. Best-effort like the
+    rest of the canary.
+    """
+    waivers = _waivers_module()
+    if waivers is None:
+        return []
+    flagged = []
+    for filepath in source_files:
+        full_path = project_dir / filepath
+        if not full_path.is_file():
+            continue
+        try:
+            lines = full_path.read_text().splitlines()
+            if waivers.invalid_waivers(lines):
+                flagged.append(filepath)
+        except Exception:  # prawduct:allow prawduct/broad-except -- canary must never crash on a single file
+            pass
+    return flagged
+
+
+def compliance_canary(project_dir: Path) -> list[str]:
+    """Lightweight compliance checks at session end. Returns informational findings."""
+    findings: list[str] = []
+    changed = gitstate._get_session_changed_files(project_dir)
+
+    if not changed:
+        return findings
+
+    source_changed = [f for f in changed if _is_source_file(f)]
+    test_changed = [f for f in changed if _is_test_file(f)]
+    dep_changed = [f for f in changed if _is_dependency_file(f)]
+
+    # 1. Code changed but no tests
+    if source_changed and not test_changed:
+        preview = ", ".join(source_changed[:3])
+        findings.append(
+            f"CANARY: {len(source_changed)} source file(s) changed but no test files modified. Changed: {preview}"
+        )
+
+    # 2. Dependency file changed without manifest update
+    if dep_changed:
+        prawduct_dir = gitstate.get_prawduct_dir(project_dir)
+        manifest_path = prawduct_dir / "artifacts" / "dependency-manifest.md"
+        dep_manifest_in_changes = any(f.endswith("dependency-manifest.md") for f in changed)
+        if manifest_path.is_file() and not dep_manifest_in_changes:
+            findings.append(
+                f"CANARY: Dependency file(s) changed ({', '.join(dep_changed)}) "
+                f"but dependency-manifest.md was not updated."
+            )
+
+    # 3. Broad exception handling in changed source files
+    broad_except_files = _check_broad_exceptions(project_dir, source_changed)
+    if broad_except_files:
+        findings.append(
+            f"CANARY: Broad exception handling detected in: {', '.join(broad_except_files)}. "
+            f"Verify exceptions are specific and include logging/re-raising."
+        )
+
+    # 4. Reason-less prawduct:allow waivers (malformed — a waiver must say why)
+    invalid_waiver_files = _check_invalid_waivers(project_dir, source_changed)
+    if invalid_waiver_files:
+        findings.append(
+            f"CANARY: Reason-less prawduct:allow waiver in: {', '.join(invalid_waiver_files)}. "
+            f"A waiver must state why it's intentional (see docs/waivers.md)."
+        )
+
+    return findings

--- a/tests/test_waivers.py
+++ b/tests/test_waivers.py
@@ -7,8 +7,6 @@ placement. Spec: docs/waivers.md.
 
 from __future__ import annotations
 
-import importlib.machinery
-import importlib.util
 import sys
 from pathlib import Path
 
@@ -16,16 +14,9 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from lib import compliance  # noqa: E402 — canary checks now live in lib/compliance (STH-9V4K ch.4)
 from lib import waivers  # noqa: E402
 from lib.waivers import Waiver  # noqa: E402
-
-# Load the extensionless hook script as a module to exercise the canary wiring.
-_hook_loader = importlib.machinery.SourceFileLoader(
-    "prawduct_hook_waivers", str(_REPO_ROOT / "bin" / "prawduct-hook")
-)
-_hook_spec = importlib.util.spec_from_loader("prawduct_hook_waivers", _hook_loader)
-_hook = importlib.util.module_from_spec(_hook_spec)
-_hook_loader.exec_module(_hook)
 
 
 class TestParseGeneral:
@@ -190,7 +181,7 @@ class TestCanaryWiring:
 
     def test_unwaived_broad_except_is_flagged(self, tmp_path: Path):
         self._write(tmp_path, "def f():\n    try:\n        g()\n    except Exception:\n        pass\n")
-        assert _hook._check_broad_exceptions(tmp_path, ["mod.py"]) == ["mod.py"]
+        assert compliance._check_broad_exceptions(tmp_path, ["mod.py"]) == ["mod.py"]
 
     def test_general_form_waiver_suppresses(self, tmp_path: Path):
         self._write(
@@ -198,7 +189,7 @@ class TestCanaryWiring:
             "def f():\n    try:\n        g()\n"
             "    except Exception:  # prawduct:allow prawduct/broad-except -- boundary\n        pass\n",
         )
-        assert _hook._check_broad_exceptions(tmp_path, ["mod.py"]) == []
+        assert compliance._check_broad_exceptions(tmp_path, ["mod.py"]) == []
 
     def test_legacy_form_waiver_still_suppresses(self, tmp_path: Path):
         self._write(
@@ -206,7 +197,7 @@ class TestCanaryWiring:
             "def f():\n    try:\n        g()\n"
             "    except Exception:  # prawduct:ok-broad-except — boundary\n        pass\n",
         )
-        assert _hook._check_broad_exceptions(tmp_path, ["mod.py"]) == []
+        assert compliance._check_broad_exceptions(tmp_path, ["mod.py"]) == []
 
     def test_reasonless_waiver_is_flagged_by_invalid_check(self, tmp_path: Path):
         self._write(
@@ -214,11 +205,11 @@ class TestCanaryWiring:
             "def f():\n    try:\n        g()\n"
             "    except Exception:  # prawduct:allow prawduct/broad-except\n        pass\n",
         )
-        assert _hook._check_invalid_waivers(tmp_path, ["mod.py"]) == ["mod.py"]
+        assert compliance._check_invalid_waivers(tmp_path, ["mod.py"]) == ["mod.py"]
 
     def test_valid_waiver_not_flagged_by_invalid_check(self, tmp_path: Path):
         self._write(
             tmp_path,
             "x = 1  # prawduct:allow prawduct/legacy-ref -- required for 1.x migration\n",
         )
-        assert _hook._check_invalid_waivers(tmp_path, ["mod.py"]) == []
+        assert compliance._check_invalid_waivers(tmp_path, ["mod.py"]) == []


### PR DESCRIPTION
## Chunk 4 of the `bin/prawduct-hook` decomposition (STH-9V4K)

Behavior-preserving refactor. Extracts the session-end **compliance canary** and its file classifiers out of the hook monolith into a new `lib/compliance.py`. Continues the leaf-first DAG walk (`gitstate ← compliance`).

### What moved (7 functions → `lib/compliance.py`)
`compliance_canary`, `_check_broad_exceptions`, `_check_invalid_waivers`, `_waivers_module`, plus the file classifiers `_is_source_file` / `_is_test_file` / `_is_dependency_file` (their only caller is the canary).

The hook drops to **4,058 lines** (−168 net). A new lazy `_compliance()` accessor (mirroring `_gitstate()` / `_buildplan_refs()`) keeps the hook's top level lib-free — the ch.1 isolation invariant. The single `cmd_stop` call site is rewired to `_compliance().compliance_canary(...)`, still wrapped in its broad-catch fail-safe so a canary failure can never block session end.

### Sanctioned internal rewrites (only deviations from a verbatim move)
- `compliance_canary`: `_gitstate()._get_session_changed_files` → `gitstate._get_session_changed_files`; inline `get_prawduct_dir` → `gitstate.get_prawduct_dir`
- `_waivers_module`: dropped the now-redundant `_plugin_root()` sys.path seeding for a relative `from . import waivers` (the `lib` package is already importable once `compliance` loads). Fail-open posture (`None` on import failure → no waiver-dependent finding) preserved exactly.

AST-verified: the 5 pure-move functions are byte-identical to the merge-base hook; the 2 rewritten ones differ *only* by the rewrites above.

### Tests
`test_waivers.py` repointed to `from lib import compliance`; the now-dead `SourceFileLoader` hook shim and its `importlib` imports removed. Assertions unchanged. Full suite **884 passed / 0 failed**.

### Review gates
- ✅ Full suite: 884 passed, 0 failed (evidence anchored to HEAD)
- ✅ Cumulative-Critic: 0 findings (covers HEAD, clean)
- ✅ Independent PR reviewer: 0 blocking / 0 warning / 0 note
- Next: Chunk 5 (`lib/coverage.py`)