### PR TITLE
docs(critic): cross-component message-contract check in Goal 1 (chunk-mode, BLOCKING)

### DIFF
--- a/skills/critic/review-protocol.md
+++ b/skills/critic/review-protocol.md
@@ -43,6 +43,7 @@ Your goals, in priority order. (`chunk` mode runs 1-3 only.)
 - Tests verify behavior, not implementation.
 - Tests deleted or assertions weakened without documented reason → **BLOCKING**. Legitimate consolidation needs a change-log entry.
 - Changed/added behavior has test coverage → **BLOCKING** if untested.
+- **Cross-component message contract (when boundaries are crossed — IPC + consumer, per the Signals above):** when changed code consumes or produces messages across a process/component boundary (IPC, WebSocket/wire protocol, event streams, pub/sub), trace the *actual emitted signal sequence on the other side* — not just that the message type/shape matches. A consumer that blocks on a signal the producer never emits, or omits handling for a terminal/error signal the producer does emit → **BLOCKING**. Matching types (e.g. a TS interface ↔ a Python dataclass) is necessary but not sufficient; read both ends. This runs in `chunk` mode (Goal 5's contract-surface check is `final`-only and one-directional — downstream-consumer-impact — so it cannot catch a consumer that mismodels the producer).
 - Tests are well-structured (behavior not implementation, edge cases, meaningful assertions) → **WARNING** if quality poor.
 - **No-behavior-change refactor**: output assertions are exact-match, not substring/contains (substring misses drift — double-prefix, error wrappers) → **WARNING**.
 - For math, data transforms, serialization, complex validation: if test-specs call for property-based tests and they're absent → **NOTE**.
@@ -89,7 +90,7 @@ Your goals, in priority order. (`chunk` mode runs 1-3 only.)
 ### 5. Decisions Were Deliberate
 - New external dependencies include rationale in dependency manifest → **WARNING** if missing.
 - Architectural patterns are captured in architecture artifact → **WARNING** if missing.
-- If changes cross contract surfaces (see `.prawduct/artifacts/boundary-patterns.md`), was consumer impact investigated? → **WARNING** if no evidence.
+- If changes cross contract surfaces (see `.prawduct/artifacts/boundary-patterns.md`), was **downstream consumer** impact investigated? → **WARNING** if no evidence. (The inverse — a consumer that mismodels the producer's actual emitted signals — is a correctness check under Goal 1, "Cross-component message contract.")
 - Major technology choices include alternatives considered → **WARNING** if missing.
 
 ### 6. The System Can Be Understood


### PR DESCRIPTION
## What

Strengthens the Critic's **Goal 1 (Nothing Is Broken)** with a cross-component message-contract check, and disambiguates **Goal 5** so the two don't overlap.

- **Goal 1 (new bullet):** when changed code consumes or produces messages across a process/component boundary (IPC, WebSocket/wire protocol, event streams, pub/sub), trace the *actual emitted signal sequence on the other side* — not just that the message type/shape matches. A consumer that blocks on a signal the producer never emits, or omits handling for a terminal/error signal the producer does emit → **BLOCKING**. Crucially, this runs in **`chunk` mode**.
- **Goal 5 (clarified):** scoped to *downstream consumer* impact, with a cross-reference to Goal 1 for the inverse (consumer-mismodels-producer) correctness case.

One file, +2/-1 lines.

## Why

The framework already flags "boundaries crossed (IPC + consumer)" as a *signal* and has Goal 5's contract-surface check — but there are three gaps that let a real cross-component mismatch slip through:

1. **Chunk-mode blindness** — Goal 5 runs in `final`/`cumulative` only; `chunk` (Goals 1–3) had nothing.
2. **Wrong direction** — Goal 5 asks "did *your change* break *downstream consumers*?"; it doesn't catch a *consumer that mismodels what the producer actually emits*.
3. **Severity** — Goal 5 is a WARNING about process ("investigation occurred"), not a BLOCKING about the contract being wrong.

Concrete motivation (full writeup in #97): in a two-process project (Electron ↔ Python over WebSocket), a chunk's consumer awaited a `done` status the producer's success path never sends (it emits `downloading`, then exits silently for a relaunch). Types matched on both sides; unit + IPC tests were green because they **synthesized the signal the real producer doesn't send**; chunk-mode review passed it. It was caught only later, and only because the invoking prompt happened to tell that reviewer to verify the consumer against the producer's actual handler — i.e. **prompt-driven, not protocol-driven.** This change makes the protocol mandate the trace.

Per the skill's own guidance ("Prefer strengthening existing goals over adding new ones"), this folds into Goal 1 rather than adding an eighth goal.

## Notes

- Verified against the structural tests in `tests/preferences/test_critic_skill_structure.py` and friends — they assert section/mode presence, which is unchanged; no test pins the exact bullet strings touched.
- I left the tag-driven changelog / `regen-views` mechanics to you, since those are release-tooling I'm not set up to drive correctly as an external contributor — happy to add a change-log entry in whatever form you prefer.

Refs #97
