### PR TITLE
docs(norms): ratify prawduct's norm registry — 20 Direction norms (norm-lifecycle Layer 2)

### DIFF
--- a/.prawduct/artifacts/api-contract.md
+++ b/.prawduct/artifacts/api-contract.md
@@ -35,6 +35,21 @@ The canonical contract lives in: `hooks/hooks.json` (which events invoke which s
 usage string and each subcommand's argv parsing, and the `--json` output shapes documented here and
 in `docs/governance-telemetry.md`.
 
+## Direction
+
+<!-- Ratified norms (2026-07-17). The Versioning, Error Model, and Deprecation sections below hold
+     the full descriptive detail; these are their binding form. See docs/norms.md. -->
+
+- **Whole-surface semantic versioning on the plugin; the internal CLI subcommand surface carries no per-subcommand version; persisted data that outlives a plugin version (the evidence store) is independently schema-versioned with forward-incompatibility detection.** (recorded decision `api_versioning_approach`)
+  Why: the plugin semver is the auto-update cache key and the one versioning handle a consumer sees; the CLI is an internal surface carried at the same version as its skill callers, so per-subcommand versioning would be ceremony without a consumer; the evidence store is the one contract that must survive across versions, so it is versioned independently and a schema-ahead fact blocks loudly. Revisit trigger: the first non-prawduct caller of `prawduct-hook` — add a stability tier + a `--version` handle before it ships.
+  Status: steady-state (mirrored in `project-state.yaml` `design_decisions.api_versioning_approach` / `api_versioning_decided`).
+- **Exit codes are the contract, on a documented and consistent scheme; message severity is a stable prefix vocabulary; errors are attributed, never raised as stack traces across the boundary.** (recorded decision `api_error_model_approach`)
+  Why: skills bind to exit codes, not parsed text, so a stable exit-code scheme + prefix vocabulary is what lets a narrow command be allowlisted instead of arbitrary `python3 -c`; a leaked stack trace across the boundary is an unattributed failure a caller cannot act on.
+  Status: steady-state. Current state: applied inline per subcommand rather than centralized behind named constants — this artifact is the canonical statement, and new subcommands cite it rather than inventing a return convention.
+- **Additive-first evolution: new subcommands and flags are added; existing flag names, exit-code meanings, and `--json` keys are never repurposed, and `--json` readers tolerate unknown keys.**
+  Why: additive-first plus tolerant readers is what keeps new versions rare and keeps a skill shipped at version N from breaking when the CLI grows at N+1; deprecation is signalled (stderr notice, kept working, removal deferred to a major), never silent.
+  Status: steady-state.
+
 ## Operations
 
 The CLI groups by responsibility. Every subcommand is read-only unless marked mutating.

--- a/.prawduct/artifacts/architecture.md
+++ b/.prawduct/artifacts/architecture.md
@@ -47,6 +47,24 @@ what we want to be true.
    the clone's shared evidence store (inside `.git`). Governance code and methodology ship in the
    plugin and stay there. This is what lets a repo commit only a tiny install reference.
 
+## Direction
+
+<!-- Ratified norms (2026-07-17). The descriptive Design Intent above motivates these; the entries
+     below are their binding form. See docs/norms.md. -->
+
+- **An independent reviewer never mutates the session it reviews — enforced at the mutation site, not by tool-restriction alone.**
+  Why: a dispatched subagent does not inherit the coordinator's tool limits, so the invariant must be enforced where mutation happens; this is the load-bearing governance guarantee — without it the reviewed party could quietly rewrite what it is being judged on.
+  Status: steady-state. Mechanism: `prawduct-hook clear` refuses while a review is active (`critic-begin` … `critic-consolidate`/`critic-end`).
+- **Authority fails closed; advice fails soft.**
+  Why: anything that produces or consumes a governance *verdict* blocks on incomplete, malformed, or ambiguous state (so governance means something), while anything that merely *informs* degrades to a note (so governance stays bearable) — the split is also an abuse-resistance property: you cannot make a gate pass by feeding it garbage, garbage makes it block.
+  Status: steady-state.
+- **Local-first: coordination is process-spawn + atomically-written files + the git object database — no network, no daemon, and the runtime carries no third-party dependencies (dev/test tooling excepted).**
+  Why: a governance layer that required infrastructure would not survive contact with "I just want to code," and a zero-dependency stdlib runtime shrinks the supply-chain surface to prawduct's own code plus git; any future network surface is a characteristic flip, not a quiet addition.
+  Status: steady-state.
+- **The plugin writes nothing into a governed repo except its own `.prawduct/` state, the shared evidence store, and the `.gitignore` / `.claude/settings*.json` it must reconcile — never framework files.**
+  Why: least authority over the machine is what makes running the plugin a safe trust decision and what lets a governed repo commit only a tiny install reference; framework code stays in the plugin, read-only from the repo's perspective.
+  Status: steady-state.
+
 ## Process Topology — "monolith with workers"
 
 The **monolith** is a single long-lived Claude Code session. The **workers** are short-lived: hook

--- a/.prawduct/artifacts/data-model.md
+++ b/.prawduct/artifacts/data-model.md
@@ -47,6 +47,27 @@ out where reality still lags.
    (`.advisories.json`, the evidence store, session state). A teammate's committed decision resolves
    an advisory for everyone; local nag state never pollutes the shared record.
 
+## Direction
+
+<!-- Ratified norms (2026-07-17). The descriptive Design Intent above motivates these; the entries
+     below are their binding form. See docs/norms.md. -->
+
+- **Governance verdicts on the Critic data plane are computed from the append-only fact ledger, never from mutable model-written state — no model sits in a fact's write path.** Facts are written by deterministic code; a reviewer's judgment enters only as validated content inside a partial that code checks against a code-written manifest before it becomes a fact.
+  Why: the governed party must never be able to certify itself — deriving every verdict from code-written facts is what keeps model judgment out of the authority path and lets any worktree reconstruct the same verdict from the same log.
+  Status: steady-state — scoped to the Critic data plane (kernel v3). Test-run and PR-review evidence still live in their own files; extending the store to subsume them (reserved kinds `test-run`/`pr-review`/`promotion`) is design direction, not yet a ratified norm.
+- **Facts are immutable and append-only; a state change is expressed as a new fact, never an edit or delete in place.**
+  Why: append-only history is what lets any checkout replay the same verdict from the same log — an in-place edit or delete would make the ledger unreproducible and a verdict unauditable.
+  Status: steady-state.
+- **Derived views are disposable and never authoritative — no gate reads a view to reach a verdict.**
+  Why: a view (`.critic-findings.json` and kin) exists for human/agent read-speed and may be regenerated or deleted at will; letting a gate trust one would smuggle mutable, model-adjacent state back into the authority path.
+  Status: steady-state.
+- **A fact written by a newer schema than the reader is surfaced as a loud block, never silently dropped.**
+  Why: forward-incompatibility must be visible — silently skipping an ahead-of-schema fact would let a gate render a verdict on incomplete evidence.
+  Status: steady-state. Mechanism: `evidence status` exit 2 (schema-ahead).
+- **Two stores, two lifetimes: shared committed *answers* are kept distinct from per-clone, gitignored *nags and caches*.**
+  Why: a teammate's committed decision must resolve state for everyone, while local nag/cache/session state must never pollute the shared record; collapsing the two would either leak local state into the repo or block a shared decision from propagating.
+  Status: steady-state.
+
 ## Entities
 
 Prawduct's stores fall into three tiers: **ledger** (source of truth), **committed curated state**

--- a/.prawduct/artifacts/nonfunctional-requirements.md
+++ b/.prawduct/artifacts/nonfunctional-requirements.md
@@ -11,15 +11,27 @@ last_validated: null
 <!-- Written toward the targets we want to hold, not a transcript of current measurements.
      Where a target is aspirational or where reality currently lags, the text says so. -->
 
+## Direction
+
+<!-- Ratified norms (2026-07-17). See docs/norms.md. -->
+
+- **Review wall-clock is a P0 constraint: cost = unit-cost × run-count, so run-count is the lever — fewer, well-scoped reviews — and the two independent reviews at the PR boundary run in parallel, never sequentially.**
+  Why: review latency is what determines whether governance feels like a partner or a tax; per-review cost is treated as fixed (reviewers inherit the session model — reviewer-model tiering was removed, the manifest's `tier` is telemetry only), so the only lever is how *often* we review, set by gate and chunk structure.
+  Status: steady-state.
+- **State-file growth past its size threshold is surfaced as an advisory warning that prompts compaction — it is never a hard block or mechanical enforcement.**
+  Why: oversized governance state is a real context-weight cost, but blocking a session on file size would be disproportionate for a local tool — this is advice (fail-soft), not authority; an over-threshold file is the nag's designed target, not a violation, so no ratification retroactivity applies.
+  Status: steady-state.
+
 ## Performance
 
 Prawduct's performance budget is dominated by one thing: **the wall-clock cost of independent
 review.** This is treated as a **P0 constraint**, because review latency is what determines whether
 governance feels like a partner or a tax.
 
-The governing model is **cost = unit-cost × run-count**. The reviewer model tier fixes the unit
-cost; **run-count is a design variable set by gate and chunk structure.** We therefore optimize
-run-count first (fewer, well-scoped reviews) and treat the per-review cost as fixed.
+The governing model is **cost = unit-cost × run-count**. Per-review cost is treated as fixed —
+reviewers inherit the session model (reviewer-model tiering was removed; the manifest's `tier` is
+telemetry only) — while **run-count is a design variable set by gate and chunk structure.** We
+therefore optimize run-count first (fewer, well-scoped reviews).
 
 Targets we want to hold:
 
@@ -83,10 +95,10 @@ probe or malformed state file never takes down a session.
 
 ## Cost Constraints
 
-- **The only meaningful operating cost is reviewer tokens.** Independent reviewers run on the most
-  capable model tier (opus, established as the efficiency frontier — a cheaper tier produced no
-  novel findings at higher net cost). The lever for cost is therefore **run-count**, controlled by
-  gate and chunk design, not by downgrading the reviewer.
+- **The only meaningful operating cost is reviewer tokens.** Independent reviewers inherit the
+  session model (reviewer-model tiering was removed — the manifest's `tier` is telemetry only and
+  selects no model). The lever for cost is therefore **run-count**, controlled by gate and chunk
+  design, not the reviewer model.
 - **No infrastructure cost.** No hosting, no external services, no databases — prawduct is a plugin
   distributed via a git-backed marketplace and runs entirely on the user's machine.
 - **Context weight is a cost.** Oversized governance state (backlog, learnings, project-state)

--- a/.prawduct/artifacts/observability-strategy.md
+++ b/.prawduct/artifacts/observability-strategy.md
@@ -33,6 +33,17 @@ The scenarios this design must make answerable:
 If those five are answerable from the terminal and the committed/local state, observability has
 done its job.
 
+## Direction
+
+<!-- Ratified norms (2026-07-17). See docs/norms.md. -->
+
+- **Terminal signals use a stable severity-prefix vocabulary (`CRITICAL:` / `WARNING:` / `NOTE:` / `PRAWDUCT:` / `BLOCKED —…`) with a channel split: stdout is the agent-facing channel (composed into model context), stderr is the user-and-diagnostics channel.**
+  Why: the AI runtime is a primary observability consumer, so a stable prefix vocabulary is what makes terminal output machine-legible, and the stdout/stderr split keeps context-injection clean while warnings and blocker text still reach the human.
+  Status: steady-state.
+- **The governance ledger has a single writer (the `ledger-append` helper); agents never hand-author it.**
+  Why: the derived metrics `review-stats` reports are only trustworthy if the event stream has one disciplined writer — a hand-authored ledger line is an unvalidated fact in the observability path.
+  Status: steady-state.
+
 ## Architecture
 
 ```

--- a/.prawduct/artifacts/operational-spec.md
+++ b/.prawduct/artifacts/operational-spec.md
@@ -13,6 +13,18 @@ last_validated: null
      backed up, and recovered. There is no server — deployment is a version promotion. Written
      toward the operational model we want. -->
 
+## Direction
+
+<!-- Ratified norms (2026-07-17). The Release Flow section below holds the descriptive detail; these
+     are their binding form. See docs/norms.md. -->
+
+- **Versioning is conservative: a small feature is a patch bump, not a minor-per-feature.**
+  Why: keeps the version number meaningful rather than inflating it — the plugin semver is the one handle a consumer reads and the auto-update cache key, so it should track real significance. A departure (a minor bump for a small change, or the reverse) is a recorded decision, not a reflex.
+  Status: steady-state. Judgment norm — no mechanical size test; audited by the janitor.
+- **Gitflow: `develop` is the integration branch (features branch off it and merge back); `main` is the release surface and only ever holds releases; the `develop`→`main` promotion is a separate, deliberate tree-set step, never a `/prawduct:pr`.**
+  Why: keeping releases on `main` as single-parent promotions (content-identical to `develop`, divergent history) is what lets the branch-pinned marketplace resolve a clean release while feature granularity stays on `develop`; conflating the two would either ship integration WIP or lose the release boundary.
+  Status: steady-state.
+
 ## Deployment
 
 Prawduct is a **Claude Code plugin**, and it *is* its own single-plugin, git-backed marketplace.

--- a/.prawduct/artifacts/project-preferences.md
+++ b/.prawduct/artifacts/project-preferences.md
@@ -64,18 +64,49 @@ Each preference is enforced by one of three mechanisms. This table is the source
 | **Critic** | `/critic` review (Goal 4: Norms) | Judgment-required rules (boundary detection, semantic naming, "appropriate" anything) | No false-confidence test. Cost: requires a reviewer per chunk; misses violations between reviews. |
 | **Session config** | Read by Claude/methodology at session boundaries (e.g., `building.md` reads `Branching`; `/pr` reads `PR creation`) | Workflow-level decisions (when to branch, when to PR) | Configuration, not enforcement. Validated by user observing Claude's behavior, not by a test or a reviewer. |
 
-| Preference | Mechanism | Enforcement artifact |
-|---|---|---|
-| `from __future__ import annotations` (Imports) | Test | `tests/preferences/test_future_annotations.py` |
-| pytest-xdist parallelization config | Test | `tests/preferences/test_parallelization_config.py` |
-| Sync-only architecture (no `async def`, no `asyncio`) | Test | `tests/preferences/test_sync_only_architecture.py` |
-| Subprocess safety (no `shell=True`) | Test | `tests/preferences/test_subprocess_safety.py` |
-| Test location (`test_*.py` only under `tests/`) | Test | `tests/preferences/test_test_location.py` |
-| Public functions in `lib/` referenced in tests | Critic | Goal 1 (test-coverage adequacy) — the dedicated `test_public_function_coverage` scanner was retired with `tools/lib/` (M4); restore a `lib/`-scoped scanner if drift appears |
-| Naming (snake_case / PascalCase / UPPER_SNAKE) | Critic *(would be linter; no linter configured — see "Linting" above)* | Reviewer reads diff against this preference |
-| Error handling (return-value based; exceptions at boundaries) | Critic | Reviewer judges what counts as a "boundary" per the definition above |
-| Class-based test grouping (allows scenario-based class names) | Critic | Reviewer judges whether grouping is sensible — strict `Test<FuncName>` would over-enforce |
-| Branching / PR creation / PR merge / PR merge strategy (Workflow) | Session config | Read by `building.md`, `/pr`, etc. at decision points |
-| All others (Language, Version, Style, Type annotations, Testing strategy, File organization) | Critic | Reviewer reads diff against this preference |
+This is the product's **norm index** (`docs/norms.md`): each row assigns an enforcement mechanism, an **audit home** (which time-domain organ catches drift — `janitor` for judgment norms with no machine-readable hook; `advisory` only when a mechanical hook is named), and a terse **why**. It has two parts: **code-level preferences** (below) and **architectural Direction norms** (the pointer table after it, indexing the `## Direction` sections in the strategy artifacts).
 
-**Rule for adding a new preference:** assign a mechanism. If the preference can be expressed as "every file/function/config matches pattern X with named exceptions" → write a test. If it requires understanding intent → assign to Critic. Never leave a preference unassigned — that's how preferences silently become aspirational.
+### Code-level preferences
+
+| Preference | Mechanism | Enforcement artifact | Audit home | Why |
+|---|---|---|---|---|
+| `from __future__ import annotations` (Imports) | Test | `tests/preferences/test_future_annotations.py` | CI (test) | uniform forward-ref typing across the runtime |
+| pytest-xdist parallelization config | Test | `tests/preferences/test_parallelization_config.py` | CI (test) | parallel fixture/state isolation must not regress |
+| Sync-only architecture (no `async def`, no `asyncio`) | Test | `tests/preferences/test_sync_only_architecture.py` | CI (test) | CLI tools with deterministic I/O — async adds no value, only surface |
+| Subprocess safety (no `shell=True`) | Test | `tests/preferences/test_subprocess_safety.py` | CI (test) | `shell=True` is a command-injection surface (`security-model.md` supply-chain) |
+| Test location (`test_*.py` only under `tests/`) | Test | `tests/preferences/test_test_location.py` | CI (test) | `testpaths` silently skips misplaced tests |
+| Public functions in `lib/` referenced in tests | Critic | Goal 1 (test-coverage adequacy) — the dedicated `test_public_function_coverage` scanner was retired with `tools/lib/` (M4); restore a `lib/`-scoped scanner if drift appears | Critic + janitor | untested public API drifts in silently |
+| Naming (snake_case / PascalCase / UPPER_SNAKE) | Critic *(would be linter; no linter configured — see "Linting" above)* | Reviewer reads diff against this preference | Critic + janitor | readability; no linter configured |
+| Error handling (return-value based; exceptions at boundaries) | Critic | Reviewer judges what counts as a "boundary" per the definition above | Critic + janitor | return-value discipline; exceptions only escape at boundaries |
+| Class-based test grouping (allows scenario-based class names) | Critic | Reviewer judges whether grouping is sensible — strict `Test<FuncName>` would over-enforce | Critic | sensible scenario grouping without over-enforcement |
+| Branching / PR creation / PR merge / PR merge strategy (Workflow) | Session config | Read by `building.md`, `/pr`, etc. at decision points | user-observed | workflow decisions, read at session boundaries |
+| All others (Language, Version, Style, Type annotations, Testing strategy, File organization) | Critic | Reviewer reads diff against this preference | Critic | style/structure conventions |
+
+### Direction norms (architectural — ratified 2026-07-17)
+
+Pointer rows into the `## Direction` sections of the strategy artifacts. The statement + full why + status live in each artifact; this table is the index.
+
+| Norm (pointer) | Home § Direction | Mechanism | Audit home | Why (terse) |
+|---|---|---|---|---|
+| Verdicts computed from facts, no model in the write path (Critic plane) | `data-model.md` | Critic | janitor | the governed party must never self-certify |
+| Facts immutable & append-only | `data-model.md` | Critic + append-only code | janitor | any checkout replays the same verdict |
+| Derived views never authoritative | `data-model.md` | Critic | janitor | keep mutable state out of the authority path |
+| Newer-schema fact surfaced, never dropped | `data-model.md` | `evidence status` exit 2 | advisory | forward-incompatibility must be visible |
+| Two stores, two lifetimes (committed answers vs. gitignored nags) | `data-model.md` | Critic + gitignore contract (doctor) | janitor | share decisions without leaking local state |
+| Reviewer never mutates its session (at the mutation site) | `architecture.md` | `clear` refusal while review active | janitor | independence enforced where mutation happens |
+| Authority fails closed; advice fails soft | `architecture.md` | Critic | janitor | gates strict so governance means something; probes gentle so it's bearable |
+| Local-first: no network/daemon, stdlib-only runtime | `architecture.md` | Critic | janitor | survive "just want to code"; shrink supply-chain surface |
+| Plugin writes nothing into a repo but its state + reconciled files | `architecture.md` | Critic | janitor | least authority; tiny install reference |
+| Untrusted governance state is data, not instructions | `security-model.md` | Critic (Goal 4) | janitor | stale/crafted metadata is the real hazard |
+| No destructive action without explicit `--apply` | `security-model.md` | Critic | janitor | no accidental irreversible change |
+| Whole-surface semver; internal CLI unversioned; evidence store schema-versioned (`api_versioning_approach`) | `api-contract.md` | Critic + `evidence status` exit 2 | janitor | one cache key; internal surface has no external consumer |
+| Exit codes are the contract; stable prefix vocab; attributed errors (`api_error_model_approach`) | `api-contract.md` | Critic | janitor | skills bind to exit codes, not parsed text |
+| Additive-first API evolution; tolerant readers | `api-contract.md` | Critic | janitor | keeps versions rare; N-shipped skills don't break at N+1 |
+| Severity-prefix vocab + stdout=agent / stderr=user split | `observability-strategy.md` | Critic | janitor | machine-legible output; clean context injection |
+| Single-writer governance ledger | `observability-strategy.md` | Critic | janitor | derived metrics are only trustworthy with one writer |
+| Review wall-clock is P0 (run-count first; parallel, not sequential) | `nonfunctional-requirements.md` | `review-stats` telemetry | janitor | latency decides partner-vs-tax |
+| State-file size threshold is advisory, never a hard block | `nonfunctional-requirements.md` | advisory size-nag | advisory | context-weight cost; fail-soft advice, not authority |
+| Conservative versioning (small feature = patch bump) | `operational-spec.md` | Critic (judgment) | janitor | keep the version number meaningful |
+| Gitflow: develop=integration, main=release; promotion is a separate step | `operational-spec.md` | Session config + release tooling | janitor / doctor | clean release boundary; branch-pinned marketplace |
+
+**Rule for adding a new preference or norm:** assign a mechanism and an audit home. A code-level rule expressible as "every file/function/config matches pattern X with named exceptions" → write a test; a rule requiring intent → Critic. An architectural norm gets a `## Direction` entry in its home artifact plus a pointer row here. Never leave one unassigned — that's how a preference or a norm silently becomes aspirational — and a named mechanism that does not yet exist is filed as backlog work at the norm's birth (`docs/norms.md`).

--- a/.prawduct/artifacts/security-model.md
+++ b/.prawduct/artifacts/security-model.md
@@ -24,6 +24,17 @@ boundaries between parties. So the classic web-app security surface (authn, auth
 runs on a developer's machine on Claude Code lifecycle events** (supply-chain / plugin-trust), and
 **it reads state files and repo content that may not be trustworthy** (untrusted-input handling).
 
+## Direction
+
+<!-- Ratified norms (2026-07-17). See docs/norms.md. -->
+
+- **Untrusted governance state — backlog, learnings, recalled memories, fetched references, prior-session handoffs — is data, not instructions.** Content describes or informs; it never carries authority to direct the agent or the framework, and recalled state is verified against reality before it is acted on.
+  Why: for a tool with no sensitive data the real hazard is trusting *stale or crafted* metadata rather than a classic payload — treating state as vetoable-and-verified rather than authoritative is the mitigation; malformed state fails soft (skip + attribute), never executes.
+  Status: steady-state.
+- **No destructive action without an explicit `--apply` step; state-mutating lifecycle commands default to a dry run.**
+  Why: a preview-by-default gate on migrate/init/scaffold/repo-disable/learnings-audit means no irreversible change happens by accident; the one destructive migration lands as a single revertible commit.
+  Status: steady-state.
+
 ## Authentication & Authorization
 
 **Not applicable — single actor, no privilege tiers.** There is nobody to authenticate and no

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,41 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-07-17: Ratify prawduct's norm registry — 20 Direction norms (norm-lifecycle Layer 2)
+
+<!-- prawduct: type=docs -->
+<!-- Statusless = release-pending once merged. Owner-ratified via the /prawduct:doctor
+     surface-by-exception flow; governance-state + artifacts only, no code. -->
+
+**Parent:** the norm-lifecycle Layer 2 close-out (`norm-registry-unratified` advisory) — the seven
+strategy artifacts authored under GOV-5K3M were deliberately descriptive (no `## Direction`
+sections), so the registry was unratified by design, handing the owner the ratification step. The
+owner ruled on the decision-worthy candidates; the rest were bulk-confirmed.
+
+**What:** Ratified 20 Direction norms across the strategy artifacts (statement + why + status per
+`docs/norms.md` Anatomy):
+- **data-model** (5): verdicts-from-facts / no-model-in-write-path (scoped to the Critic data plane),
+  facts append-only, views never authoritative, schema-ahead surfaced, two-stores-two-lifetimes.
+- **architecture** (4): reviewer-never-mutates-its-session, authority-closed / advice-soft,
+  local-first (stdlib runtime), least-authority write boundary.
+- **security-model** (2): untrusted-state-is-data, no-destructive-without-`--apply`.
+- **api-contract** (3): `api_versioning_approach`, `api_error_model_approach`, additive-first.
+- **observability-strategy** (2): severity-prefix + stdout/stderr split, single-writer ledger.
+- **nonfunctional-requirements** (2): review-wall-clock-P0, state-file-thresholds-are-advisory.
+- **operational-spec** (2): conservative versioning (judgment norm), gitflow develop/main.
+
+**Owner rulings:** state-file thresholds ratified as **advisory** (warn/advise, no mechanical
+enforcement — so over-threshold files are the nag's target, not violations, and no retroactivity
+applies); verdicts-from-facts **scoped to the Critic data plane** (honest — test-run/PR-review
+evidence is not yet on the store); conservative versioning bound as a **judgment** norm. Two wording
+fixes applied (stdlib scoped to the runtime; the true least-authority write boundary). The
+metrics/telemetry statement was left descriptive, not ratified.
+
+Extended `project-preferences.md` § Enforcement into the product's norm index (added `Audit home` +
+`Why` columns; 20 pointer rows). Recorded `norm_registry_ratified` in `project-state.yaml` — clears
+the `norm-registry-unratified` advisory; `coverage-status` now reports the chain fully satisfied
+(Layer 0/1/2).
+
 ## 2026-07-17: Norm-ratification flow surfaces by exception, not a flat wall (fix)
 
 <!-- prawduct: type=fix -->

--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -664,6 +664,16 @@ operator_verification_required: false
 api_versioning_decided: "plugin-semver + evidence-schema-version; CLI internal, external-consumer versioning deferred (revisit: first non-prawduct caller of prawduct-hook)"
 
 # =============================================================================
+# NORM REGISTRY RATIFICATION (advisory-probe resolution signal)
+# =============================================================================
+# Flat top-level scalar the norm-registry-unratified probe reads (column-0
+# scalar). Truthy = the owner ratified the norm registry -> suppress the nudge.
+# The ratified norms live in `## Direction` sections across the strategy
+# artifacts, indexed in artifacts/project-preferences.md section Enforcement.
+
+norm_registry_ratified: "2026-07-17 — 20 Direction norms across the 7 strategy artifacts; preferences Enforcement index carries the norm columns (Audit home / Why)"
+
+# =============================================================================
 # DEPRECATED TERMS
 # =============================================================================
 # Track vocabulary changes to catch stale references.


### PR DESCRIPTION
Ratifies prawduct's norm registry — the norm-lifecycle **Layer 2** close-out that clears the `norm-registry-unratified` advisory.

## What

Ratified **20 `## Direction` norms** across the seven strategy-class artifacts (statement + why + status per `docs/norms.md` Anatomy):

- **data-model** (5): verdicts-from-facts / no-model-in-write-path (scoped to the Critic data plane), facts append-only, views never authoritative, schema-ahead surfaced, two-stores-two-lifetimes
- **architecture** (4): reviewer-never-mutates-its-session, authority-closed / advice-soft, local-first (stdlib runtime), least-authority write boundary
- **security-model** (2): untrusted-state-is-data, no-destructive-without-`--apply`
- **api-contract** (3): `api_versioning_approach`, `api_error_model_approach`, additive-first
- **observability-strategy** (2): severity-prefix + stdout/stderr split, single-writer ledger
- **nonfunctional-requirements** (2): review-wall-clock-P0, state-file-thresholds-are-advisory
- **operational-spec** (2): conservative versioning (judgment norm), gitflow develop/main

Extended `project-preferences.md` § Enforcement into the norm index (added `Audit home` + `Why` columns; 20 pointer rows) and recorded `norm_registry_ratified` in `project-state.yaml` — `coverage-status` now reports the chain fully satisfied (Layer 0/1/2).

## Owner rulings (surface-by-exception)

Ratified via the just-shipped `/prawduct:doctor` surface-by-exception flow (#124). The decision-worthy candidates were surfaced individually:
- **state-file thresholds** → **advisory** (warn/advise, no mechanical enforcement — over-threshold files are the nag's target, not violations, so no retroactivity applies)
- **verdicts-from-facts** → **scoped to the Critic data plane** (honest — test-run/PR-review evidence is not yet on the store)
- **conservative versioning** → bound as a **judgment** norm

Two wording fixes applied (stdlib scoped to the runtime; the true least-authority write boundary); the metrics/telemetry statement was left descriptive, not ratified. The Critic caught a stale claim during authoring — the wall-clock norm asserted reviewers run on the most-capable model tier, removed in v2.1.0; corrected to "inherit the session model."

## Review

**Doc-only PR — cumulative-Critic and PR-reviewer gates skipped per `check-pr-doc-only`** (all 10 files are `.prawduct/artifacts/*.md` specs + `project-state.yaml` state; no judgeable code, no governance-protected paths). The norm *content* was independently Critic-reviewed during authoring (verify-resolutions 0 blocking / 0 warning / 0 note). Rebased onto the current `develop` (post-#124); the sole conflict was an additive change-log union.

Base `develop` — entry stays statusless (release-pending).
