### PR TITLE
feat: fail-loud change-log tag validation + regen-views --check (VWS-6R4T)

### DIFF
--- a/.prawduct/artifacts/build-plan-changelog-fail-loud.md
+++ b/.prawduct/artifacts/build-plan-changelog-fail-loud.md
@@ -1,0 +1,163 @@
+---
+artifact: build-plan
+version: 2
+scope: changelog-fail-loud
+depends_on:
+  - artifact: framework-efficiency-review-2026-07-02
+last_validated: 2026-07-02
+---
+
+# Build Plan — changelog-fail-loud (Wave 1 Plan B, VWS-6R4T)
+
+Parent requirement: `.prawduct/artifacts/framework-efficiency-review-2026-07-02.md`
+(Wave 1 Plan B, Overbuilt #2). Backlog: VWS-6R4T (related REL-3M7K; the item's named
+overlaps REL-9F2T, VWS-4D8J, VWS-7N3K are all already shipped/archived — nothing to fold).
+
+## Requirements Confidence
+
+**Level:** High
+
+**Why:** Owner-accepted parent artifact names the failure class with evidence (~12 of 71
+learnings, trenchant's entire lifespan); the code paths (`lib/views.py` tag parse/flip,
+`bin/prawduct-hook` regen-views handler) are small, pure, and fully test-covered. A
+pre-plan probe against the real change-log (124 entries, 38 scoped plans) confirmed:
+no roster validation exists anywhere today; zero exact-match violations among
+plan-resolvable entries (so the new validator lands green); 26 shipped-scope entries
+have no plan file and are legitimately historical (the existing exemption is correct);
+`regen-views --check` is referenced by two learnings but does not exist.
+
+**Open assumptions / unknowns:**
+- [ASSUMPTION: The parent's "consider shrinking the vocabulary (one scope identifier,
+  statusless-until-release as the only lifecycle)" is **descoped** to its own backlog
+  item rather than built here. Rationale: it deletes `status=merged` + `stamp-merged`
+  machinery that shipped 3 weeks ago (v2.1.1) and works; the cascade touches the PR
+  skill, release process doc, several learnings, and tests (the enumerate-the-surfaces
+  rule says that is its own plan); and roster validation makes the existing vocabulary
+  safe, removing the P0 urgency. Owner was asked 2026-07-02 (no response — AFK);
+  recommendation applied. | HIGH impact | user can override]
+- [ASSUMPTION: "Errors loudly on non-matches" means regen-views **fails closed**: on
+  any validation error it prints ERROR lines and exits 2 *without writing any view*
+  (no silent partial flips — partial application is the bug class). Error set: (a)
+  `chunks=` ID not in the resolved plan's Status roster after normalization — for ANY
+  entry whose `scope=` resolves to a plan file, shipped included, because release-prep
+  flips entries to `shipped` *before* running regen-views, so a shipped-exempt
+  validator would never fire at the moment it matters; (b) unrecognized `status=`
+  value (promoted from warning — warnings are effectively blocking); (c) unreleased
+  (statusless-tagged or merged) scope with no plan file (promoted from warning); (d)
+  duplicate `scope:` across plan files (promoted — resolution is ambiguous); (e)
+  conflicting scalar keys across multiple tag lines (the first-wins repair can pick
+  the wrong value). Mere tag-line multiplicity without conflicts stays a warning (the
+  union repair is correct output). Shipped scopes with NO plan file remain exempt
+  (historical/retired plans). | MED impact | user can override]
+- [ASSUMPTION: Tolerant matching = a `normalize_chunk_id()` applied uniformly to both
+  sides of every comparison (the shipped-set flip in `collect_shipped_chunks` /
+  `regenerate_status_section` AND the new validator): casefold; purely-numeric IDs
+  compare by integer value (`1` ≡ `01`); `_` and `-` unify. Normalization must be
+  proven collision-free against the real change-log before landing (probe shows
+  numeric IDs and letter IDs A–E; no expected collisions). | MED impact | user can
+  override]
+- [ASSUMPTION: `regen-views --check` = compute + validate, write nothing. Exit 0 when
+  validation passes (pending writes are normal at release time, reported not erred);
+  exit 2 with ERROR lines on any validation failure. This makes the two existing
+  learnings that already tell operators to "confirm via `regen-views --check`" true
+  instead of stale. | LOW impact | user can override]
+- [ASSUMPTION: REL-3M7K (root CHANGELOG.md headline + green-suite gate at release-prep)
+  stays its own item — different mechanism (banner parse / release-prep process), not
+  the tag DSL. Noted as related, not folded. | LOW impact | user can defer]
+
+**What would raise confidence:** Owner's answer on the vocabulary-shrink descope
+(assumption 1) — the plan proceeds on the recommendation either way.
+
+## Status
+
+- [ ] Chunk 01: Fail-loud tag validation — roster check, tolerant chunk IDs, `--check`
+Context: not started.
+
+## Scaffolding
+
+Existing repo — no scaffold. Tests: `pytest tests/test_views.py` (full suite before
+commit).
+
+### Verification Strategy
+
+Beyond tests, run against this repo's real state (self-hosting caution — this edits
+the machinery that will flip THIS plan's own Status at release):
+1. `prawduct-hook regen-views --check` on HEAD exits 0 (the 124-entry change-log and
+   38 scoped plans validate clean — matches the pre-plan probe).
+2. `prawduct-hook regen-views` on HEAD is a no-op/idempotent (flip behavior unchanged
+   by normalization on already-consistent data).
+3. In a scratch copy: corrupt one entry's `chunks=` to a nonexistent ID → regen-views
+   prints a loud ERROR naming the entry, the bad ID, and the plan's actual roster, and
+   exits 2 with NO files written; `chunks=1` against a `Chunk 01:` roster flips
+   correctly (tolerance proven live).
+
+## Build Chunks
+
+### Chunk 01: Fail-loud tag validation — roster check, tolerant chunk IDs, `--check`
+
+- **Description:** Kill the silent-partial-flip class in the change-log→views DSL.
+  Three moves:
+  1. `lib/views.py` — add `normalize_chunk_id()` and apply it to both sides of every
+     chunk-ID comparison (shipped set + Status-roster match), so zero-padding /
+     case / separator variants stop being silent no-flips. Add
+     `validate_chunk_roster(change_log_content, artifacts_dir)` (pure, mirrors the
+     existing validators): for every entry whose `scope=` resolves to a plan file,
+     every `chunks=` ID must match that plan's Status-section roster after
+     normalization; returns one error string per miss naming entry title/line, the
+     unmatched ID, and the plan's actual roster. Split
+     `validate_tag_line_multiplicity`'s conflict case out as an error.
+  2. `bin/prawduct-hook` `cmd_regen_views` — restructure the advisory block into a
+     validate-then-apply sequence: run all validators BEFORE `apply_regen`; any
+     ERROR-class finding prints loudly and exits 2 with nothing written (fail
+     closed). Promotions per plan assumption (b)-(e); mere multiplicity stays
+     WARNING. Add the `--check` flag: compute + validate + print planned actions,
+     write nothing, exit 0 valid / 2 on violations. Update the usage string.
+  3. `docs/release-process.md` — add `--check` to step 4 as the pre-flight
+     ("run `regen-views --check` first; fix any ERROR before the real run"), and
+     update the two stderr-WARNING sentences that the promotions make stale.
+- **Depends on:** none
+- **Artifacts consumed:** `.prawduct/artifacts/framework-efficiency-review-2026-07-02.md`
+- **Deliverables:** edits to `lib/views.py`, `bin/prawduct-hook`,
+  `tests/test_views.py`, `tests/test_hook_regen_views.py` (or the existing hook-test
+  home for regen-views), `docs/release-process.md`
+- **Tests:**
+  - Normalization: `1`≡`01`≡` 01`, `A`≡`a`, `foo_bar`≡`foo-bar`; non-numeric IDs
+    unaffected by zero-strip; no collisions across the real change-log's ID corpus
+    (regression: flips on the repo's own change-log are byte-identical pre/post).
+  - Roster validator: miss on a resolvable scope → error naming entry/ID/roster;
+    shipped scope with no plan file → no error (historical exemption); statusless
+    and merged and shipped entries with resolvable plans all validated; tolerant
+    match suppresses the former zero-padding false miss.
+  - Fail-closed wiring: a roster miss makes regen-views exit 2 and write NO view
+    files (plan Status, release-notes, scope_rollups all untouched); status-typo,
+    unreleased-no-plan, duplicate-scope, scalar-conflict all exit 2; multiplicity
+    alone still exits 0 with a WARNING.
+  - `--check`: clean repo exits 0 and prints planned actions without writing;
+    violation exits 2; never writes in either case.
+- **Acceptance criteria:**
+  - Full pytest suite passes.
+  - Live checks per Verification Strategy (idempotent on HEAD, loud on scratch
+    corruption, tolerance proven live).
+- **Type:** cumulative-final
+- **Done when:**
+  1. Acceptance criteria met and tests pass
+  2. Committed and chunk marked `[x]` in Status
+  3. `/prawduct:critic cumulative` run against `merge-base...HEAD`, blocking
+     findings resolved — this IS the chunk's review and the `/prawduct:pr create` gate
+  4. Backlog: VWS-6R4T updated via `/prawduct:backlog` (shrink-descope recorded on
+     the item; new item filed for the vocabulary shrink; REL-3M7K noted related)
+
+## Early Feedback Milestone
+
+**Milestone chunk:** 01 (single-chunk plan)
+**What the user can do:** Run `regen-views --check` before a release and get a loud,
+named error for any tag that would silently fail to flip; write `chunks=1` against a
+`Chunk 01:` plan and have it just work.
+
+## Governance Checkpoints
+
+**Commit & PR cadence:** Commit the chunk, then one `/prawduct:critic cumulative`
+(the chunk review AND the PR gate), then `/prawduct:pr` per the wave rules (own
+feature branch off develop, ships at next version bump). `active_build_plan` stays
+pointed at the release-pending gate-noise plan until the release ships (gitflow plan
+lifecycle); this plan is scope-resolved via its frontmatter.

--- a/.prawduct/artifacts/build-plan-changelog-fail-loud.md
+++ b/.prawduct/artifacts/build-plan-changelog-fail-loud.md
@@ -71,7 +71,10 @@ have no plan file and are legitimately historical (the existing exemption is cor
 ## Status
 
 - [ ] Chunk 01: Fail-loud tag validation — roster check, tolerant chunk IDs, `--check`
-Context: not started.
+Context: Chunk 01 built 2026-07-02; suite 1529/0; live checks pass (--check clean on
+HEAD, regen idempotent, scratch corruption errors loudly exit 2 nothing written,
+chunks=1 vs Chunk 01 tolerant-validates). Checkbox flips at release via regen-views
+(entry statusless on branch). Next: cumulative Critic, then /prawduct:pr when asked.
 
 ## Scaffolding
 

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -7,6 +7,11 @@
 
 ## Open
 
+- **[CRT-5D8Q]** PR-gate coverage vs verify-resolutions scope disagree on the metadata exemption — deadlock when the ledger fallback window has lapsed
+  `effort: S · impact: M · area: governance/critic-gate · source: critic · added: 2026-07-02 · status: open · stage: ready · related: CRT-8H3R, CRT-2K9F, CRT-4J8W, STH-6T9W · refs: lib/gates.py (_record_covers_head L972, _compute_verify_resolutions_scope L447)`
+
+  The two gate helpers draw the `.prawduct/` metadata-exemption boundary differently. `_record_covers_head` exempts only `.md` files, so a routine post-cumulative `.prawduct/*.yaml` change (e.g. repointing `active_build_plan`) marks the cumulative record stale. But `_compute_verify_resolutions_scope` exempts ALL `.prawduct/` metadata, so the demanded verify-resolutions pass returns "no-actionable-findings" and the SKILL's literal demotion to `final` yields a non-gate-qualifying record — deadlock when the ledger fallback window has lapsed. Fix-shape: make the two helpers agree on the metadata-exemption boundary. Observed live 2026-07-02 on feature/changelog-fail-loud (Critic hand-anchored a chain record to route around it). Governance-protected (lib/gates.py) → full Critic + PR review. (critic)
+
 - **[COV-4M2J]** Coverage floor is Python-only — `bin/test-reference-verify` symbol-grep can't reference non-Python (JS/TS/Go/…) changed files; bring-your-own-verifier via `--merge-into` is the only escape
   `effort: L · impact: M · area: coverage · source: builder · added: 2026-06-26 · status: open · stage: requirements · related: COV-3R9K, COV-8R2K, TST-2H9P · refs: bin/test-reference-verify (symbol-grep floor), lib/coverage.py (changed-files derivation), bin/prawduct-hook (verify-coverage, test-evidence record F4a overlay), skills/critic/review-cycle.md (Goal 1 F4b)`
 

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -768,6 +768,8 @@
   `skills/pr/SKILL.md` merge-flow step 6, `docs/release-process.md`, `stamp_merged` in
   `lib/views.py`, several learnings. (planning)
 
+## Promoted
+
 ## Archive
 
 - **[VWS-6R4T]** Wave 1 Plan B: changelog-fail-loud — regen-views validates every change-log tag against the plan roster and errors loudly; tolerant chunk-ID matching

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -633,7 +633,7 @@
      Each wave item ships as its own small 1-2 chunk plan on its own branch — NOT one monolithic plan. -->
 
 - **[VWS-6R4T]** Wave 1 Plan B: changelog-fail-loud — regen-views validates every change-log tag against the plan roster and errors loudly; tolerant chunk-ID matching
-  `effort: M · impact: L · area: change-log/views · source: user · added: 2026-07-02 · status: open · stage: ready · related: REL-9F2T, REL-2N8K, REL-6C3W, VWS-4D8J, VWS-7N3K, BLD-5J8N · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan B, Overbuilt #2)`
+  `effort: M · impact: L · area: change-log/views · source: user · added: 2026-07-02 · status: open · stage: ready · accepted-by: @brooks · related: REL-9F2T, REL-2N8K, REL-6C3W, VWS-4D8J, VWS-7N3K, BLD-5J8N, REL-4Q9V · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan B, Overbuilt #2), .prawduct/artifacts/build-plan-changelog-fail-loud.md · reviewed: 2026-07-02`
 
   P0. The literal-string tag DSL fails partially and SILENTLY (~12 of 71 learnings, duplicate
   incoming bugs, broke for trenchant's entire lifespan). Fix: validate every tag (`scope=`,
@@ -642,6 +642,12 @@
   vocabulary: one scope identifier; statusless-until-release as the only lifecycle. Overlaps the
   REL-9F2T silent-drop family and VWS-4D8J/VWS-7N3K — dedup pass should fold or `closes:` those
   once this is planned. Prefer deletion over patching. (user)
+
+  — 2026-07-02: claimed by @brooks; build plan authored at
+  `.prawduct/artifacts/build-plan-changelog-fail-loud.md` (branch `feature/changelog-fail-loud`).
+  The "consider shrinking the vocabulary" clause is DESCOPED from that plan per the plan's
+  HIGH-impact assumption (owner asked 2026-07-02, AFK, recommendation applied) — the shrink now
+  lives as its own item, [REL-4Q9V].
 
 - **[MET-3Q8V]** Wave 1 Plan C: prose-diet — single-source the mode/type matrix, strip the build-plan template to a filled example, fold agent-stance + delegator skills, reconcile the 5 contradictions
   `effort: L · impact: L · area: methodology/prose · source: user · added: 2026-07-02 · status: open · stage: ready · related: MET-7R4J, MET-5C2H, CRT-5Q8W · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan C, Overbuilt #3), methodology/planning.md:97-137, templates/build-plan.md:222-281, methodology/building.md:284`
@@ -770,7 +776,14 @@
   layer accretes its own bugs and learnings. Draft the amendment (Principle 19 — Evolving
   Principles is the vehicle) and confirm wording with the owner. (user)
 
-## Promoted
+- **[REL-4Q9V]** Vocabulary shrink for the change-log lifecycle — drop `status=merged` and stamp-merged machinery; statusless-until-release as the only lifecycle; one scope identifier
+  `effort: M · impact: M · area: governance/change-log · source: builder · added: 2026-07-02 · status: open · stage: design · related: VWS-6R4T, REL-9F2T · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan B "consider shrinking"), .prawduct/artifacts/build-plan-changelog-fail-loud.md (descope assumption + rationale)`
+
+  Deletion-over-patching candidate. Descoped from the changelog-fail-loud plan (VWS-6R4T) per
+  that plan's HIGH-impact assumption. Blocked on the owner confirming the shrink is wanted once
+  fail-loud validation ships — validation removes the P0 urgency. Cascade surfaces:
+  `skills/pr/SKILL.md` merge-flow step 6, `docs/release-process.md`, `stamp_merged` in
+  `lib/views.py`, several learnings. (planning)
 
 ## Archive
 

--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -632,23 +632,6 @@
      Waves: 1 = P0 (kill recurring taxes), 2 = P1 (outcome gaps), 3 = P2 (weaker-model scaffolding).
      Each wave item ships as its own small 1-2 chunk plan on its own branch — NOT one monolithic plan. -->
 
-- **[VWS-6R4T]** Wave 1 Plan B: changelog-fail-loud — regen-views validates every change-log tag against the plan roster and errors loudly; tolerant chunk-ID matching
-  `effort: M · impact: L · area: change-log/views · source: user · added: 2026-07-02 · status: open · stage: ready · accepted-by: @brooks · related: REL-9F2T, REL-2N8K, REL-6C3W, VWS-4D8J, VWS-7N3K, BLD-5J8N, REL-4Q9V · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan B, Overbuilt #2), .prawduct/artifacts/build-plan-changelog-fail-loud.md · reviewed: 2026-07-02`
-
-  P0. The literal-string tag DSL fails partially and SILENTLY (~12 of 71 learnings, duplicate
-  incoming bugs, broke for trenchant's entire lifespan). Fix: validate every tag (`scope=`,
-  `chunks=`, `status=`) against the plan roster at write/check time — no silent partial flips;
-  tolerant chunk-ID matching (zero-padding, separator variants). Consider shrinking the
-  vocabulary: one scope identifier; statusless-until-release as the only lifecycle. Overlaps the
-  REL-9F2T silent-drop family and VWS-4D8J/VWS-7N3K — dedup pass should fold or `closes:` those
-  once this is planned. Prefer deletion over patching. (user)
-
-  — 2026-07-02: claimed by @brooks; build plan authored at
-  `.prawduct/artifacts/build-plan-changelog-fail-loud.md` (branch `feature/changelog-fail-loud`).
-  The "consider shrinking the vocabulary" clause is DESCOPED from that plan per the plan's
-  HIGH-impact assumption (owner asked 2026-07-02, AFK, recommendation applied) — the shrink now
-  lives as its own item, [REL-4Q9V].
-
 - **[MET-3Q8V]** Wave 1 Plan C: prose-diet — single-source the mode/type matrix, strip the build-plan template to a filled example, fold agent-stance + delegator skills, reconcile the 5 contradictions
   `effort: L · impact: L · area: methodology/prose · source: user · added: 2026-07-02 · status: open · stage: ready · related: MET-7R4J, MET-5C2H, CRT-5Q8W · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan C, Overbuilt #3), methodology/planning.md:97-137, templates/build-plan.md:222-281, methodology/building.md:284`
 
@@ -786,6 +769,27 @@
   `lib/views.py`, several learnings. (planning)
 
 ## Archive
+
+- **[VWS-6R4T]** Wave 1 Plan B: changelog-fail-loud — regen-views validates every change-log tag against the plan roster and errors loudly; tolerant chunk-ID matching
+  `effort: M · impact: L · area: change-log/views · source: user · added: 2026-07-02 · status: shipped · stage: ready · closed-by: changelog-fail-loud · related: REL-9F2T, REL-2N8K, REL-6C3W, VWS-4D8J, VWS-7N3K, BLD-5J8N, REL-4Q9V · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan B, Overbuilt #2), .prawduct/artifacts/build-plan-changelog-fail-loud.md · reviewed: 2026-07-02`
+
+  P0. The literal-string tag DSL fails partially and SILENTLY (~12 of 71 learnings, duplicate
+  incoming bugs, broke for trenchant's entire lifespan). Fix: validate every tag (`scope=`,
+  `chunks=`, `status=`) against the plan roster at write/check time — no silent partial flips;
+  tolerant chunk-ID matching (zero-padding, separator variants). Consider shrinking the
+  vocabulary: one scope identifier; statusless-until-release as the only lifecycle. Overlaps the
+  REL-9F2T silent-drop family and VWS-4D8J/VWS-7N3K — dedup pass should fold or `closes:` those
+  once this is planned. Prefer deletion over patching. (user)
+
+  — 2026-07-02: claimed by @brooks; build plan authored at
+  `.prawduct/artifacts/build-plan-changelog-fail-loud.md` (branch `feature/changelog-fail-loud`).
+  The "consider shrinking the vocabulary" clause is DESCOPED from that plan per the plan's
+  HIGH-impact assumption (owner asked 2026-07-02, AFK, recommendation applied) — the shrink now
+  lives as its own item, [REL-4Q9V].
+
+  **Shipped 2026-07-02** on `feature/changelog-fail-loud` (chunk 01 built and Critic-cleared,
+  aaaf39a): fail-loud roster validation + tolerant chunk-ID matching + `regen-views --check`
+  shipped. The vocabulary-shrink clause lives on as [REL-4Q9V].
 
 - **[GOV-7T2M]** Wave 1 Plan A: gate-noise — freshness = `test-status` exit code only (both review protocols) + work-model tripwire verb/corpus fix
   `effort: S · impact: L · area: gates · source: user · added: 2026-07-02 · status: shipped · stage: ready · closed-by: gate-noise · related: WMK-4Q9T, WMK-7D3R · refs: .prawduct/artifacts/framework-efficiency-review-2026-07-02.md (Wave 1 Plan A), .prawduct/artifacts/build-plan-gate-noise.md, skills/critic/review-protocol.md, skills/pr/review-protocol.md, lib/work_model_index.py:120-126, bin/prawduct-hook:2661-2675 · reviewed: 2026-07-02`

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,38 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-07-02: fail-loud change-log tag validation + tolerant chunk IDs + regen-views --check (changelog-fail-loud)
+
+<!-- prawduct: chunks=01 | type=feature | scope=changelog-fail-loud -->
+
+**Why:** Wave 1 Plan B of the owner-accepted efficiency-review fix program
+(`.prawduct/artifacts/framework-efficiency-review-2026-07-02.md`, VWS-6R4T, Overbuilt #2).
+The change-log tag DSL's failures were partial and SILENT: a `chunks=` ID that didn't
+literally match the plan's `Chunk <id>:` heading (zero-padding included) simply never
+flipped, a `status=` typo passed with a warning nobody reads, and the documented release
+pre-flight `regen-views --check` didn't exist. This class produced ~12 of this repo's 71
+learnings and broke for trenchant's entire lifespan. The parent's "consider shrinking the
+vocabulary" clause is descoped to REL-4Q9V (recorded HIGH-impact assumption in the plan).
+
+**What:**
+- `lib/views.py` — `normalize_chunk_id()` (case, `-`/`_`, numeric zero-padding) applied to
+  BOTH sides of the checkbox flip; new `validate_chunk_roster()` (every `chunks=` ID on an
+  entry whose `scope=` resolves to a plan file must match that plan's `## Status` roster —
+  shipped entries included, since release-prep flips to shipped BEFORE regen runs); new
+  `validate_tag_conflicts()` (conflicting scalars across tag lines split out of the
+  multiplicity warning — first-wins may pick the wrong value).
+- `bin/prawduct-hook` `cmd_regen_views` — validation is fail-CLOSED: any ERROR (status typo,
+  roster miss, unreleased scope with no plan file, duplicate scope, tag-line conflict)
+  exits 2 with NOTHING written; mere multi-tag-line union stays a WARNING. New `--check`
+  flag: compute + validate + report, write nothing (exit 0 valid / 2 violations) — the
+  release pre-flight two learnings already referenced.
+- `docs/release-process.md` — step 4 opens with the `--check` pre-flight; the two
+  warn-and-proceed sentences updated to the fail-closed contract.
+- Tests: contract change documented — `TestRegenViewsStatusTypoWarning` (warn-and-proceed)
+  rewritten as `TestRegenViewsStatusTypoError` (fail-closed), conflict clause moved from the
+  multiplicity warning test to `TestValidateTagConflicts`; new lib + subprocess coverage for
+  normalization, roster validation, fail-closed writes, and `--check`.
+
 ## 2026-07-02: work-model tripwire — maintenance-verb split + recursive doc corpus (gate-noise)
 
 <!-- prawduct: chunks=01 | type=bugfix | scope=gate-noise | status=merged -->

--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -540,7 +540,11 @@ views_enabled: true
 # 2026-07-02: gate-noise (Wave 1 Plan A of the efficiency-review fix program,
 # GOV-7T2M) — work-model tripwire maintenance-verb split + recursive doc corpus.
 # Single chunk, Type: cumulative-final, feature/gate-noise off develop.
-active_build_plan: artifacts/build-plan-gate-noise.md
+# 2026-07-02: repointed at changelog-fail-loud (Wave 1 Plan B, VWS-6R4T) — fail-loud
+# tag validation, tolerant chunk IDs, regen-views --check. Single chunk,
+# feature/changelog-fail-loud off develop. gate-noise merged (PR #114,
+# release-pending); its plan is RETAINED and regens via scope=gate-noise.
+active_build_plan: artifacts/build-plan-changelog-fail-loud.md
 
 # =============================================================================
 # COVERAGE EVIDENCE (opt-in, v1.4+)

--- a/bin/prawduct-hook
+++ b/bin/prawduct-hook
@@ -1808,7 +1808,7 @@ def _read_bool_yaml_key(state_path: Path, key: str) -> bool:
 # =============================================================================
 
 
-def cmd_regen_views(project_dir: Path) -> int:
+def cmd_regen_views(project_dir: Path, args: list[str] | None = None) -> int:
     """Regenerate derived views from the change-log canonical store.
 
     Three views are produced in one pass when `views_enabled: true`:
@@ -1821,13 +1821,28 @@ def cmd_regen_views(project_dir: Path) -> int:
     No-op when `views_enabled: true` is absent (enabled by default in v1.4;
     sync auto-enables for existing repos and `false` is the explicit opt-out).
 
+    Validation is fail-CLOSED (VWS-6R4T): every change-log tag is validated
+    against the plan roster BEFORE any view is written, and any ERROR-class
+    finding (unrecognized status=, chunks= ID missing from the plan's Status
+    roster, unreleased scope with no plan file, duplicate scope, conflicting
+    tag lines) aborts the whole regen with exit 2 and nothing written — a
+    partial flip is the silent failure class this command must never produce.
+    Mere tag-line multiplicity (union repair is correct) stays a WARNING.
+
+    `--check` computes + validates but writes NOTHING: the release pre-flight.
+    Exit 0 = tags validate (pending writes are reported, not errors); exit 2 =
+    validation errors.
+
     Exit codes:
-      0 - success (views disabled, no changes needed, or regen applied cleanly)
+      0 - success (views disabled, no changes needed, regen applied cleanly,
+          or --check with clean validation)
       1 - the plugin lib/ could not be imported (incomplete install) — a
           state-mutating command must not report success on a broken install
           (mirrors accept/verify-operator-verification's ImportError handling)
-      2 - I/O or schema error (missing change-log or build-plan)
+      2 - I/O or schema error (missing change-log or build-plan), or a tag
+          validation error (fail closed: no views written)
     """
+    check_only = "--check" in (args or [])
     # Ensure the plugin root is on sys.path so `from lib import views` resolves
     # both when invoked as a script and when imported via SourceFileLoader in tests.
     lib_root = _plugin_root()
@@ -1867,33 +1882,45 @@ def cmd_regen_views(project_dir: Path) -> int:
         print("Views disabled (set views_enabled: true in project-state.yaml).")
         return 0
 
-    # Surface change-log status= typos (e.g. status=shippd) as NON-fatal
-    # warnings on stderr — an unrecognized status silently fails to flip a
-    # checkbox, so we warn rather than letting the typo pass unnoticed. This
-    # does NOT change the exit code or the flip rule (only status==shipped flips).
+    # Validate BEFORE any write (VWS-6R4T, fail closed). The validators are
+    # pure lib functions; severity policy lives here: a tag that would produce
+    # a wrong or silently-partial view is an ERROR that aborts the regen with
+    # nothing written; a tag whose union repair still yields correct output
+    # (mere multiplicity) is a WARNING. The read is load-bearing now — a
+    # change-log read failure fails the command rather than skipping checks.
     try:
         change_log_text = (prawduct_dir / "change-log.md").read_text(encoding="utf-8")
-        parsed_entries = views.parse_change_log(change_log_text)
-        for warning in views.validate_status_values(parsed_entries):
-            print(f"WARNING: {warning}", file=sys.stderr)
-        # Surface entries with multiple tag lines — parse_change_log unions
-        # them (VWS-4D8J) so the regen is correct, but the canonical format is
-        # one line per entry and conflicting scalars were kept first-wins.
-        for warning in views.validate_tag_line_multiplicity(parsed_entries):
-            print(f"WARNING: {warning}", file=sys.stderr)
-        # Surface release-pending (status=merged) scopes with no resolvable
-        # build-plan file, and duplicate scopes across plan files — non-fatal
-        # (warn + skip), mirroring the status-typo precedent above. The regen
-        # itself silently skips an unresolvable scope (REL-4T8N multi-scope).
-        for warning in views.diagnose_scope_plan_coverage(
-            change_log_text, prawduct_dir / "artifacts"
-        ):
-            print(f"WARNING: {warning}", file=sys.stderr)
-    except OSError:
-        # Best-effort advisory only — the regen computation (plan_regen) already
-        # succeeded above and apply_regen still runs below, so a change-log read
-        # hiccup here must not fail the warning-emitting command.
-        pass
+    except OSError as e:
+        print(f"ERROR reading change-log for validation: {e}", file=sys.stderr)
+        return 2
+    parsed_entries = views.parse_change_log(change_log_text)
+    artifacts_dir = prawduct_dir / "artifacts"
+    errors: list[str] = []
+    # Unrecognized status= (typo) — the entry would silently never flip.
+    errors.extend(views.validate_status_values(parsed_entries))
+    # Conflicting scalar values across tag lines — first-wins may be wrong.
+    errors.extend(views.validate_tag_conflicts(parsed_entries))
+    # Unreleased scope with no plan file + duplicate scope across plan files.
+    errors.extend(views.diagnose_scope_plan_coverage(change_log_text, artifacts_dir))
+    # chunks= IDs that match nothing in their plan's Status roster.
+    errors.extend(views.validate_chunk_roster(change_log_text, artifacts_dir))
+    for warning in views.validate_tag_line_multiplicity(parsed_entries):
+        print(f"WARNING: {warning}", file=sys.stderr)
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        print(
+            f"{len(errors)} validation error(s) — no views written. Fix the "
+            f"change-log tags (or plan roster) and re-run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if check_only:
+        for r in results:
+            print(f"[check] {r.summary}")
+        print("check passed: tags validate against the plan roster; nothing written.")
+        return 0
 
     try:
         views.apply_regen(prawduct_dir, results)
@@ -2623,7 +2650,7 @@ _USAGE = (
     "review-stats [--json]|classify-diff-risk [<base>]|"
     "check-operator-verification|accept-operator-verification <rationale>|"
     "verify-operator-verification <vrf-id>|"
-    "check-pr-doc-only|check-change-log-entry|regen-views|stamp-merged|"
+    "check-pr-doc-only|check-change-log-entry|regen-views [--check]|stamp-merged|"
     "infer-critic-mode [args]|"
     "compute-verify-resolutions-scope|resolve-base|advisory <subcmd> [args]|"
     "migrate-plugin [--apply] [--json]|init-product <target> --name <name> [--apply] [--json]|"
@@ -2815,7 +2842,7 @@ def main() -> int:
     elif command == "stamp-merged":
         return cmd_stamp_merged(project_dir)
     elif command == "regen-views":
-        return cmd_regen_views(project_dir)
+        return cmd_regen_views(project_dir, sys.argv[2:])
     elif command == "infer-critic-mode":
         args = " ".join(sys.argv[2:]) if len(sys.argv) > 2 else None
         return cmd_infer_critic_mode(project_dir, args)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,16 +74,22 @@ When `develop` is ready to release as `vX.Y.Z`:
    ```
    <!-- prawduct: chunks=01,02,… | release=vX.Y.Z | status=shipped | scope=<plan-scope> -->
    ```
-4. **Regenerate derived views:** `prawduct-hook regen-views`. With `views_enabled`, the build
+4. **Regenerate derived views:** run `prawduct-hook regen-views --check` first — the
+   pre-flight validates every change-log tag against the plan roster without writing
+   anything (exit 2 + ERROR lines name any tag that would fail to flip); fix errors, then
+   run `prawduct-hook regen-views` for real. With `views_enabled`, the build
    plans' `## Status` checkboxes, release notes, and `scope_rollups` are a *derived view* of
    the change-log's `status=shipped` entries — they flip to `[x]` only at this release step.
    Do **not** hand-edit the checkboxes; `regen-views` would revert the edit.
    **Batched releases (multiple scopes in one version):** a single `regen-views` now regenerates
    the `## Status` of **every** release-pending plan in one pass — it enumerates each distinct
    `scope=` in the change-log (`status` ∈ {`shipped`, `merged`}) and resolves it to its build-plan
-   file via that plan's frontmatter `scope:` (REL-4T8N). You no longer point `active_build_plan` at
-   each plan in turn and re-run per scope. A `status=merged` scope with no matching plan file is
-   reported on stderr and skipped (not fatal).
+   file via that plan's frontmatter `scope:` (REL-4T8N). Validation is fail-closed (VWS-6R4T):
+   an unrecognized `status=`, a `chunks=` ID missing from its plan's `## Status` roster, an
+   unreleased scope with no matching plan file, a duplicate `scope:` across plan files, or
+   conflicting tag lines aborts the whole regen (exit 2, nothing written) — no silent partial
+   flips. Chunk-ID matching is tolerant (`chunks=1` flips `Chunk 01`; case and `-`/`_`
+   variants match).
 5. **Tag the release:** `git tag vX.Y.Z` (and push the tag).
 6. **Confirm the banner.** On the next session against the new `main`, the version-delta banner
    shows `v(old) → vX.Y.Z` plus the crossed releases' change-log highlights, and announces any
@@ -98,7 +104,7 @@ Two values are meaningful to the release flow:
   (merge-flow step 6 runs `prawduct-hook stamp-merged` on the integration branch); a
   **statusless tagged entry on the integration branch therefore means the stamp was
   missed**, not that the work is unmerged — step 3 flips it to `shipped` all the same, and
-  `regen-views` warns when such an entry's `scope=` resolves to no plan file.
+  `regen-views` fails loudly (exit 2) when such an entry's `scope=` resolves to no plan file.
   `regen-views` does **not** flip checkboxes for `merged` entries, so the
   build plan's `## Status` stays `[ ]` and the `active_build_plan` pointer is retained until the
   release (see "KEEP the build plan" in `learnings.md` and the `active_build_plan` note in
@@ -108,11 +114,12 @@ Two values are meaningful to the release flow:
 - **`status=shipped`** — the work is in a tagged release. This is the **only** value that
   `regen-views` flips to `[x]` (in `## Status`, release notes, and `scope_rollups`).
 
-Any other `status=` value (including a typo) is treated like "not shipped" — the entry never
-flips its checkboxes — but `regen-views` surfaces it as a stderr WARNING (the VWS-3K7P
-typo-guard), alongside warnings for entries with multiple tag lines (unioned, VWS-4D8J) and for
-unreleased entries whose `scope=` resolves to no plan file. Treat any `regen-views` WARNING at
-release time as a release-process error to fix before tagging.
+Any other `status=` value (including a typo) is a **fatal validation error** (VWS-6R4T,
+promoting the VWS-3K7P typo-guard): `regen-views` exits 2 with an ERROR line and writes
+nothing, as it does for a `chunks=` ID missing from its plan's roster, an unreleased scope
+with no plan file, duplicate scopes, or conflicting tag lines. Entries with multiple
+non-conflicting tag lines are still unioned with a stderr WARNING (VWS-4D8J) — fix the
+format, but the output is correct. Run `regen-views --check` before tagging; it must exit 0.
 
 ## Step 1 mechanics — promoting when `develop` and `main` have diverged
 

--- a/lib/views.py
+++ b/lib/views.py
@@ -54,6 +54,27 @@ CHUNK_LINE_RE = re.compile(
 CHUNK_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
+def normalize_chunk_id(chunk_id: str) -> str:
+    """Canonical form of a chunk ID for matching (VWS-6R4T).
+
+    Matching between a change-log ``chunks=`` tag and a build-plan
+    ``Chunk <id>:`` line was historically literal string equality, so
+    ``chunks=1`` silently failed to flip ``Chunk 01`` — a partial, invisible
+    failure. Tolerance rules, applied to BOTH sides of every comparison:
+
+    * case-insensitive (``A`` ≡ ``a``)
+    * ``_`` and ``-`` unify (``foo_bar`` ≡ ``foo-bar``)
+    * purely-numeric IDs compare by integer value (``1`` ≡ ``01``)
+
+    The zero-strip applies only when the WHOLE ID is digits, so a mixed ID
+    like ``01a`` keeps its digits verbatim and cannot collide with ``1a``.
+    """
+    norm = chunk_id.strip().casefold().replace("_", "-")
+    if norm.isdigit():
+        norm = str(int(norm))
+    return norm
+
+
 @dataclass
 class ChangeLogEntry:
     """A change-log entry with optional tagged metadata."""
@@ -179,9 +200,10 @@ def validate_status_values(entries: list[ChangeLogEntry]) -> list[str]:
     A change-log ``status=`` typo (e.g. ``status=shippd``) silently fails to flip
     a checkbox — the entry parses fine but ``shipped_chunks`` returns ``[]``, so
     the chunk never marks complete and the release driver sees no error. This
-    pure helper surfaces those typos as non-fatal warnings: it flags every entry
-    whose ``status=`` tag is PRESENT but not in ``{shipped, merged}``. Entries
-    with no ``status=`` tag (untagged historical entries) are not flagged.
+    pure helper flags every entry whose ``status=`` tag is PRESENT but not in
+    ``{shipped, merged}``. Entries with no ``status=`` tag (untagged historical
+    entries) are not flagged. The regen-views caller treats these as fatal
+    (fail closed, nothing written — VWS-6R4T); the function itself stays pure.
 
     Returns ``[]`` when every status value is valid or absent.
     """
@@ -208,9 +230,11 @@ def validate_tag_line_multiplicity(entries: list[ChangeLogEntry]) -> list[str]:
     than silently dropping the later ones (VWS-4D8J — a second line's
     ``chunks=`` nearly shipped unflipped at v2.1.0), but the union is a repair,
     not a blessing: this pure helper (mirroring :func:`validate_status_values`)
-    surfaces each multi-tag entry as a non-fatal warning so the author merges
-    the lines. Conflicting scalar keys were kept first-wins; the warning names
-    the ignored values.
+    surfaces each multi-tag entry so the author merges the lines. The caller
+    treats these as WARNINGS — the union produces correct output. Conflicting
+    scalar values across the lines do NOT (first-wins may pick the wrong one);
+    those are surfaced separately by :func:`validate_tag_conflicts` and treated
+    as errors (VWS-6R4T).
 
     Returns ``[]`` when every entry has at most one tag line.
     """
@@ -218,20 +242,40 @@ def validate_tag_line_multiplicity(entries: list[ChangeLogEntry]) -> list[str]:
     for entry in entries:
         if entry.tag_line_count <= 1:
             continue
-        msg = (
+        warnings.append(
             f"change-log entry {entry.title!r} (line {entry.line_number}) has "
             f"{entry.tag_line_count} prawduct tag lines — the canonical format "
-            f"is one per entry; chunks= lists were unioned across them"
+            f"is one per entry; chunks= lists were unioned across them. Merge "
+            f"them into a single tag line."
         )
-        if entry.tag_conflicts:
-            msg += (
-                "; conflicting keys kept first-wins ("
-                + "; ".join(entry.tag_conflicts)
-                + ")"
-            )
-        msg += ". Merge them into a single tag line."
-        warnings.append(msg)
     return warnings
+
+
+def validate_tag_conflicts(entries: list[ChangeLogEntry]) -> list[str]:
+    """Return an error string per entry whose tag lines CONFLICT (VWS-6R4T).
+
+    When multiple tag lines set the same scalar key to different values,
+    :func:`_merge_tag_line` keeps the first and records the loser in
+    ``tag_conflicts`` — a repair that may have picked the wrong value (e.g.
+    two ``status=`` lines disagreeing about whether work shipped). Unlike mere
+    multiplicity (a style problem the union fixes), a conflict means the
+    derived views may be built from the wrong tag, so the caller treats these
+    as fatal: fix the entry, don't guess.
+
+    Returns ``[]`` when no entry has conflicting tag lines.
+    """
+    errors: list[str] = []
+    for entry in entries:
+        if not entry.tag_conflicts:
+            continue
+        errors.append(
+            f"change-log entry {entry.title!r} (line {entry.line_number}) has "
+            f"conflicting values across its {entry.tag_line_count} tag lines "
+            f"(kept first-wins: " + "; ".join(entry.tag_conflicts) + ") — the "
+            f"derived views may be built from the wrong value. Merge the tag "
+            f"lines and resolve the conflict."
+        )
+    return errors
 
 
 def stamp_merged(content: str) -> tuple[str, list[str]]:
@@ -427,9 +471,14 @@ def regenerate_status_section(
     ``(chunk_id, old_state, new_state)`` with ``state`` in ``{" ", "x"}``.
     Non-chunk lines (the ``## Status`` heading, HTML comments, blanks, the
     ``Context:`` line) pass through unchanged. Order is preserved.
+
+    Membership is tested after :func:`normalize_chunk_id` on BOTH sides, so
+    zero-padding / case / separator variants flip correctly (VWS-6R4T) —
+    ``changes`` still reports the plan's verbatim chunk IDs.
     """
     out: list[str] = []
     changes: list[tuple[str, str, str]] = []
+    shipped_norm = {normalize_chunk_id(c) for c in shipped_chunks}
     for line in section_lines:
         m = CHUNK_LINE_RE.match(line)
         if not m:
@@ -437,7 +486,7 @@ def regenerate_status_section(
             continue
         chunk_id = m.group("id")
         current = m.group("state")
-        new_state = "x" if chunk_id in shipped_chunks else " "
+        new_state = "x" if normalize_chunk_id(chunk_id) in shipped_norm else " "
         if current.lower() != new_state:
             changes.append((chunk_id, current, new_state))
         out.append(f"{m.group('prefix')}[{new_state}]{m.group('rest')}")
@@ -522,10 +571,11 @@ def collect_release_pending_scopes(entries: list[ChangeLogEntry]) -> list[str]:
 def diagnose_scope_plan_coverage(
     change_log_content: str, artifacts_dir: Path
 ) -> list[str]:
-    """Warn about release-pending scopes with no plan file + duplicate scopes.
+    """Flag release-pending scopes with no plan file + duplicate scopes.
 
     Pure diagnostic (mirrors :func:`validate_status_values`): the caller
-    (``cmd_regen_views``) prints the returned strings on stderr. Two cases:
+    (``cmd_regen_views``) prints the returned strings on stderr and treats
+    them as fatal (fail closed — VWS-6R4T). Two cases:
 
     * An unreleased scope with NO matching build-plan file — its ``## Status``
       cannot be regenerated, a real release-process error. "Unreleased" covers
@@ -585,6 +635,82 @@ def diagnose_scope_plan_coverage(
                 f"## Status cannot be regenerated."
             )
     return warnings
+
+
+def validate_chunk_roster(
+    change_log_content: str, artifacts_dir: Path
+) -> list[str]:
+    """One error string per ``chunks=`` ID that can never flip a checkbox (VWS-6R4T).
+
+    The silent-partial-flip failure class: a ``chunks=`` ID that matches no
+    ``Chunk <id>:`` line in its plan's ``## Status`` section simply never
+    flips, with no signal — the entry parses fine, the regen "succeeds", and
+    the miss surfaces months later as a stale checkbox. This pure validator
+    makes the miss loud: for every entry whose ``scope=`` resolves to a
+    build-plan FILE (via :func:`build_scope_to_plan_map`), every ``chunks=``
+    ID must match that plan's Status roster after :func:`normalize_chunk_id`
+    on both sides. It also errors when the entry carries chunk IDs but the
+    plan's roster is empty or the ``## Status`` section is absent.
+
+    Validation applies to entries of EVERY status, shipped included —
+    release-prep flips entries to ``shipped`` *before* running regen-views,
+    so a shipped-exempt validator would never fire at the moment it matters.
+
+    Deliberately outside the contract: entries with no ``scope=`` (legacy
+    unfiltered single-plan repos — no roster to resolve against) and scopes
+    with no plan file (historical/retired plans;
+    :func:`diagnose_scope_plan_coverage` owns the unreleased subset of those).
+
+    Returns ``[]`` when every resolvable ``chunks=`` ID matches its roster.
+    """
+    errors: list[str] = []
+    plan_map = build_scope_to_plan_map(artifacts_dir)
+    # Cache per plan file: (verbatim roster IDs, normalized roster set).
+    rosters: dict[Path, tuple[list[str], set[str]]] = {}
+    for entry in parse_change_log(change_log_content):
+        scope = entry.tags.get("scope")
+        chunks = entry.tags.get("chunks")
+        if not (isinstance(scope, str) and scope):
+            continue
+        if not (isinstance(chunks, list) and chunks):
+            continue
+        plan_path = plan_map.get(scope)
+        if plan_path is None:
+            continue
+        if plan_path not in rosters:
+            try:
+                plan_content = plan_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            _start, _end, section = extract_status_section(plan_content)
+            roster = [
+                m.group("id")
+                for m in (CHUNK_LINE_RE.match(line) for line in section)
+                if m
+            ]
+            rosters[plan_path] = (
+                roster,
+                {normalize_chunk_id(c) for c in roster},
+            )
+        roster, roster_norm = rosters[plan_path]
+        missing = [
+            c
+            for c in chunks
+            if isinstance(c, str) and normalize_chunk_id(c) not in roster_norm
+        ]
+        if missing:
+            roster_desc = (
+                ", ".join(roster)
+                if roster
+                else "(empty — no chunk checkboxes in ## Status)"
+            )
+            errors.append(
+                f"change-log entry {entry.title!r} (line {entry.line_number}) "
+                f"has chunks={','.join(missing)} not present in "
+                f"{plan_path.name}'s ## Status roster [{roster_desc}] — these "
+                f"IDs will never flip a checkbox (scope={scope!r})."
+            )
+    return errors
 
 
 YAML_TOP_LEVEL_KEY_RE = re.compile(r"^(?P<key>[A-Za-z_][A-Za-z0-9_]*):\s*")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -291,7 +291,9 @@ class TestValidateTagLineMultiplicity:
         assert "2 prawduct tag lines" in warnings[0]
         assert "unioned" in warnings[0]
 
-    def test_conflicts_named_in_warning(self):
+    def test_conflicts_not_in_multiplicity_warning(self):
+        # Conflicting scalars are validate_tag_conflicts' job now (VWS-6R4T);
+        # the multiplicity warning covers only the style problem.
         entries = views.parse_change_log(
             "## X\n"
             "<!-- prawduct: status=shipped -->\n"
@@ -299,8 +301,7 @@ class TestValidateTagLineMultiplicity:
         )
         warnings = views.validate_tag_line_multiplicity(entries)
         assert len(warnings) == 1
-        assert "first-wins" in warnings[0]
-        assert "ignored 'merged'" in warnings[0]
+        assert "first-wins" not in warnings[0]
 
     def test_one_warning_per_multi_tag_entry(self):
         entries = views.parse_change_log(
@@ -310,6 +311,164 @@ class TestValidateTagLineMultiplicity:
         )
         warnings = views.validate_tag_line_multiplicity(entries)
         assert len(warnings) == 2
+
+
+class TestValidateTagConflicts:
+    def test_conflicting_scalars_are_errors(self):
+        entries = views.parse_change_log(
+            "## X\n"
+            "<!-- prawduct: status=shipped -->\n"
+            "<!-- prawduct: status=merged -->\n"
+        )
+        errors = views.validate_tag_conflicts(entries)
+        assert len(errors) == 1
+        assert "first-wins" in errors[0]
+        assert "ignored 'merged'" in errors[0]
+
+    def test_union_without_conflict_is_clean(self):
+        # Multiple tag lines whose scalars AGREE (or don't overlap) union
+        # cleanly — multiplicity is a warning elsewhere, not a conflict.
+        entries = views.parse_change_log(
+            "## X\n"
+            "<!-- prawduct: chunks=01 | status=shipped -->\n"
+            "<!-- prawduct: chunks=02 | status=shipped -->\n"
+        )
+        assert views.validate_tag_conflicts(entries) == []
+
+    def test_single_tag_line_is_clean(self):
+        entries = views.parse_change_log(
+            "## X\n<!-- prawduct: chunks=01 | status=shipped -->\n"
+        )
+        assert views.validate_tag_conflicts(entries) == []
+
+
+class TestNormalizeChunkId:
+    def test_numeric_zero_padding(self):
+        assert views.normalize_chunk_id("01") == views.normalize_chunk_id("1")
+        assert views.normalize_chunk_id("007") == views.normalize_chunk_id("7")
+        assert views.normalize_chunk_id("0") == "0"
+
+    def test_case_insensitive(self):
+        assert views.normalize_chunk_id("A") == views.normalize_chunk_id("a")
+
+    def test_separators_unify(self):
+        assert views.normalize_chunk_id("foo_bar") == views.normalize_chunk_id(
+            "foo-bar"
+        )
+
+    def test_mixed_ids_keep_digits_verbatim(self):
+        # Zero-strip applies only to purely-numeric IDs: "01a" must NOT
+        # collide with "1a".
+        assert views.normalize_chunk_id("01a") == "01a"
+        assert views.normalize_chunk_id("01a") != views.normalize_chunk_id("1a")
+
+    def test_whitespace_stripped(self):
+        assert views.normalize_chunk_id(" 01 ") == "1"
+
+
+class TestValidateChunkRoster:
+    def _arrange(self, tmp_path, plan_content: str) -> "Path":
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "build-plan-feat.md").write_text(
+            "---\nartifact: build-plan\nscope: feat\n---\n" + plan_content
+        )
+        return artifacts
+
+    def test_miss_names_entry_id_and_roster(self, tmp_path):
+        artifacts = self._arrange(
+            tmp_path, "## Status\n- [ ] Chunk 01: A\n- [ ] Chunk 02: B\n"
+        )
+        errors = views.validate_chunk_roster(
+            "## E\n<!-- prawduct: chunks=03 | scope=feat | status=merged -->\n",
+            artifacts,
+        )
+        assert len(errors) == 1
+        assert "chunks=03" in errors[0]
+        assert "01, 02" in errors[0]
+        assert "build-plan-feat.md" in errors[0]
+
+    def test_tolerant_match_suppresses_zero_padding_miss(self, tmp_path):
+        # The historical false miss: chunks=1 against a `Chunk 01:` roster.
+        artifacts = self._arrange(tmp_path, "## Status\n- [ ] Chunk 01: A\n")
+        errors = views.validate_chunk_roster(
+            "## E\n<!-- prawduct: chunks=1 | scope=feat | status=shipped -->\n",
+            artifacts,
+        )
+        assert errors == []
+
+    def test_shipped_entries_validated_too(self, tmp_path):
+        # Release-prep flips to shipped BEFORE running regen-views, so
+        # shipped entries with a resolvable plan are inside the contract.
+        artifacts = self._arrange(tmp_path, "## Status\n- [ ] Chunk 01: A\n")
+        errors = views.validate_chunk_roster(
+            "## E\n<!-- prawduct: chunks=09 | scope=feat | status=shipped -->\n",
+            artifacts,
+        )
+        assert len(errors) == 1
+
+    def test_scope_without_plan_file_skipped(self, tmp_path):
+        # Historical/retired plans: no file to validate against — the
+        # unreleased subset is diagnose_scope_plan_coverage's job.
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        errors = views.validate_chunk_roster(
+            "## E\n<!-- prawduct: chunks=01 | scope=gone | status=shipped -->\n",
+            artifacts,
+        )
+        assert errors == []
+
+    def test_scopeless_entry_skipped(self, tmp_path):
+        # Legacy unfiltered single-plan repos: no scope= → no roster to
+        # resolve against; outside the contract.
+        artifacts = self._arrange(tmp_path, "## Status\n- [ ] Chunk 01: A\n")
+        errors = views.validate_chunk_roster(
+            "## E\n<!-- prawduct: chunks=99 | status=shipped -->\n",
+            artifacts,
+        )
+        assert errors == []
+
+    def test_empty_roster_with_chunks_is_error(self, tmp_path):
+        artifacts = self._arrange(tmp_path, "## Status\nContext: no boxes.\n")
+        errors = views.validate_chunk_roster(
+            "## E\n<!-- prawduct: chunks=01 | scope=feat | status=merged -->\n",
+            artifacts,
+        )
+        assert len(errors) == 1
+        assert "empty" in errors[0]
+
+    def test_clean_change_log_no_errors(self, tmp_path):
+        artifacts = self._arrange(
+            tmp_path, "## Status\n- [x] Chunk 01: A\n- [ ] Chunk 02: B\n"
+        )
+        errors = views.validate_chunk_roster(
+            "## E1\n<!-- prawduct: chunks=01 | scope=feat | status=shipped -->\n"
+            "## E2\n<!-- prawduct: chunks=02 | scope=feat | status=merged -->\n",
+            artifacts,
+        )
+        assert errors == []
+
+
+class TestTolerantStatusFlip:
+    """VWS-6R4T: chunk-ID matching is normalized on both sides of the flip."""
+
+    def test_unpadded_tag_flips_padded_roster(self):
+        section = ["## Status", "- [ ] Chunk 01: A", "- [ ] Chunk 02: B"]
+        new_lines, changes = views.regenerate_status_section(section, {"1"})
+        assert "- [x] Chunk 01: A" in new_lines
+        assert "- [ ] Chunk 02: B" in new_lines
+        assert changes == [("01", " ", "x")]
+
+    def test_case_and_separator_variants_flip(self):
+        section = ["## Status", "- [ ] Chunk Foo_Bar: A", "- [ ] Chunk B: b"]
+        new_lines, _ = views.regenerate_status_section(section, {"foo-bar", "b"})
+        assert "- [x] Chunk Foo_Bar: A" in new_lines
+        assert "- [x] Chunk B: b" in new_lines
+
+    def test_exact_match_still_flips(self):
+        section = ["## Status", "- [ ] Chunk 01: A"]
+        new_lines, _ = views.regenerate_status_section(section, {"01"})
+        assert "- [x] Chunk 01: A" in new_lines
 
 
 class TestCollectShippedChunks:
@@ -1930,10 +2089,12 @@ def _make_product_repo(
     return product
 
 
-def _run_regen(product_dir: Path) -> subprocess.CompletedProcess:
+def _run_regen(
+    product_dir: Path, *extra_args: str
+) -> subprocess.CompletedProcess:
     env = {**os.environ, "CLAUDE_PROJECT_DIR": str(product_dir)}
     return subprocess.run(
-        ["python3", str(HOOK_PATH), "regen-views"],
+        ["python3", str(HOOK_PATH), "regen-views", *extra_args],
         capture_output=True,
         text=True,
         env=env,
@@ -2180,12 +2341,13 @@ class TestRegenViewsImportError:
         )
 
 
-class TestRegenViewsStatusTypoWarning:
-    """VWS-3K7P: a change-log `status=` typo is surfaced on stderr as a
-    NON-fatal warning — regen still succeeds (exit 0) and still flips the
-    valid entries; only the typoed entry fails to flip (as it always did)."""
+class TestRegenViewsStatusTypoError:
+    """VWS-3K7P → VWS-6R4T: a change-log `status=` typo is now FATAL. The
+    typoed entry would silently never flip, so regen fails closed — exit 2,
+    ERROR on stderr, and NOTHING written (not even the valid entries — a
+    partial flip is the failure class the fail-closed contract forbids)."""
 
-    def test_typo_warns_on_stderr_non_fatal(self, tmp_path: Path):
+    def test_typo_errors_and_writes_nothing(self, tmp_path: Path):
         product = _make_product_repo(
             tmp_path,
             views_enabled=True,
@@ -2203,14 +2365,13 @@ class TestRegenViewsStatusTypoWarning:
             ),
         )
         result = _run_regen(product)
-        # Non-fatal: command still succeeds.
-        assert result.returncode == 0, result.stderr
-        # Warning surfaced on stderr, naming the bad value.
+        assert result.returncode == 2, result.stdout + result.stderr
         assert "shippd" in result.stderr
-        assert "warning" in result.stderr.lower()
+        assert "ERROR" in result.stderr
+        assert "no views written" in result.stderr
         new_plan = (product / ".prawduct" / "artifacts" / "build-plan.md").read_text()
-        # Valid entry flipped; typoed entry did NOT flip (flip rule unchanged).
-        assert "- [x] Chunk 00: A" in new_plan
+        # Fail closed: NOTHING flipped, valid entry included.
+        assert "- [ ] Chunk 00: A" in new_plan
         assert "- [ ] Chunk 01: B" in new_plan
 
     def test_no_warning_when_all_valid(self, tmp_path: Path):
@@ -2262,6 +2423,173 @@ class TestRegenViewsMultiTagLineWarning:
         assert "- [x] Chunk 00: A" in new_plan
         assert "- [x] Chunk 01: B" in new_plan
         assert "- [ ] Chunk 02: C" in new_plan
+
+
+def _make_scoped_product_repo(
+    tmp_path: Path, *, change_log: str, plan_status: str, scope: str = "feat"
+) -> Path:
+    """Product repo whose build plan declares a frontmatter scope (VWS-6R4T)."""
+    product = tmp_path / "product"
+    (product / ".prawduct" / "artifacts").mkdir(parents=True)
+    (product / ".prawduct" / "project-state.yaml").write_text("views_enabled: true\n")
+    (product / ".prawduct" / "change-log.md").write_text(change_log)
+    (product / ".prawduct" / "artifacts" / f"build-plan-{scope}.md").write_text(
+        f"---\nartifact: build-plan\nscope: {scope}\n---\n{plan_status}"
+    )
+    return product
+
+
+class TestRegenViewsFailClosed:
+    """VWS-6R4T: any tag validation error aborts the whole regen — exit 2,
+    ERROR on stderr, NOTHING written (no silent partial flips)."""
+
+    def test_roster_miss_errors_and_writes_nothing(self, tmp_path: Path):
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: good\n"
+                "<!-- prawduct: chunks=01 | scope=feat | status=shipped |"
+                " release=v1.0.0 -->\n"
+                "\n"
+                "## 2026-07-02: bad chunk id\n"
+                "<!-- prawduct: chunks=07 | scope=feat | status=shipped -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n- [ ] Chunk 02: B\n",
+        )
+        result = _run_regen(product)
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "chunks=07" in result.stderr
+        assert "never flip" in result.stderr
+        # Fail closed across ALL views: plan untouched, release-notes absent.
+        plan = (
+            product / ".prawduct" / "artifacts" / "build-plan-feat.md"
+        ).read_text()
+        assert "- [ ] Chunk 01: A" in plan
+        assert not (product / ".prawduct" / "release-notes.md").exists()
+
+    def test_tolerant_id_variant_is_not_an_error_and_flips(self, tmp_path: Path):
+        # chunks=1 against a `Chunk 01:` roster: the exact case the tolerant
+        # matcher exists for — validates clean AND flips.
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: unpadded\n"
+                "<!-- prawduct: chunks=1 | scope=feat | status=shipped -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n",
+        )
+        result = _run_regen(product)
+        assert result.returncode == 0, result.stderr
+        plan = (
+            product / ".prawduct" / "artifacts" / "build-plan-feat.md"
+        ).read_text()
+        assert "- [x] Chunk 01: A" in plan
+
+    def test_conflicting_tag_lines_error(self, tmp_path: Path):
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: conflicted\n"
+                "<!-- prawduct: chunks=01 | scope=feat | status=shipped -->\n"
+                "<!-- prawduct: status=merged -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n",
+        )
+        result = _run_regen(product)
+        assert result.returncode == 2
+        assert "conflicting" in result.stderr.lower()
+        plan = (
+            product / ".prawduct" / "artifacts" / "build-plan-feat.md"
+        ).read_text()
+        assert "- [ ] Chunk 01: A" in plan
+
+    def test_unreleased_scope_without_plan_errors(self, tmp_path: Path):
+        # Promoted from WARNING (REL-4T8N warn-and-skip): a merged scope with
+        # no plan file means its Status can never regenerate — fatal now.
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: merged into develop\n"
+                "<!-- prawduct: chunks=01 | scope=ghost | status=merged -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n",
+        )
+        result = _run_regen(product)
+        assert result.returncode == 2
+        assert "ghost" in result.stderr
+        assert "no matching build-plan file" in result.stderr
+
+    def test_shipped_scope_without_plan_still_exempt(self, tmp_path: Path):
+        # Historical/retired plans stay exempt — a shipped scope with no file
+        # is expected (predates scope: frontmatter or plan was retired).
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: historical\n"
+                "<!-- prawduct: chunks=01 | scope=old | status=shipped |"
+                " release=v0.9.0 -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n",
+        )
+        result = _run_regen(product)
+        assert result.returncode == 0, result.stderr
+
+    def test_duplicate_scope_across_plans_errors(self, tmp_path: Path):
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: e\n"
+                "<!-- prawduct: chunks=01 | scope=feat | status=merged -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n",
+        )
+        (product / ".prawduct" / "artifacts" / "build-plan-second.md").write_text(
+            "---\nartifact: build-plan\nscope: feat\n---\n## Status\n"
+        )
+        result = _run_regen(product)
+        assert result.returncode == 2
+        assert "duplicate scope" in result.stderr.lower()
+
+
+class TestRegenViewsCheckFlag:
+    """`regen-views --check`: validate + report, never write (VWS-6R4T)."""
+
+    def test_check_clean_exits_zero_and_writes_nothing(self, tmp_path: Path):
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: pending flip\n"
+                "<!-- prawduct: chunks=01 | scope=feat | status=shipped |"
+                " release=v1.0.0 -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n",
+        )
+        result = _run_regen(product, "--check")
+        assert result.returncode == 0, result.stderr
+        assert "check passed" in result.stdout
+        # Pending writes are REPORTED (not errors) and NOT applied.
+        assert "[check]" in result.stdout
+        plan = (
+            product / ".prawduct" / "artifacts" / "build-plan-feat.md"
+        ).read_text()
+        assert "- [ ] Chunk 01: A" in plan  # unflipped
+        assert not (product / ".prawduct" / "release-notes.md").exists()
+
+    def test_check_with_violation_exits_two_and_writes_nothing(
+        self, tmp_path: Path
+    ):
+        product = _make_scoped_product_repo(
+            tmp_path,
+            change_log=(
+                "## 2026-07-02: bad\n"
+                "<!-- prawduct: chunks=09 | scope=feat | status=shipped -->\n"
+            ),
+            plan_status="## Status\n- [ ] Chunk 01: A\n",
+        )
+        result = _run_regen(product, "--check")
+        assert result.returncode == 2
+        assert "chunks=09" in result.stderr
+        assert not (product / ".prawduct" / "release-notes.md").exists()
 
 
 # =============================================================================


### PR DESCRIPTION
## What

Closes the silent-partial-flip failure class (~12 of 71 learnings trace to it): `regen-views` now validates every change-log tag against the plan roster **before writing anything** — status typos, roster-miss `chunks=` IDs, unreleased scopes without plan files, duplicate scopes, and conflicting tag lines abort with exit 2 and nothing written.

- **Fail-loud tag validation** (`lib/views.py`): pure validators, severity policy centralized in `cmd_regen_views`; errors abort before any write, multiplicity stays a warning.
- **Tolerant chunk-ID matching**: case, `-`/`_`, and zero-padding normalize (`chunks=1` flips `Chunk 01`); collision-safe (zero-strip gated on all-digit IDs).
- **`regen-views --check`**: read-only pre-flight for the release flow; `docs/release-process.md` updated to the fail-closed contract.
- Vocabulary shrink (dropping `status=merged`/stamp-merged) descoped to REL-4Q9V per recorded HIGH-impact assumption.

## Governance

- Tests: 1529 passed / 0 failed (fresh evidence this session).
- Cumulative Critic: clean (1 NOTE, actioned on-branch); verify-resolutions chain record covers HEAD.
- Independent PR review (fable, escalate tier): 0 blocking, 1 warning, 1 note — both resolved on-branch (restored `## Promoted` backlog heading; repointed `active_build_plan`).
- Filed CRT-5D8Q: PR-gate coverage vs verify-resolutions scope disagree on the metadata exemption (surfaced live during this branch's review chain).