### PR TITLE
Consolidate critic_mode mirrors onto shared lib helpers (STH-2K8R)

### DIFF
--- a/.prawduct/artifacts/build-plan-critic-mode-consolidation.md
+++ b/.prawduct/artifacts/build-plan-critic-mode-consolidation.md
@@ -42,7 +42,11 @@ the verbose mode constants, `TestChainAnchorParity`) is explicitly OUT of scope.
 ## Status
 
 - [ ] Chunk 01: Consolidate critic_mode mirrors onto buildplan_refs/gitstate + shared Status walker
-Context: Plan written 2026-06-10; baseline suite re-run in progress. Not started.
+Context: Chunk 01 built and committed 2026-06-10 (9acb8c3). Suite 1331 passed / 0 failed
+(evidence recorded). Cumulative Critic: 0 blocking / 1 warning / 0 notes — the warning
+(verify-chunk-refs false positives on extension-less module paths in this plan's prose)
+is fixed in-place; refs verify clean. Ready for PR when the user asks. Checkbox flips at
+release via the scope=critic-mode-consolidation change-log tag (views enabled).
 
 ## Scaffolding
 
@@ -77,17 +81,17 @@ pinned mirror's rationale — see out-of-scope).
   behavior-preserving by construction — it collapses parity relationships, so it gets its
   own tests and Critic review):
   1. **`_is_metadata_path` + `_METADATA_PREFIXES`** (`lib/critic_mode.py`) → import from
-     `lib/gitstate`; update `gitstate`'s "(Mirrored in `lib/critic_mode.py`.)" comment.
+     `lib/gitstate.py`; update `gitstate`'s "(Mirrored in `lib/critic_mode.py`.)" comment.
   2. **Inline porcelain parse** in `_get_uncommitted_code_files` → keep the
      `--untracked-files=all` subprocess call, parse each line via
      `gitstate.parse_porcelain_line` (rename-dst + quote handling become canonical; the
      near-duplicate noted by the review-fixes Chunk 1 Critic goes away).
-  3. **`_git_head_sha`** (`lib/critic_mode.py`) → import from `lib/gitstate` (same
+  3. **`_git_head_sha`** (`lib/critic_mode.py`) → import from `lib/gitstate.py` (same
      semantics; gitstate's adds the standard subprocess-failure guard).
   4. **`_current_chunk_id_from_status`** (`lib/critic_mode.py`) → import from
-     `lib/buildplan_refs` (pre-verified output-equivalent: first `- [ ]` item,
+     `lib/buildplan_refs.py` (pre-verified output-equivalent: first `- [ ]` item,
      comment-aware, `None` on missing plan/section/non-`Chunk NN:` form).
-  5. **BLD-6Q1N:** extract the shared Status-section walker into `lib/buildplan_refs`
+  5. **BLD-6Q1N:** extract the shared Status-section walker into `lib/buildplan_refs.py`
      (comment-aware, next-`## `-stop — the skeleton currently copied in 5 readers), then
      fold onto it: a single `_count_build_plan_chunks` in `buildplan_refs` replacing BOTH
      duplicates (`lib/gates.py` ~L694 — keep its broad-except gate posture at the call
@@ -96,7 +100,7 @@ pinned mirror's rationale — see out-of-scope).
      `buildplan_refs._parse_build_plan_status`'s own Status loop.
   6. **Chunk-section discovery:** extract the shared chunk-section walker
      (`### Chunk <id>:` name-anchored, leading-zero-tolerant, fence-skipping,
-     sibling/`## `-stop) into `lib/buildplan_refs` and fold its 4 copies onto it:
+     sibling/`## `-stop) into `lib/buildplan_refs.py` and fold its 4 copies onto it:
      `_parse_build_plan_chunk_refs`, `_parse_build_plan_chunk_type`,
      `_parse_build_plan_chunk_trivial_rationale` (all in `buildplan_refs`), and
      `critic_mode._critic_mode_for_chunk` (the "chunk-`Type:` parser" mirror named in

--- a/.prawduct/artifacts/build-plan-critic-mode-consolidation.md
+++ b/.prawduct/artifacts/build-plan-critic-mode-consolidation.md
@@ -1,0 +1,165 @@
+<!-- Build Plan — critic-mode-consolidation (STH-2K8R + BLD-6Q1N, closes CRT-3D9K)
+     One consolidation pass deleting lib/critic_mode.py's now-unjustified mirrors
+     onto lib/buildplan_refs + lib/gitstate, plus the BLD-6Q1N shared Status-section
+     walker. Branch feature/critic-mode-consolidation. For HOW to build
+     (governance, test discipline, Critic review), read /prawduct:building.
+-->
+---
+artifact: build-plan
+version: 2
+scope: critic-mode-consolidation
+depends_on:
+  - artifact: project-preferences
+last_validated: 2026-06-10
+---
+
+## Requirements Confidence
+
+**Level:** High
+
+**Why:** Both items are audited backlog entries at `stage: ready`; the 2026-06-10 groom
+re-confirmed every code site against HEAD, and pre-plan reads this session re-verified all
+of them at v2.1.3 (`lib/critic_mode.py` L437-474/520-531/559-600/640-682/744-784,
+`lib/gates.py` L694-734, `lib/buildplan_refs.py` L31-109/505-520, `lib/gitstate.py`
+L58-102/290-304). The parity-pin learning was applied during planning: the one test-pinned
+deliberate mirror (`_chain_extendable_anchor` ↔ `gates._chain_anchor` +
+the verbose mode constants, `TestChainAnchorParity`) is explicitly OUT of scope.
+
+**Open assumptions / unknowns:**
+- [ASSUMPTION: the shared Status-section walker's exact shape (line iterator vs item
+  iterator) is an implementation choice, bounded by "all five reader call sites fold onto
+  it" — BLD-6Q1N's `_iter_status_section_items` name is a suggestion, not a contract |
+  LOW impact | user can defer]
+- [ASSUMPTION: ships as one PR to `develop` on `feature/critic-mode-consolidation` |
+  LOW impact | user can override]
+- [ASSUMPTION: `gitstate.git_status_output` stays as-is; `critic_mode` keeps its own
+  `git status --porcelain --untracked-files=all` subprocess call (the `-uall` flag is
+  load-bearing — `test_wins_for_no_plan_medium_plus_work`) and folds only the LINE PARSING
+  onto `gitstate.parse_porcelain_line` | LOW impact | user can correct]
+
+**What would raise confidence:** N/A.
+
+## Status
+
+- [ ] Chunk 01: Consolidate critic_mode mirrors onto buildplan_refs/gitstate + shared Status walker
+Context: Plan written 2026-06-10; baseline suite re-run in progress. Not started.
+
+## Scaffolding
+
+Existing repo — no scaffold. Tests run via `python3 -m pytest tests/ -q` from the repo
+root (evidence via `prawduct-hook test-evidence record`). No new dependencies.
+
+### Verification Strategy
+
+Two layers: (1) the full pytest suite — this refactor's safety net is the existing
+behavioral coverage in `tests/test_critic_mode_inference.py`, `tests/test_cumulative_gate.py`,
+and `tests/test_gitstate_porcelain.py`, which must pass UNCHANGED (tests are contracts; a
+consolidation that needs a test edit is a behavior change to stop and examine); (2) exercise
+the real surface — run `prawduct-hook infer-critic-mode` on this repo mid-chunk (dirty tree,
+active plan) and at chunk-end, and confirm the rationale/mode output is sane against the
+known git state.
+
+## Project Structure
+
+No new modules. Direction of consolidation follows the existing lib DAG
+(`gitstate` ← `buildplan_refs` ← consumers): shared helpers land in `lib/buildplan_refs.py`
+(Status-section walking, chunk-section walking) and `lib/gitstate.py` (already hosts the
+canonical `_is_metadata_path` / `parse_porcelain_line` / `_git_head_sha`); `lib/critic_mode.py`
+and `lib/gates.py` become importers. `critic_mode` must NOT import `gates` (that is the
+pinned mirror's rationale — see out-of-scope).
+
+## Build Chunks
+
+### Chunk 01: Consolidate critic_mode mirrors onto buildplan_refs/gitstate + shared Status walker
+
+- **Description:** Delete `lib/critic_mode.py`'s mirror implementations and fold all
+  Status-section reader parsing onto one shared walker, in one pass (NOT
+  behavior-preserving by construction — it collapses parity relationships, so it gets its
+  own tests and Critic review):
+  1. **`_is_metadata_path` + `_METADATA_PREFIXES`** (`lib/critic_mode.py`) → import from
+     `lib/gitstate`; update `gitstate`'s "(Mirrored in `lib/critic_mode.py`.)" comment.
+  2. **Inline porcelain parse** in `_get_uncommitted_code_files` → keep the
+     `--untracked-files=all` subprocess call, parse each line via
+     `gitstate.parse_porcelain_line` (rename-dst + quote handling become canonical; the
+     near-duplicate noted by the review-fixes Chunk 1 Critic goes away).
+  3. **`_git_head_sha`** (`lib/critic_mode.py`) → import from `lib/gitstate` (same
+     semantics; gitstate's adds the standard subprocess-failure guard).
+  4. **`_current_chunk_id_from_status`** (`lib/critic_mode.py`) → import from
+     `lib/buildplan_refs` (pre-verified output-equivalent: first `- [ ]` item,
+     comment-aware, `None` on missing plan/section/non-`Chunk NN:` form).
+  5. **BLD-6Q1N:** extract the shared Status-section walker into `lib/buildplan_refs`
+     (comment-aware, next-`## `-stop — the skeleton currently copied in 5 readers), then
+     fold onto it: a single `_count_build_plan_chunks` in `buildplan_refs` replacing BOTH
+     duplicates (`lib/gates.py` ~L694 — keep its broad-except gate posture at the call
+     site or inside the shared helper, behavior identical — and `lib/critic_mode.py`
+     ~L744); `critic_mode._chunk_ids_in_status_order`; and
+     `buildplan_refs._parse_build_plan_status`'s own Status loop.
+  6. **Chunk-section discovery:** extract the shared chunk-section walker
+     (`### Chunk <id>:` name-anchored, leading-zero-tolerant, fence-skipping,
+     sibling/`## `-stop) into `lib/buildplan_refs` and fold its 4 copies onto it:
+     `_parse_build_plan_chunk_refs`, `_parse_build_plan_chunk_type`,
+     `_parse_build_plan_chunk_trivial_rationale` (all in `buildplan_refs`), and
+     `critic_mode._critic_mode_for_chunk` (the "chunk-`Type:` parser" mirror named in
+     STH-2K8R's original body — it stays in `critic_mode` as the `**Critic mode:**`
+     field reader but uses the shared walker for section discovery).
+  7. **Docstrings:** delete the manual-sync/mirror claims that this pass makes false —
+     `critic_mode`'s module-docstring rationale ("helpers intentionally re-implemented
+     here"), the per-function "Mirrors `bin/prawduct-hook`'s …" notes on deleted bodies.
+     The hook-side rationale is dead since STH-9V4K (v2.0.14): the canonical helpers live
+     in lib siblings `critic_mode` already imports from (`core`, `coverage`).
+  - **Out of scope (deliberate):** (a) `critic_mode._chain_extendable_anchor` +
+    `_MODE_*_VERBOSE` constants ↔ `gates._chain_anchor` + `_CRITIC_MODE_*` — a deliberate,
+    test-pinned mirror (`TestChainAnchorParity`) whose rationale (keep `gates` out of the
+    shim's import graph) still holds; the parity test keeps enforcing it. (b)
+    `lib/views.py::extract_status_section` — an index-based REWRITER (needs line indices
+    to splice), not a reader; folding it would contort the walker. (c) `bin/prawduct-hook`'s
+    import-light pinned mirrors (`_read_bool_yaml_key` etc.). (d) `critic_mode`'s other
+    git helpers (`_commit_resolves`, `_commits_ahead_of_base`, `_committed_files_since`,
+    `_committed_chunk_ids`) — single implementations, not mirrors.
+- **Depends on:** none
+- **Artifacts consumed:** `.prawduct/artifacts/project-preferences.md`, backlog entries
+  STH-2K8R / BLD-6Q1N / archived CRT-3D9K
+- **Deliverables:** consolidated `lib/critic_mode.py`, `lib/buildplan_refs.py`,
+  `lib/gates.py`, `lib/gitstate.py` (comment only); new tests in `tests/`
+- **Tests:** ALL existing tests pass unchanged (the behavioral contract). New: direct
+  unit tests on the shared Status-section walker (comment skip, next-section stop, both
+  checkbox states, missing section) and the shared chunk-section walker (leading-zero
+  tolerance, fence skip, sibling-chunk stop, section-not-found); a consolidation pin
+  asserting the duplicate bodies are GONE (e.g. `critic_mode._count_build_plan_chunks is
+  buildplan_refs._count_build_plan_chunks` / `gates._count_build_plan_chunks is` the same,
+  or absence-of-def checks) so the mirrors can't quietly come back — the anti-divergence
+  analogue of `TestChainAnchorParity`, inverted: those two must stay EQUAL, these must
+  stay SINGULAR; a porcelain edge-case test through `_get_uncommitted_code_files`'s new
+  path (quoted path with spaces, rename) that the old inline parse handled implicitly.
+- **Acceptance criteria:** full suite green with zero edits to existing test assertions;
+  exactly one Status-section reader walker and one chunk-section walker remain in `lib/`
+  (grep-verifiable: the `== "## Status"` / `startswith("### Chunk ")` scan skeletons
+  appear once each in lib readers, `views.py` rewriter aside); `lib/critic_mode.py` no
+  longer defines `_is_metadata_path`, `_METADATA_PREFIXES`, `_git_head_sha`,
+  `_current_chunk_id_from_status`, or `_count_build_plan_chunks`; `critic_mode` still does
+  not import `gates`; live `prawduct-hook infer-critic-mode` run on this repo returns a
+  sane mode + rationale.
+- **Type:** cumulative-final
+- **Done when:**
+  1. Acceptance criteria met and tests pass (evidence recorded)
+  2. Committed, then `/prawduct:critic cumulative` run against `merge-base...HEAD`
+     (single-chunk plan shipping as one PR — this one review IS the chunk review, the
+     end-of-cycle synthesis, and the `/prawduct:pr create` gate) and blocking findings
+     resolved
+  3. Chunk marked `[x]` in Status (via tagged change-log entry — views enabled)
+  4. Backlog: STH-2K8R + BLD-6Q1N → `status=shipped` with `closed-by:` anchors (CRT-3D9K
+     already archived; its closure rides STH-2K8R's anchor)
+
+## Early Feedback Milestone
+
+**Milestone chunk:** 01
+**What the user can do:** N/A in the product-UI sense — internal consolidation. After the
+chunk, `lib/` has one canonical implementation per helper and the drift hazard class the
+2026-06-09 Critic flagged (third porcelain parser) is closed.
+
+## Governance Checkpoints
+
+**Commit & PR cadence:** Single chunk, `Type: cumulative-final` — commit after the suite
+is green, then one `/prawduct:critic cumulative` serves as chunk review + PR gate
+(one review run total — review wall-clock is P0). PR to `develop` via `/prawduct:pr`
+when the user asks.

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -130,38 +130,6 @@
   rather than per-file; and only raise a per-file budget when every existing token is high-ROI. Output: a
   recommendation + (likely) a revised budget model. Then it can advance to `design`/`ready`. (user)
 
-- **[STH-2K8R]** `lib/critic_mode` could consume `lib/buildplan_refs` directly instead of mirroring its build-plan helpers
-  `effort: S · impact: S · area: refactor · source: builder · added: 2026-06-07 · status: open · stage: ready · closes: CRT-3D9K · related: STH-9V4K, BLD-6Q1N · reviewed: 2026-06-10`
-
-  `lib/critic_mode.py` carries independent re-implementations of `_current_chunk_id_from_status`,
-  the chunk-`Type:` parser, and `_is_metadata_path` (and references `_parse_build_plan_status`),
-  whose stated rationale is "no dependency on `bin/prawduct-hook` — re-implemented to stay importable
-  from the slash-command shim" (critic_mode.py docstring ~L46). STH-9V4K ch.2–3 moved those helpers
-  into `lib/gitstate` + `lib/buildplan_refs`, which `critic_mode` *already* imports siblings from
-  (`from .core import resolve_build_plan_path`). So the mirror's reason-to-exist is now gone:
-  `critic_mode` could `from .buildplan_refs import _current_chunk_id_from_status` (etc.) and
-  `from .gitstate import _is_metadata_path`, deleting the duplicate bodies + their manual-sync
-  docstrings. Defer until the decomposition (ch.4–7) lands so the lib surface is stable. NOT a
-  behavior-preserving move (it changes critic_mode's structure + collapses a parity relationship),
-  so it needs its own tests + Critic pass — kept out of ch.3 for scope discipline. Filed from the
-  ch.3 buildplan_refs extraction on 2026-06-07. (builder)
-
-  Critic note (review-fixes Chunk 1, 2026-06-09): lib/critic_mode.py contains a third porcelain
-  parser that near-duplicates the new shared gitstate.parse_porcelain_line (quoted paths, renames);
-  fold it onto the shared helper when consolidating this item's lib/critic_mode mirrors.
-
-  Groom 2026-06-10: UNBLOCKED — the defer-until condition ("until the decomposition (ch.4–7) lands")
-  is satisfied: STH-9V4K shipped in v2.0.14 (archived). The lib surface is stable; this is now
-  directly actionable.
-
-  — merged from CRT-3D9K (2026-06-10) — this item's consolidation closes CRT-3D9K by construction
-  (CRT-3D9K's own text says so); CRT-3D9K's full original body is preserved on its archived entry.
-  Audit 2026-06-10 confirmed critic_mode still carries its own _current_chunk_id_from_status
-  (~L640), _count_build_plan_chunks (~L744, duplicate of lib/gates.py ~L633 — the BLD-6Q1N pair),
-  and an inline porcelain parse in _get_uncommitted_code_files (~L462-474) that does NOT use
-  gitstate.parse_porcelain_line despite importing gitstate. One consolidation pass closes STH-2K8R +
-  CRT-3D9K + the porcelain remnant; do BLD-6Q1N in the same pass.
-
 - **[ADR-7X2M]** Adversarial review agent (4th review-agent role) — RFC: systematic edge-case / attack-surface generation
   `effort: L · impact: M · area: methodology · source: user · added: 2026-06-06 · status: open · stage: requirements · related: CRT-9V4T, PRR-4M9T, JAN-4F7M · reviewed: 2026-06-10`
 
@@ -325,18 +293,6 @@
 
   v1.4 Chunk 02 (F3) shipped file-path verification only; the original plan also called for symbol (function/class names) and backlog-ID verification. Deferred during build because (a) symbols in prose are often approximate (`parse_func` vs implementation's `_parse_func`) so strict grep produces false positives requiring fuzzy match; (b) this project's backlog has no formal IDs (bullet titles, not e.g. `BL-123`), so the check would be inert here and need per-project ID convention. Add when a project surfaces a concrete need: define matching rules (substring grep across configured source roots for symbols; project-preferences `backlog_id_pattern` regex for backlog refs) and extend `_parse_build_plan_chunk_refs` to return `symbols` and `backlog_refs` lists alongside `file_paths`. Note: this project now HAS formal backlog IDs (`[PFX-XXXX]`) post-migration, so the backlog-ID half is newly actionable. Filed from /critic NOTE on 2026-05-18. (critic)
 
-- **[BLD-6Q1N]** Extract `_iter_status_section_items` shared parser for build-plan Status
-  `effort: S · impact: S · area: build-plan · source: critic · added: 2026-05-08 · status: open · stage: ready · refs: lib/gates.py, lib/critic_mode.py, lib/buildplan_refs.py · reviewed: 2026-06-10`
-
-  `_count_build_plan_chunks` (bin/prawduct-hook lines ~2073-2113, added v1.3.13) duplicates the Status-section parsing skeleton of `_parse_build_plan_status` (lines ~1021-1099): same `## Status` detection, same HTML-comment skip, same exit on next `## ` heading. Two callers is borderline; if a third caller appears (e.g., a future stop-hook check that needs chunk metadata), extract to `_iter_status_section_items(prawduct_dir) -> Iterator[StatusItem]` and refactor both call sites. Filed from /critic NOTE on 2026-05-08. (critic)
-
-  Groom 2026-06-10 — refs refreshed post hook-decomposition (STH-9V4K, v2.0.14) and the premise is
-  now STRONGER: `_count_build_plan_chunks` exists as near-duplicate copies in BOTH `lib/gates.py`
-  (~L633) and `lib/critic_mode.py` (~L744), alongside `_parse_build_plan_status` in
-  `lib/buildplan_refs.py` (~L31). The third-caller threshold the item set is effectively met;
-  natural home for the shared iterator is lib/buildplan_refs. Overlaps the STH-2K8R consolidation —
-  consider doing both in one pass.
-
 - **[MET-9K4R]** Workflow-values schema/validator
   `effort: S · impact: S · area: methodology · source: critic · added: 2026-05-01 · status: open · stage: design · reviewed: 2026-06-10`
 
@@ -476,6 +432,56 @@
   (invoker writes the requested mode to a .prawduct dotfile; helper reads + deletes it). (builder)
 
 ## Promoted
+
+- **[STH-2K8R]** `lib/critic_mode` could consume `lib/buildplan_refs` directly instead of mirroring its build-plan helpers
+  `effort: S · impact: S · area: refactor · source: builder · added: 2026-06-07 · status: promoted · stage: ready · closes: CRT-3D9K · related: STH-9V4K, BLD-6Q1N · reviewed: 2026-06-10`
+
+  `lib/critic_mode.py` carries independent re-implementations of `_current_chunk_id_from_status`,
+  the chunk-`Type:` parser, and `_is_metadata_path` (and references `_parse_build_plan_status`),
+  whose stated rationale is "no dependency on `bin/prawduct-hook` — re-implemented to stay importable
+  from the slash-command shim" (critic_mode.py docstring ~L46). STH-9V4K ch.2–3 moved those helpers
+  into `lib/gitstate` + `lib/buildplan_refs`, which `critic_mode` *already* imports siblings from
+  (`from .core import resolve_build_plan_path`). So the mirror's reason-to-exist is now gone:
+  `critic_mode` could `from .buildplan_refs import _current_chunk_id_from_status` (etc.) and
+  `from .gitstate import _is_metadata_path`, deleting the duplicate bodies + their manual-sync
+  docstrings. Defer until the decomposition (ch.4–7) lands so the lib surface is stable. NOT a
+  behavior-preserving move (it changes critic_mode's structure + collapses a parity relationship),
+  so it needs its own tests + Critic pass — kept out of ch.3 for scope discipline. Filed from the
+  ch.3 buildplan_refs extraction on 2026-06-07. (builder)
+
+  Critic note (review-fixes Chunk 1, 2026-06-09): lib/critic_mode.py contains a third porcelain
+  parser that near-duplicates the new shared gitstate.parse_porcelain_line (quoted paths, renames);
+  fold it onto the shared helper when consolidating this item's lib/critic_mode mirrors.
+
+  Groom 2026-06-10: UNBLOCKED — the defer-until condition ("until the decomposition (ch.4–7) lands")
+  is satisfied: STH-9V4K shipped in v2.0.14 (archived). The lib surface is stable; this is now
+  directly actionable.
+
+  — merged from CRT-3D9K (2026-06-10) — this item's consolidation closes CRT-3D9K by construction
+  (CRT-3D9K's own text says so); CRT-3D9K's full original body is preserved on its archived entry.
+  Audit 2026-06-10 confirmed critic_mode still carries its own _current_chunk_id_from_status
+  (~L640), _count_build_plan_chunks (~L744, duplicate of lib/gates.py ~L633 — the BLD-6Q1N pair),
+  and an inline porcelain parse in _get_uncommitted_code_files (~L462-474) that does NOT use
+  gitstate.parse_porcelain_line despite importing gitstate. One consolidation pass closes STH-2K8R +
+  CRT-3D9K + the porcelain remnant; do BLD-6Q1N in the same pass.
+
+  Promoted 2026-06-10 into `artifacts/build-plan-critic-mode-consolidation.md` (branch
+  `feature/critic-mode-consolidation`) — one consolidation chunk covering STH-2K8R + BLD-6Q1N.
+
+- **[BLD-6Q1N]** Extract `_iter_status_section_items` shared parser for build-plan Status
+  `effort: S · impact: S · area: build-plan · source: critic · added: 2026-05-08 · status: promoted · stage: ready · refs: lib/gates.py, lib/critic_mode.py, lib/buildplan_refs.py · related: STH-2K8R · reviewed: 2026-06-10`
+
+  `_count_build_plan_chunks` (bin/prawduct-hook lines ~2073-2113, added v1.3.13) duplicates the Status-section parsing skeleton of `_parse_build_plan_status` (lines ~1021-1099): same `## Status` detection, same HTML-comment skip, same exit on next `## ` heading. Two callers is borderline; if a third caller appears (e.g., a future stop-hook check that needs chunk metadata), extract to `_iter_status_section_items(prawduct_dir) -> Iterator[StatusItem]` and refactor both call sites. Filed from /critic NOTE on 2026-05-08. (critic)
+
+  Groom 2026-06-10 — refs refreshed post hook-decomposition (STH-9V4K, v2.0.14) and the premise is
+  now STRONGER: `_count_build_plan_chunks` exists as near-duplicate copies in BOTH `lib/gates.py`
+  (~L633) and `lib/critic_mode.py` (~L744), alongside `_parse_build_plan_status` in
+  `lib/buildplan_refs.py` (~L31). The third-caller threshold the item set is effectively met;
+  natural home for the shared iterator is lib/buildplan_refs. Overlaps the STH-2K8R consolidation —
+  consider doing both in one pass.
+
+  Promoted 2026-06-10 into `artifacts/build-plan-critic-mode-consolidation.md` (branch
+  `feature/critic-mode-consolidation`) — one consolidation chunk covering STH-2K8R + BLD-6Q1N.
 
 ## Archive
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,50 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-06-10: Consolidate critic_mode's mirrored helpers onto buildplan_refs/gitstate + shared build-plan walkers (STH-2K8R + BLD-6Q1N)
+
+<!-- prawduct: chunks=01 | type=refactor | scope=critic-mode-consolidation -->
+
+**Why:** `lib/critic_mode.py` carried five re-implementations whose stated
+rationale — "no dependency on `bin/prawduct-hook`; re-implemented to stay
+importable from the slash-command shim" — died when STH-9V4K (v2.0.14) moved
+the canonical helpers into lib siblings `critic_mode` already imports from.
+The copies were live drift hazards: the 2026-06-09 review-fixes Critic
+flagged the inline porcelain parse as a third parser that silently lacked
+`parse_porcelain_line`'s quoted-path/rename hardening rationale trail, and
+the Status-walk skeleton existed in five places (BLD-6Q1N's third-caller
+threshold met twice over).
+
+**What:** One consolidation pass, not behavior-preserving by construction
+(it collapses parity relationships). (1) `critic_mode` deleted
+`_is_metadata_path`/`_METADATA_PREFIXES`, `_git_head_sha`,
+`_current_chunk_id_from_status`, `_chunk_ids_in_status_order`, and
+`_count_build_plan_chunks`; it now consumes `lib.gitstate` and
+`lib.buildplan_refs`. (2) `_get_uncommitted_code_files` keeps its own
+`-uall` git call but parses lines via `gitstate.parse_porcelain_line`.
+(3) BLD-6Q1N: `buildplan_refs` gains the canonical Status-section walkers
+(`_iter_status_section_lines`/`_iter_status_section_items`) and chunk-section
+walker (`_chunk_section_lines`); `_count_build_plan_chunks` and
+`_chunk_ids_in_status_order` live there now; `gates.py` deleted its duplicate
+counter and delegates. All five Status readers and all four chunk-section
+parsers fold onto the shared walkers. (4) Shared-helper read errors now
+catch `(OSError, UnicodeDecodeError)` — unifying gates' broad-except posture
+and critic_mode's OSError-only posture (a malformed-encoding plan previously
+crashed critic_mode's copy, returned (0,0) from gates'). (5) Deliberately
+NOT consolidated: `_chain_extendable_anchor` ↔ `gates._chain_anchor` + the
+verbose mode constants — a test-pinned mirror (`TestChainAnchorParity`)
+whose rationale (keep `gates` out of the shim's import graph) still holds;
+`lib/views.py`'s index-based Status rewriter (needs positions, not a
+reader's view); the hook's import-light pinned mirrors. (6) New
+`tests/test_buildplan_walkers.py`: walker unit coverage, porcelain edge
+cases through the consolidated parse path, and consolidation pins — the
+inverse of `TestChainAnchorParity`: that mirror must stay equal, these must
+stay singular (source-scan + namespace assertions). Two existing
+metadata-allowlist pins repointed from `lib.critic_mode` to the canonical
+`lib.gitstate` home, assertions unchanged. Net −150 lines of production
+code; closes STH-2K8R, BLD-6Q1N, and CRT-3D9K (by construction — merged
+into STH-2K8R).
+
 ## 2026-06-10: /prawduct:critic explicit mode argument — forward to the helper, never self-parse (CRT-2N7V)
 
 <!-- prawduct: chunks=03 | type=fix | release=v2.1.3 | status=shipped | scope=gate-hardening -->

--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -500,6 +500,10 @@ views_enabled: true
 # in v2.1.3 (#92, same day), regen-views flipped its ## Status via the
 # scope=gate-hardening tags and the pointer is cleared — no release-pending
 # plans remain. The build-plan file is retained as a historical artifact.
+# 2026-06-10: pointed at the in-progress critic-mode-consolidation plan
+# (STH-2K8R + BLD-6Q1N, closes CRT-3D9K; branch feature/critic-mode-consolidation).
+
+active_build_plan: artifacts/build-plan-critic-mode-consolidation.md
 
 # =============================================================================
 # COVERAGE EVIDENCE (opt-in, v1.4+)

--- a/lib/buildplan_refs.py
+++ b/lib/buildplan_refs.py
@@ -28,6 +28,104 @@ from . import gitstate
 from .core import resolve_build_plan_path
 
 
+def _iter_status_section_lines(content: str):
+    """Yield stripped lines inside the build plan's ``## Status`` section.
+
+    The one canonical Status-section walk (BLD-6Q1N): starts after a line that
+    is exactly ``## Status``, stops at the next ``## `` heading, and skips
+    HTML-comment spans (``<!-- ... -->``, multi-line). This skeleton was
+    previously copied in five readers across ``buildplan_refs`` / ``gates`` /
+    ``critic_mode``; all of them now fold onto this generator. (The index-based
+    Status *rewriter* in ``lib/views.py`` is deliberately separate — it splices
+    lines back into the file, so it needs positions, not a reader's view.)
+    """
+    in_status = False
+    in_comment = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "## Status":
+            in_status = True
+            continue
+        if not in_status:
+            continue
+        if stripped.startswith("## ") and stripped != "## Status":
+            break
+        if "<!--" in stripped:
+            in_comment = True
+        if "-->" in stripped:
+            in_comment = False
+            continue
+        if in_comment:
+            continue
+        yield stripped
+
+
+def _iter_status_section_items(content: str):
+    """Yield ``(checked, text)`` for each ``- [ ]`` / ``- [x]`` Status item."""
+    for stripped in _iter_status_section_lines(content):
+        if stripped.startswith("- [ ]"):
+            yield False, stripped[5:].strip()
+        elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
+            yield True, stripped[5:].strip()
+
+
+def _chunk_id_from_item_text(text: str) -> str | None:
+    """``"Chunk 02: name"`` → ``"02"``; ``None`` for non-``Chunk NN:`` items."""
+    if not text.startswith("Chunk "):
+        return None
+    chunk_id = text[len("Chunk "):].split(":", 1)[0].strip()
+    return chunk_id or None
+
+
+def _count_build_plan_chunks(prawduct_dir: Path) -> tuple[int, int]:
+    """Count chunks in the active build plan's Status section.
+
+    Resolves the plan via the ``active_build_plan:`` pointer (falls back to
+    ``artifacts/build-plan.md``), so scope-named plans are counted too.
+    Returns ``(total, complete)``; ``(0, 0)`` if the plan or its Status section
+    is missing or unreadable. The single canonical implementation — consumed by
+    ``lib.gates`` (end-of-cycle synthesis gate) and ``lib.critic_mode`` (mode
+    inference), which carried near-duplicate copies until STH-2K8R/BLD-6Q1N.
+    """
+    plan_path = resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return 0, 0
+    try:
+        content = plan_path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return 0, 0
+    total = 0
+    complete = 0
+    for checked, _text in _iter_status_section_items(content):
+        total += 1
+        if checked:
+            complete += 1
+    return total, complete
+
+
+def _chunk_ids_in_status_order(prawduct_dir: Path) -> list[str]:
+    """Raw chunk ids (e.g. ``"01"``) in build-plan Status order, both states.
+
+    Returns the ordered ``Chunk <id>:`` ids for ``- [ ]`` and ``- [x]`` items
+    alike, so a git-derived progress count can map to the right current chunk
+    (CRT-7B4M — see ``lib.critic_mode._git_aware_progress``, its consumer).
+    Empty list when the plan or its Status section is missing or unreadable.
+    """
+    plan_path = resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return []
+    try:
+        content = plan_path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return []
+    ids: list[str] = []
+    for _checked, text in _iter_status_section_items(content):
+        cid = _chunk_id_from_item_text(text)
+        if cid:
+            ids.append(cid)
+    return ids
+
+
 def _parse_build_plan_status(prawduct_dir: Path) -> dict[str, str]:
     """Parse work context from build-plan.md Status section.
 
@@ -69,27 +167,8 @@ def _parse_build_plan_status(prawduct_dir: Path) -> dict[str, str]:
                 break
 
         # Parse Status section for current chunk and context
-        in_status = False
-        in_comment = False
         has_any_items = False
-        for line in content.splitlines():
-            stripped = line.strip()
-            if stripped == "## Status":
-                in_status = True
-                continue
-            if not in_status:
-                continue
-            # Exit on next section
-            if stripped.startswith("## ") and stripped != "## Status":
-                break
-            # Track HTML comments (multi-line)
-            if "<!--" in stripped:
-                in_comment = True
-            if "-->" in stripped:
-                in_comment = False
-                continue
-            if in_comment:
-                continue
+        for stripped in _iter_status_section_lines(content):
             # Current chunk = first unchecked item
             if stripped.startswith("- [ ]") and "current_chunk" not in result:
                 has_any_items = True
@@ -159,6 +238,51 @@ def _looks_like_file_path(token: str) -> bool:
     return True
 
 
+def _chunk_section_lines(
+    content: str, chunk_id: str
+) -> tuple[bool, list[tuple[int, str]]]:
+    """Locate the ``### Chunk <chunk_id>:`` section and return its body lines.
+
+    The one canonical chunk-section walk: name-anchored with leading-zero
+    tolerance (``"02"`` matches ``### Chunk 2:`` and vice versa), stops at the
+    next sibling ``### Chunk`` or ``## `` heading, and drops fenced code blocks
+    (project-structure diagrams aren't load-bearing prose). Returns
+    ``(found, [(line_num, raw_line), ...])`` with 1-based line numbers into
+    ``content``. This skeleton was previously copied in the three chunk-field
+    parsers below and ``lib.critic_mode``'s ``**Critic mode:**`` reader; all
+    four now fold onto it.
+    """
+    target = chunk_id.lstrip("0") or "0"
+    in_section = False
+    in_fence = False
+    section_lines: list[tuple[int, str]] = []
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("### Chunk "):
+            # Heading format: "### Chunk NN: Name"
+            rest = stripped[len("### Chunk "):]
+            head = rest.split(":", 1)[0].strip()
+            head_norm = head.lstrip("0") or "0"
+            if in_section:
+                # Entered a sibling chunk; stop accumulating.
+                break
+            if head_norm == target:
+                in_section = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            # Left the Build Chunks section entirely.
+            break
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        section_lines.append((line_num, line))
+    return in_section, section_lines
+
+
 def _parse_build_plan_chunk_refs(prawduct_dir: Path, chunk_id: str) -> dict:
     """Extract backticked file-path references from a single chunk's section
     in ``.prawduct/artifacts/build-plan.md``.
@@ -187,39 +311,8 @@ def _parse_build_plan_chunk_refs(prawduct_dir: Path, chunk_id: str) -> dict:
         result["error"] = f"unreadable build-plan: {exc}"
         return result
 
-    # Normalize chunk_id: strip leading zeros for matching ("02" matches
-    # "### Chunk 2:" and vice versa) but report the original in errors.
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    section_lines: list[tuple[int, str]] = []
-    for line_num, line in enumerate(content.splitlines(), start=1):
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            # Heading format: "### Chunk NN: Name"
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                # Entered a sibling chunk; stop accumulating.
-                break
-            if head_norm == target:
-                in_section = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            # Left the Build Chunks section entirely.
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        section_lines.append((line_num, line))
-
-    if not in_section and not section_lines:
+    found, section_lines = _chunk_section_lines(content, chunk_id)
+    if not found:
         result["error"] = f"chunk {chunk_id!r} not found in build-plan"
         return result
 
@@ -263,9 +356,9 @@ def _parse_build_plan_chunk_type(
     Unknown values surface as ``(None, "unknown type: <value>")`` so the
     author fixes the typo instead of getting silent fall-through.
 
-    Section discovery mirrors ``_parse_build_plan_chunk_refs`` — name-anchored
-    on ``### Chunk <chunk_id>:`` with leading-zero tolerance; fenced code
-    blocks are skipped.
+    Section discovery is the shared ``_chunk_section_lines`` walker —
+    name-anchored on ``### Chunk <chunk_id>:`` with leading-zero tolerance;
+    fenced code blocks are skipped.
     """
     plan_path = resolve_build_plan_path(prawduct_dir)
     if not plan_path.is_file():
@@ -275,40 +368,16 @@ def _parse_build_plan_chunk_type(
     except OSError as exc:
         return None, f"unreadable build-plan: {exc}"
 
-    target = chunk_id.lstrip("0") or "0"
+    found, section_lines = _chunk_section_lines(content, chunk_id)
+    if not found:
+        return None, f"chunk {chunk_id!r} not found in build-plan"
 
-    in_section = False
-    in_fence = False
-    section_found = False
     declared: str | None = None
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                break  # hit sibling chunk
-            if head_norm == target:
-                in_section = True
-                section_found = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
+    for _line_num, line in section_lines:
         m = _BUILD_PLAN_TYPE_RE.match(line)
         if m:
             declared = m.group(1)
             break
-
-    if not section_found:
-        return None, f"chunk {chunk_id!r} not found in build-plan"
 
     if declared is None:
         return "code", None  # fail-closed default
@@ -329,9 +398,9 @@ def _parse_build_plan_chunk_trivial_rationale(
     a list-item / heading prefix) is joined into a single string until the
     next field.
 
-    Section discovery mirrors ``_parse_build_plan_chunk_type`` —
-    name-anchored on ``### Chunk <chunk_id>:`` with leading-zero
-    tolerance; fenced code blocks are skipped.
+    Section discovery is the shared ``_chunk_section_lines`` walker —
+    name-anchored on ``### Chunk <chunk_id>:`` with leading-zero tolerance;
+    fenced code blocks are skipped.
     """
     plan_path = resolve_build_plan_path(prawduct_dir)
     if not plan_path.is_file():
@@ -341,34 +410,14 @@ def _parse_build_plan_chunk_trivial_rationale(
     except OSError as exc:
         return None, f"unreadable build-plan: {exc}"
 
-    target = chunk_id.lstrip("0") or "0"
+    found, section_lines = _chunk_section_lines(content, chunk_id)
+    if not found:
+        return None, f"chunk {chunk_id!r} not found in build-plan"
 
-    in_section = False
-    in_fence = False
-    section_found = False
     capturing = False
     rationale_lines: list[str] = []
-    for line in content.splitlines():
+    for _line_num, line in section_lines:
         stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                break  # hit sibling chunk
-            if head_norm == target:
-                in_section = True
-                section_found = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
         m = _BUILD_PLAN_TRIVIAL_RATIONALE_RE.match(line)
         if m:
             capturing = True
@@ -388,8 +437,6 @@ def _parse_build_plan_chunk_trivial_rationale(
             if stripped:
                 rationale_lines.append(stripped)
 
-    if not section_found:
-        return None, f"chunk {chunk_id!r} not found in build-plan"
     if not capturing:
         return None, (
             "missing-rationale: Type: trivial requires non-empty "

--- a/lib/critic_mode.py
+++ b/lib/critic_mode.py
@@ -51,11 +51,14 @@ cumulative would undo that. The guard preserves the spec's intent (run
 cumulative when about to PR) without the cost.
 
 Pure-ish: takes ``project_dir``, reads files under it, runs ``git``
-subprocesses against it. Deterministic given fixed git state. Imports
-only from the stdlib + ``lib.core`` (the build-plan resolver) — no
-dependency on ``bin/prawduct-hook``; its metadata/build-plan helpers are
-intentionally re-implemented here to keep the module lightweight and
-importable from the slash-command shim.
+subprocesses against it. Deterministic given fixed git state. Imports only
+from the stdlib + light lib siblings (``core``, ``coverage``, ``gitstate``,
+``buildplan_refs``) — never ``bin/prawduct-hook``, and never ``lib.gates``
+(keeping gates out of this module's import graph is why the chain-anchor
+helper below is a deliberate, test-pinned mirror rather than an import).
+The metadata/build-plan helpers once re-implemented here moved to their
+canonical homes in ``gitstate``/``buildplan_refs`` (STH-2K8R); this module
+consumes them.
 """
 
 from __future__ import annotations
@@ -65,6 +68,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from . import buildplan_refs, gitstate
 from .core import resolve_build_plan_path, read_bool_yaml_key
 from .coverage import _resolve_base_branch
 
@@ -103,21 +107,6 @@ _BUILD_PLAN_CRITIC_MODE_RE = re.compile(
 # Capital-C + digits matches the "Chunk NN" commit convention without
 # false-matching prose like "10-chunk plan" (CRT-7B4M).
 _CHUNK_COMMIT_RE = re.compile(r"Chunk\s+(\d+)")
-
-# Mirrors ``_METADATA_PREFIXES`` in ``bin/prawduct-hook``. Kept in sync
-# manually — duplication is acceptable for this small set; extracting to
-# ``lib.core`` would expand core's surface for one consumer.
-#
-# Plugin-only metadata: product-owned state and the committed install
-# reference. The file-sync-era entries (``.claude/skills/`` for synced
-# framework skills, ``tools/product-hook``) are intentionally absent — post
-# v2.0.x a plugin repo never carries them, and a product's *own* skill under
-# ``.claude/skills/`` is product code that must be gated, not excused.
-_METADATA_PREFIXES = (
-    ".prawduct/",
-    ".claude/settings.json",
-)
-
 
 def infer_mode(
     project_dir: Path | str,
@@ -160,13 +149,13 @@ def infer_mode(
     # and "first unchecked" is always Chunk 01, which would pin every chunk's
     # mode to Chunk 01's declaration. When that's the case, derive progress from
     # git instead (CRT-7B4M); otherwise use the checkboxes.
-    total, checkbox_complete = _count_build_plan_chunks(prawduct_dir)
+    total, checkbox_complete = buildplan_refs._count_build_plan_chunks(prawduct_dir)
     git_progress = _git_aware_progress(project_dir, prawduct_dir, total)
     if git_progress is not None:
         complete, current_chunk_id = git_progress
     else:
         complete = checkbox_complete
-        current_chunk_id = _current_chunk_id_from_status(prawduct_dir)
+        current_chunk_id = buildplan_refs._current_chunk_id_from_status(prawduct_dir)
 
     # Plan-level override: the CURRENT chunk may declare a ``**Critic mode:**``
     # field. Honor it here (above inference, below explicit args) so a
@@ -277,8 +266,10 @@ def _rule_verify_resolutions_fires(
 def _chain_extendable_anchor(data: dict) -> str | None:
     """Return the cumulative anchor a verify pass over ``data`` would extend.
 
-    Mirrors ``lib.gates._chain_anchor`` (CRT-4J8W) — kept in lockstep like
-    the other hook/gates mirrors in this module. Chain-extendable: a
+    Mirrors ``lib.gates._chain_anchor`` (CRT-4J8W) — the one DELIBERATE
+    mirror left in this module (importing ``gates`` here would widen the
+    slash-command shim's import surface), pinned by
+    ``TestChainAnchorParity`` rather than by comment. Chain-extendable: a
     ``cumulative``-mode record (anchor = its own ``commit_reviewed``) or a
     ``verify-resolutions``-mode record carrying a valid
     ``extends_cumulative`` (multi-link propagation). ``None`` otherwise.
@@ -339,7 +330,7 @@ def _rule_postfix_chain_fires(prawduct_dir: Path, project_dir: Path) -> str:
         return ""
     delta = {
         f for f in _committed_files_since(project_dir, commit_reviewed)
-        if not _is_metadata_path(f)
+        if not gitstate._is_metadata_path(f)
     }
     if not any(not f.endswith(".md") for f in delta):
         return ""
@@ -377,7 +368,7 @@ def _rule_cumulative_fires(
     # with an extends_cumulative anchor — CRT-4J8W). Without the chain arm,
     # no-args /prawduct:critic right after a successful chain pass would
     # recommend a pointless full cumulative.
-    head_sha = _git_head_sha(project_dir)
+    head_sha = gitstate._git_head_sha(project_dir)
     findings_path = prawduct_dir / ".critic-findings.json"
     if head_sha and findings_path.is_file():
         try:
@@ -434,11 +425,6 @@ def _rule_final_fires(project_dir: Path, total: int, complete: int) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _is_metadata_path(filepath: str) -> bool:
-    """Mirrors ``bin/prawduct-hook``'s ``_is_metadata_path``."""
-    return any(filepath.startswith(p) for p in _METADATA_PREFIXES)
-
-
 def _get_uncommitted_code_files(project_dir: Path) -> set[str]:
     """Return uncommitted-change file paths (vs HEAD), minus metadata.
 
@@ -447,7 +433,10 @@ def _get_uncommitted_code_files(project_dir: Path) -> set[str]:
     ``--untracked-files=all`` so a new directory expands to per-file
     entries rather than collapsing to ``?? subdir/`` (the default
     ``--untracked-files=normal`` undercounts new directories — caught
-    by ``test_wins_for_no_plan_medium_plus_work``).
+    by ``test_wins_for_no_plan_medium_plus_work``). The ``-uall`` flag is
+    why this keeps its own ``git status`` call instead of
+    ``gitstate.git_status_output``; line parsing (quoted paths, renames)
+    is ``gitstate.parse_porcelain_line``.
     """
     proc = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=all"],
@@ -460,16 +449,11 @@ def _get_uncommitted_code_files(project_dir: Path) -> set[str]:
         return set()
     files: set[str] = set()
     for line in proc.stdout.splitlines():
-        if len(line) < 4:
+        parsed = gitstate.parse_porcelain_line(line)
+        if parsed is None:
             continue
-        path = line[3:].strip()
-        if " -> " in path:
-            path = path.split(" -> ", 1)[1].strip()
-        # Strip optional surrounding quotes (porcelain quotes paths
-        # containing special chars).
-        if path.startswith('"') and path.endswith('"'):
-            path = path[1:-1]
-        if path and not _is_metadata_path(path):
+        path = parsed[2]
+        if not gitstate._is_metadata_path(path):
             files.add(path)
     return files
 
@@ -517,20 +501,6 @@ def _commits_ahead_of_base(project_dir: Path, base: str) -> int:
         return -1
 
 
-def _git_head_sha(project_dir: Path) -> str:
-    """``git rev-parse HEAD`` or ``""`` on failure."""
-    proc = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if proc.returncode != 0:
-        return ""
-    return proc.stdout.strip()
-
-
 def _committed_chunk_ids(project_dir: Path, base: str) -> set[str]:
     """Normalized chunk ids referenced in commit subjects on ``base..HEAD``.
 
@@ -553,50 +523,6 @@ def _committed_chunk_ids(project_dir: Path, base: str) -> set[str]:
     for subject in proc.stdout.splitlines():
         for m in _CHUNK_COMMIT_RE.finditer(subject):
             ids.add(m.group(1).lstrip("0") or "0")
-    return ids
-
-
-def _chunk_ids_in_status_order(prawduct_dir: Path) -> list[str]:
-    """Raw chunk ids (e.g. ``"01"``) in build-plan Status order, both states.
-
-    Parses the ``## Status`` section like :func:`_count_build_plan_chunks` but
-    returns the ordered ``Chunk <id>:`` ids (for ``- [ ]`` and ``- [x]`` alike),
-    so a git-derived progress count can map to the right current chunk.
-    """
-    plan_path = resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        return []
-    try:
-        content = plan_path.read_text()
-    except OSError:
-        return []
-    ids: list[str] = []
-    in_status = False
-    in_comment = False
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped == "## Status":
-            in_status = True
-            continue
-        if not in_status:
-            continue
-        if stripped.startswith("## ") and stripped != "## Status":
-            break
-        if "<!--" in stripped:
-            in_comment = True
-        if "-->" in stripped:
-            in_comment = False
-            continue
-        if in_comment:
-            continue
-        for marker in ("- [ ]", "- [x]", "- [X]"):
-            if stripped.startswith(marker):
-                rest = stripped[len(marker):].strip()
-                if rest.startswith("Chunk "):
-                    cid = rest[len("Chunk "):].split(":", 1)[0].strip()
-                    if cid:
-                        ids.append(cid)
-                break
     return ids
 
 
@@ -628,58 +554,13 @@ def _git_aware_progress(
     committed = _committed_chunk_ids(project_dir, base)
     if not committed:
         return None
-    status_ids = _chunk_ids_in_status_order(prawduct_dir)
+    status_ids = buildplan_refs._chunk_ids_in_status_order(prawduct_dir)
     complete = sum(1 for cid in status_ids if (cid.lstrip("0") or "0") in committed)
     current = next(
         (cid for cid in status_ids if (cid.lstrip("0") or "0") not in committed),
         None,
     )
     return complete, current
-
-
-def _current_chunk_id_from_status(prawduct_dir: Path) -> str | None:
-    """Return the chunk id of the first ``- [ ]`` item in the build-plan
-    Status section, e.g. ``"02"`` for ``- [ ] Chunk 02: widget``.
-
-    Mirrors ``bin/prawduct-hook``'s ``_current_chunk_id_from_status`` (via
-    ``_parse_build_plan_status``) so the inference helper, the stop hook,
-    and the Critic helper agree on "which chunk is current." Returns
-    ``None`` when there is no plan, no Status section, all chunks are
-    complete, or the current item isn't in the ``Chunk NN:`` form.
-    """
-    plan_path = resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        return None
-    try:
-        content = plan_path.read_text()
-    except OSError:
-        return None
-
-    in_status = False
-    in_comment = False
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped == "## Status":
-            in_status = True
-            continue
-        if not in_status:
-            continue
-        if stripped.startswith("## ") and stripped != "## Status":
-            break
-        if "<!--" in stripped:
-            in_comment = True
-        if "-->" in stripped:
-            in_comment = False
-            continue
-        if in_comment:
-            continue
-        if stripped.startswith("- [ ]"):
-            current = stripped[5:].strip()
-            if not current.startswith("Chunk "):
-                return None
-            chunk_id = current[len("Chunk "):].split(":", 1)[0].strip()
-            return chunk_id or None
-    return None
 
 
 def _critic_mode_for_chunk(prawduct_dir: Path, chunk_id: str | None) -> str | None:
@@ -694,9 +575,9 @@ def _critic_mode_for_chunk(prawduct_dir: Path, chunk_id: str | None) -> str | No
 
     ``chunk_id`` is resolved by the caller — git-aware on a views-enabled
     feature branch (CRT-7B4M), otherwise the first ``- [ ]`` chunk via
-    :func:`_current_chunk_id_from_status`. Section discovery mirrors
-    ``bin/prawduct-hook``'s ``_parse_build_plan_chunk_type``: name-anchored on
-    ``### Chunk <id>:`` with leading-zero tolerance, fenced code blocks
+    ``buildplan_refs._current_chunk_id_from_status``. Section discovery is
+    the shared ``buildplan_refs._chunk_section_lines`` walker: name-anchored
+    on ``### Chunk <id>:`` with leading-zero tolerance, fenced code blocks
     skipped, stop at the next sibling chunk or top-level section.
     """
     if chunk_id is None:
@@ -710,75 +591,10 @@ def _critic_mode_for_chunk(prawduct_dir: Path, chunk_id: str | None) -> str | No
     except OSError:
         return None
 
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                break  # hit sibling chunk
-            if head_norm == target:
-                in_section = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
+    _found, section_lines = buildplan_refs._chunk_section_lines(content, chunk_id)
+    for _line_num, line in section_lines:
         m = _BUILD_PLAN_CRITIC_MODE_RE.match(line)
         if m:
             token = m.group(1)
             return token if token in _VALID_ARG_MODES else None
     return None
-
-
-def _count_build_plan_chunks(prawduct_dir: Path) -> tuple[int, int]:
-    """Count chunks in the active build plan's Status section.
-
-    Mirrors ``bin/prawduct-hook``'s ``_count_build_plan_chunks``. Resolves the
-    plan via the ``active_build_plan:`` pointer (falls back to
-    ``artifacts/build-plan.md``), so scope-named plans are counted too.
-    Returns ``(total, complete)``; ``(0, 0)`` if plan/Status absent.
-    """
-    plan_path = resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        return 0, 0
-    try:
-        content = plan_path.read_text()
-    except OSError:
-        return 0, 0
-    in_status = False
-    in_comment = False
-    total = 0
-    complete = 0
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped == "## Status":
-            in_status = True
-            continue
-        if not in_status:
-            continue
-        if stripped.startswith("## ") and stripped != "## Status":
-            break
-        if "<!--" in stripped:
-            in_comment = True
-        if "-->" in stripped:
-            in_comment = False
-            continue
-        if in_comment:
-            continue
-        if stripped.startswith("- [ ]"):
-            total += 1
-        elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
-            total += 1
-            complete += 1
-    return total, complete

--- a/lib/gates.py
+++ b/lib/gates.py
@@ -14,9 +14,10 @@ gate per design constraint 1 + Chunk 7, and it uses the hook-resident gate
 ``_gates()``. ``_has_active_build_plan_file`` and ``_is_trivial_fileset_eligible``
 were reassigned here (they are gate logic, lib-clean) from the briefing region.
 
-Depends on its lib siblings ``gitstate`` / ``coverage`` / ``buildplan_refs`` and
-``core`` (``read_bool_yaml_key`` / ``resolve_build_plan_path`` — canonical twins
-of the hook's parity-pinned inline mirrors), plus the stdlib — the DAG node
+Depends on its lib siblings ``gitstate`` / ``coverage`` / ``buildplan_refs``
+(build-plan Status parsing, including ``_count_build_plan_chunks``) and ``core``
+(``read_bool_yaml_key`` — canonical twin of the hook's parity-pinned inline
+mirror), plus the stdlib — the DAG node
 ``gitstate``/``coverage``/``buildplan_refs`` ← ``gates``.
 """
 
@@ -30,7 +31,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from . import buildplan_refs, coverage, gitstate
-from .core import read_bool_yaml_key, resolve_build_plan_path
+from .core import read_bool_yaml_key
 
 
 _EVIDENCE_REQUIRED_FIELDS: dict[str, tuple[type, ...]] = {
@@ -691,49 +692,6 @@ def critic_findings_satisfy_session_gate(
         return False, ""
 
 
-def _count_build_plan_chunks(prawduct_dir: Path) -> tuple[int, int]:
-    """Count chunks in build-plan.md's Status section.
-
-    Returns ``(total, complete)``: total chunks declared, and how many are
-    marked ``[x]``. Returns ``(0, 0)`` if the plan is missing, has no Status
-    section, or has no chunk items. Mirrors the parsing rules in
-    ``_parse_build_plan_status`` (skip HTML comments; exit on next ``## ``).
-    """
-    plan_path = resolve_build_plan_path(prawduct_dir)
-    if not plan_path.is_file():
-        return 0, 0
-    try:
-        content = plan_path.read_text()
-        in_status = False
-        in_comment = False
-        total = 0
-        complete = 0
-        for line in content.splitlines():
-            stripped = line.strip()
-            if stripped == "## Status":
-                in_status = True
-                continue
-            if not in_status:
-                continue
-            if stripped.startswith("## ") and stripped != "## Status":
-                break
-            if "<!--" in stripped:
-                in_comment = True
-            if "-->" in stripped:
-                in_comment = False
-                continue
-            if in_comment:
-                continue
-            if stripped.startswith("- [ ]"):
-                total += 1
-            elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
-                total += 1
-                complete += 1
-        return total, complete
-    except Exception:  # prawduct:allow prawduct/broad-except -- gate check must not crash session end
-        return 0, 0
-
-
 def _critic_session_satisfies_gate(prawduct_dir: Path) -> tuple[bool, str]:
     """Check whether the latest Critic findings satisfy end-of-cycle synthesis.
 
@@ -761,7 +719,7 @@ def _critic_session_satisfies_gate(prawduct_dir: Path) -> tuple[bool, str]:
     blocker has cleared (i.e. findings exist and ``validate_critic_findings``
     returned True). Defensive checks here keep the helper standalone-safe.
     """
-    total, complete = _count_build_plan_chunks(prawduct_dir)
+    total, complete = buildplan_refs._count_build_plan_chunks(prawduct_dir)
     if total == 0:
         return True, ""
     if total == 1:

--- a/lib/gitstate.py
+++ b/lib/gitstate.py
@@ -54,7 +54,8 @@ def git_has_changes(project_dir: Path) -> str:
 # (``.claude/skills/`` for synced framework skills, ``tools/product-hook``)
 # are intentionally absent — a plugin repo never carries them, and a
 # product's *own* skill under ``.claude/skills/`` is product code that must
-# be gated, not excused. (Mirrored in ``lib/critic_mode.py``.)
+# be gated, not excused. The single canonical copy — ``lib/critic_mode.py``'s
+# mirror was consolidated onto this one (STH-2K8R).
 _METADATA_PREFIXES = (
     ".prawduct/",
     ".claude/settings.json",

--- a/tests/test_buildplan_walkers.py
+++ b/tests/test_buildplan_walkers.py
@@ -1,0 +1,303 @@
+"""Tests for the shared build-plan walkers + consolidation pins (STH-2K8R / BLD-6Q1N).
+
+Three concerns:
+
+1. Direct unit coverage of the canonical walkers in ``lib.buildplan_refs`` —
+   ``_iter_status_section_lines`` / ``_iter_status_section_items`` (the one
+   Status-section reader walk) and ``_chunk_section_lines`` (the one
+   chunk-section walk) — plus the helpers built on them
+   (``_count_build_plan_chunks``, ``_chunk_ids_in_status_order``).
+
+2. Consolidation pins: the duplicate bodies deleted from ``lib.critic_mode``
+   and ``lib.gates`` must STAY deleted. This is the inverted analogue of
+   ``TestChainAnchorParity`` — that deliberate mirror must stay EQUAL; these
+   must stay SINGULAR. A source-scan asserts the walk skeletons' anchor
+   literals don't reappear in the consumer modules.
+
+3. Porcelain edge cases through ``critic_mode._get_uncommitted_code_files``'s
+   consolidated parse path (``gitstate.parse_porcelain_line``): quoted paths
+   with spaces and rename destinations — cases the old inline parse handled
+   implicitly and must keep handling.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from lib import buildplan_refs, critic_mode, gates, gitstate
+from lib.buildplan_refs import (
+    _chunk_ids_in_status_order,
+    _chunk_section_lines,
+    _count_build_plan_chunks,
+    _iter_status_section_items,
+    _iter_status_section_lines,
+)
+
+LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers (sterile-git idiom shared with test_critic_mode_inference)
+# ---------------------------------------------------------------------------
+
+
+def _git_env(repo: Path) -> dict[str, str]:
+    """Sterile env for git calls; HOME outside the repo (see the inference
+    tests' helper for why — OS caches must not appear as untracked files)."""
+    return {
+        "HOME": str(repo.parent / "_home"),
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        env=_git_env(repo),
+        check=True,
+        timeout=10,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "--quiet", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+
+def _write(repo: Path, rel: str, content: str) -> Path:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def _write_plan(prawduct: Path, content: str) -> None:
+    plan = prawduct / "artifacts" / "build-plan.md"
+    plan.parent.mkdir(parents=True, exist_ok=True)
+    plan.write_text(content)
+
+
+PLAN = """# Build Plan — Walker Fixture (2026-06-10)
+
+**Size**: small | **Type**: refactor
+
+## Status
+
+<!-- A multi-line comment
+     - [ ] Chunk 99: decoy inside comment
+     spanning lines -->
+- [x] Chunk 01: first
+- [X] Chunk 02: second (capital X)
+- [ ] Chunk 03: third
+Context: mid-plan.
+
+## Build Chunks
+
+### Chunk 1: first
+
+- **Type:** code
+- **Critic mode:** chunk
+
+```text
+- **Critic mode:** cumulative
+inside a fence — field lines here are not load-bearing prose
+```
+
+- body line after fence
+
+### Chunk 02: second
+
+- **Type:** doc-only
+
+## Notes
+
+- [ ] not a status item (outside Status)
+"""
+
+
+# ---------------------------------------------------------------------------
+# 1. Walker unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIterStatusSection:
+    def test_yields_only_status_section_lines(self):
+        lines = list(_iter_status_section_lines(PLAN))
+        assert "- [x] Chunk 01: first" in lines
+        assert "Context: mid-plan." in lines
+        # Stops at the next ## heading — Build Chunks content never appears.
+        assert not any("Type:" in ln for ln in lines)
+        assert "- [ ] not a status item (outside Status)" not in lines
+
+    def test_html_comment_span_is_skipped(self):
+        lines = list(_iter_status_section_lines(PLAN))
+        assert not any("decoy" in ln for ln in lines)
+
+    def test_no_status_section_yields_nothing(self):
+        assert list(_iter_status_section_lines("# Plan\n\n## Other\n- [ ] x\n")) == []
+
+    def test_items_carry_checked_state_and_text(self):
+        items = list(_iter_status_section_items(PLAN))
+        assert items == [
+            (True, "Chunk 01: first"),
+            (True, "Chunk 02: second (capital X)"),
+            (False, "Chunk 03: third"),
+        ]
+
+
+class TestCountAndIds:
+    def test_count_build_plan_chunks(self, tmp_path: Path):
+        prawduct = tmp_path / ".prawduct"
+        _write_plan(prawduct, PLAN)
+        assert _count_build_plan_chunks(prawduct) == (3, 2)
+
+    def test_count_missing_plan_is_zero(self, tmp_path: Path):
+        assert _count_build_plan_chunks(tmp_path / ".prawduct") == (0, 0)
+
+    def test_chunk_ids_in_status_order(self, tmp_path: Path):
+        prawduct = tmp_path / ".prawduct"
+        _write_plan(prawduct, PLAN)
+        assert _chunk_ids_in_status_order(prawduct) == ["01", "02", "03"]
+
+    def test_non_chunk_items_are_skipped_in_ids(self, tmp_path: Path):
+        prawduct = tmp_path / ".prawduct"
+        _write_plan(
+            prawduct,
+            "## Status\n- [ ] Chunk 01: a\n- [ ] tidy the docs\n- [x] Chunk 02: b\n",
+        )
+        assert _chunk_ids_in_status_order(prawduct) == ["01", "02"]
+
+
+class TestChunkSectionLines:
+    def test_leading_zero_tolerance_both_directions(self):
+        # Plan heading "### Chunk 1:" found via id "01"; "### Chunk 02:" via "2".
+        found, lines = _chunk_section_lines(PLAN, "01")
+        assert found
+        assert any("**Critic mode:** chunk" in ln for _n, ln in lines)
+        found2, lines2 = _chunk_section_lines(PLAN, "2")
+        assert found2
+        assert any("**Type:** doc-only" in ln for _n, ln in lines2)
+
+    def test_fenced_block_is_dropped(self):
+        found, lines = _chunk_section_lines(PLAN, "1")
+        assert found
+        body = [ln for _n, ln in lines]
+        assert not any("cumulative" in ln for ln in body)
+        assert any("body line after fence" in ln for ln in body)
+
+    def test_stops_at_sibling_chunk(self):
+        _found, lines = _chunk_section_lines(PLAN, "1")
+        assert not any("doc-only" in ln for _n, ln in lines)
+
+    def test_stops_at_next_h2(self):
+        _found, lines = _chunk_section_lines(PLAN, "02")
+        assert not any("not a status item" in ln for _n, ln in lines)
+
+    def test_not_found(self):
+        found, lines = _chunk_section_lines(PLAN, "42")
+        assert not found
+        assert lines == []
+
+    def test_line_numbers_are_one_based_into_content(self):
+        _found, lines = _chunk_section_lines(PLAN, "1")
+        content_lines = PLAN.splitlines()
+        for line_num, line in lines:
+            assert content_lines[line_num - 1] == line
+
+
+# ---------------------------------------------------------------------------
+# 2. Consolidation pins — the deleted mirrors must stay deleted
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidationPins:
+    """Inverse of ``TestChainAnchorParity``: that mirror must stay equal,
+    these must stay singular. A copy quietly reintroduced in a consumer
+    module is the regression this class exists to catch (STH-2K8R)."""
+
+    CONSOLIDATED_OUT_OF_CRITIC_MODE = (
+        "_METADATA_PREFIXES",
+        "_is_metadata_path",
+        "_git_head_sha",
+        "_current_chunk_id_from_status",
+        "_chunk_ids_in_status_order",
+        "_count_build_plan_chunks",
+    )
+
+    def test_critic_mode_defines_no_consolidated_helpers(self):
+        for name in self.CONSOLIDATED_OUT_OF_CRITIC_MODE:
+            assert name not in vars(critic_mode), (
+                f"lib.critic_mode regrew {name!r}; the canonical copy lives in "
+                "lib.gitstate / lib.buildplan_refs (STH-2K8R)"
+            )
+
+    def test_gates_defines_no_chunk_counter(self):
+        assert "_count_build_plan_chunks" not in vars(gates), (
+            "lib.gates regrew _count_build_plan_chunks; the canonical copy "
+            "lives in lib.buildplan_refs (BLD-6Q1N)"
+        )
+
+    def test_walk_skeleton_literals_stay_out_of_consumers(self):
+        """The Status / chunk-section walk skeletons are recognizable by their
+        anchor literals. Readers in consumer modules must go through the
+        shared walkers, so the literals may appear only in
+        ``lib/buildplan_refs.py`` (and ``lib/views.py``'s index-based Status
+        REWRITER, which is deliberately separate)."""
+        for mod in ("critic_mode.py", "gates.py"):
+            src = (LIB_DIR / mod).read_text()
+            assert '"## Status"' not in src, f"lib/{mod} regrew a Status walk"
+            assert '"### Chunk "' not in src, f"lib/{mod} regrew a chunk-section walk"
+
+    def test_canonical_helpers_are_what_consumers_reach(self):
+        # The names critic_mode now resolves are the canonical objects.
+        assert critic_mode.buildplan_refs is buildplan_refs
+        assert critic_mode.gitstate is gitstate
+
+
+# ---------------------------------------------------------------------------
+# 3. Porcelain edge cases through the consolidated parse path
+# ---------------------------------------------------------------------------
+
+
+class TestUncommittedCodeFilesPorcelainEdges:
+    def test_quoted_path_with_spaces_is_unquoted(self, tmp_path: Path):
+        _init_repo(tmp_path)
+        _write(tmp_path, "README.md", "x\n")
+        _git(tmp_path, "add", "-A")
+        _git(tmp_path, "commit", "-m", "initial", "--quiet")
+
+        _write(tmp_path, "my doc file.py", "# spaces\n")
+        files = critic_mode._get_uncommitted_code_files(tmp_path)
+        assert "my doc file.py" in files
+        assert not any(f.startswith('"') for f in files)
+
+    def test_rename_yields_destination(self, tmp_path: Path):
+        _init_repo(tmp_path)
+        _write(tmp_path, "old_name.py", "# code\n")
+        _git(tmp_path, "add", "-A")
+        _git(tmp_path, "commit", "-m", "initial", "--quiet")
+
+        _git(tmp_path, "mv", "old_name.py", "new_name.py")
+        files = critic_mode._get_uncommitted_code_files(tmp_path)
+        assert "new_name.py" in files
+        assert "old_name.py" not in files
+
+    def test_metadata_paths_are_excluded(self, tmp_path: Path):
+        _init_repo(tmp_path)
+        _write(tmp_path, "README.md", "x\n")
+        _git(tmp_path, "add", "-A")
+        _git(tmp_path, "commit", "-m", "initial", "--quiet")
+
+        _write(tmp_path, ".prawduct/.session-start", "t\n")
+        _write(tmp_path, "src/app.py", "# code\n")
+        files = critic_mode._get_uncommitted_code_files(tmp_path)
+        assert files == {"src/app.py"}

--- a/tests/test_critic_mode_inference.py
+++ b/tests/test_critic_mode_inference.py
@@ -1173,16 +1173,20 @@ class TestMetadataPathClassification:
     were removed — a plugin repo never carries them, and a product's *own*
     skill under ``.claude/skills/`` is product code that must be gated, not
     excused from the reflection/Critic gates.
+
+    The allowlist's canonical home is ``lib.gitstate`` — ``critic_mode``'s
+    mirror was consolidated onto it (STH-2K8R), so these pins target the one
+    copy every consumer (gates, critic_mode, the hook via lib) now reads.
     """
 
     def test_product_state_and_install_reference_are_metadata(self):
-        from lib.critic_mode import _is_metadata_path
+        from lib.gitstate import _is_metadata_path
 
         assert _is_metadata_path(".prawduct/project-state.yaml")
         assert _is_metadata_path(".claude/settings.json")
 
     def test_retired_filesync_prefixes_are_not_metadata(self):
-        from lib.critic_mode import _is_metadata_path
+        from lib.gitstate import _is_metadata_path
 
         # A product's own skill is product code, not excused framework metadata.
         assert not _is_metadata_path(".claude/skills/my-skill/SKILL.md")


### PR DESCRIPTION
One consolidation pass (STH-2K8R + BLD-6Q1N; closes CRT-3D9K by construction). `lib/critic_mode.py` deletes its five mirror implementations (`_is_metadata_path`/`_METADATA_PREFIXES`, `_git_head_sha`, `_current_chunk_id_from_status`, `_chunk_ids_in_status_order`, `_count_build_plan_chunks`) and consumes the canonical homes in `lib/gitstate` and `lib/buildplan_refs`; its inline porcelain parse folds onto `gitstate.parse_porcelain_line` (keeping the load-bearing `-uall` subprocess call). `lib/buildplan_refs` gains the canonical Status-section walkers and chunk-section walker; all five Status readers and four chunk-section parsers fold onto them; `lib/gates.py` deletes its duplicate counter.

Deliberately NOT consolidated: the test-pinned `_chain_extendable_anchor` ↔ `gates._chain_anchor` mirror (keeps `gates` out of the shim's import graph) and `views.py`'s index-based rewriter.

Shared-helper read errors unify on `(OSError, UnicodeDecodeError)`, fixing a latent crash in critic_mode's old OSError-only copy. New `tests/test_buildplan_walkers.py` adds walker unit coverage, porcelain edge cases, and consolidation pins (the inverse of `TestChainAnchorParity`: that mirror must stay equal, these must stay singular). Net −150 production lines.

**Test evidence:** 1331 passed / 0 failed. **Cumulative Critic:** 0 blocking / 1 warning (gate noise — verify-chunk-refs false positives on extension-less module paths in plan prose — fixed in-place; refs verify clean). **PR review:** 0 blocking / 0 warnings / 0 notes (fable, 3-claim adversarial audit of the Critic record, all verified).