### PR TITLE
fix(backlog-service): resumable import envelope keeps its audit warnings (BKL-9V2W)

### DIFF
--- a/.prawduct/backlog.md
+++ b/.prawduct/backlog.md
@@ -1309,11 +1309,6 @@
 
   From the test-evidence-environments review (the work that shipped TST-6F2R's multi-environment `test_commands` list): a product with one environment whose toolchain cannot emit JUnit is excluded from the declared-list form — the aggregated record has no way to accept a counts-only source alongside the JUnit-capable environments. Today's escape is a wrapper script, or repeated `--from-junit` for the JUnit halves plus nothing for the counts half. Design question: should `--from-counts` compose as one more aggregated source (i.e. a counts entry participating in the same multi-environment aggregation) rather than remaining an exclusive whole-record mode? Touches ENV-2W7K's "document --from-counts as the paved non-pytest path" — if composition ships, that documentation should describe the composed form. (critic)
 
-- **[BKL-9V2W]** migrate.import_items: resumable error envelope (TransportError path) drops accrued warnings[] — alias self-heal audit lines lost and never re-emitted on resume
-  `effort: S · impact: S · area: backlog-service · kind: bug · source: critic · added: 2026-07-18 · status: open · stage: ready · related: BKL-6M4T, BKL-3K9N`
-
-  Cumulative-Critic correctness reviewer NOTE (rev-20260718T144940Z): migrate.import_items' resumable mid-run error envelope (TransportError path) carries created/skipped/collisions but drops the accrued warnings[] — an alias self-heal audit line emitted by an already-completed record is lost, and it is never re-emitted on the re-run because the restored label makes the skip take the fast path. The live-migration audit trail should not lose these. Fix direction: include warnings in the error envelope, or re-emit them on resume. Same lost-audit-warning class as the known minor limitation recorded on BKL-3K9N (429-retry path); this is the TransportError-resume path.
-
 ## Promoted
 
 - **[BKL-5D2C]** Move the backlog out of git to a centralized, agent-friendly issue-tracking service
@@ -1347,6 +1342,13 @@
   Promoted 2026-07-17: Offline code + tests landed 2026-07-17 (commit 8ecd02e, cumulative-Critic 0 blocking). core.resolve_ref wires PFX→canonical alias resolution into get/link; migrate._find_by_key gains a block-id_aliases fallback skip-authority (_AliasIndex) that self-heals a human-deleted id:PFX label so a re-import can't duplicate; reconcile-labels re-derives deleted aliases. In-flight under the Chunk 06 slice (BKL-6M4T) — closes when the slice merges. Follow-ups spun off: BKL-7Q2N (mutator-side PFX resolution), BKL-9J3F (CC5 decoder gaps).
 
 ## Archive
+
+- **[BKL-9V2W]** migrate.import_items: resumable error envelope (TransportError path) drops accrued warnings[] — alias self-heal audit lines lost and never re-emitted on resume
+  `effort: S · impact: S · area: backlog-service · kind: bug · source: critic · added: 2026-07-18 · reviewed: 2026-07-18 · status: shipped · stage: ready · related: BKL-6M4T, BKL-3K9N · closed-by: fix/import-resumable-warnings`
+
+  Cumulative-Critic correctness reviewer NOTE (rev-20260718T144940Z): migrate.import_items' resumable mid-run error envelope (TransportError path) carries created/skipped/collisions but drops the accrued warnings[] — an alias self-heal audit line emitted by an already-completed record is lost, and it is never re-emitted on the re-run because the restored label makes the skip take the fast path. The live-migration audit trail should not lose these. Fix direction: include warnings in the error envelope, or re-emit them on resume. Same lost-audit-warning class as the known minor limitation recorded on BKL-3K9N (429-retry path); this is the TransportError-resume path.
+
+  Shipped 2026-07-18 (closed-by: fix/import-resumable-warnings).
 
 - **[BKL-5R2K]** Wire the merge/transfer redirect-follow (`ids.resolve_redirect` / `migrate.resolve`) into a real get/pick consumer
   `effort: S · impact: S · area: backlog-service · source: critic · added: 2026-07-17 · reviewed: 2026-07-17 · status: shipped · stage: ready · refs: artifacts/build-plan-backlog-service.md · closed-by: Chunk-06`

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,28 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-07-18: Backlog service — resumable import envelope keeps its audit warnings (backlog-service)
+
+<!-- prawduct: type=bugfix | scope=backlog-service-v1 -->
+<!-- Statusless: bugfix on the importer resume path ahead of the deferred live leg (BKL-6M4T). -->
+
+**BKL-9V2W.** `migrate.import_items`' resumable mid-run error envelope (the
+TransportError path) carried `created`/`skipped`/`collisions` but dropped the
+accrued `warnings[]` — so an alias self-heal audit line emitted by an
+already-completed record was lost, and never re-emitted on resume (the restored
+`id:PFX` label makes the record skip the fast path, so the heal never re-runs).
+The live-migration audit trail must not lose these.
+
+- **Data plane** (`lib/backlog/migrate.py`): the resumable error envelope now
+  carries the accrued `warnings[]` at top level (matching the ok envelope).
+- **CLI** (`lib/backlog/cli.py`): the human-mode *error* path now surfaces
+  `warnings[]` like the ok path — a carried-but-unprinted warning would still be
+  invisible to the operator running the migration.
+- **Contract** (`documentation/backlog-service-api-contract.md` §3): notes that a
+  resumable error also carries top-level `warnings[]`.
+- Regression tests: `test_resumable_error_carries_accrued_self_heal_warnings`
+  (data plane) + `test_error_envelope_warnings_reach_stderr` (CLI emitter).
+
 ## 2026-07-18: Backlog service — owner-feedback gap-fills (backlog-service)
 
 <!-- prawduct: type=feature | scope=backlog-service-v1 -->

--- a/.prawduct/learnings.md
+++ b/.prawduct/learnings.md
@@ -24,6 +24,8 @@ When a feature branch fails a release-hygiene test (e.g. `test_changelog_has_cur
 
 ## When a fail-closed validator guards a model-written field, tolerate the natural encoding variant — reserve the hard fail for genuine ambiguity, because incidental strictness at a model-output seam is a latent fail-close
 
+## When the success path threads advisory/audit data through a result envelope, add it to EVERY error-return path too — in an envelope-heavy codebase the error return is built by a *different* constructor (here `core.from_transport_error` vs `core.ok(data, warnings)`) that has no slot for the field and silently drops it; the damage is permanent, not cosmetic, when the datum is one-shot (a self-heal audit line that won't re-run on resume, so it can never be re-emitted). Second instance of this class in backlog-service import (BKL-3K9N rate-limit path, BKL-9V2W TransportError path — both funnel through one outer `except`). Grep the error/exception returns whenever you enrich a success envelope.
+
 ## When designing any flow step that records status or bookkeeping, make it ride IN the PR that does the work — a step that can only run post-merge on the integration branch is structurally broken for protected-branch consumers
 
 ## When a governance checkpoint verifies a required side-effect happened, put it OUTSIDE the control flow that produces the side-effect — a check inside the fallible flow can't catch that flow's own skip

--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -17,7 +17,7 @@ backlog_format_version: 2
 # Last full backlog grooming (stamped by /prawduct:backlog list/pick/groom).
 # Timestamp, not a count — counts are always re-derived (D14). Resolves the
 # backlog-overdue-grooming advisory.
-backlog_last_groomed_at: 2026-07-17
+backlog_last_groomed_at: 2026-07-18
 
 # Distribution model. `plugin` = this repo is governed by the Prawduct plugin
 # (v2.0.0), not file-sync. Set in Chunk 13 when the repo cut over to dogfood its

--- a/documentation/backlog-service-api-contract.md
+++ b/documentation/backlog-service-api-contract.md
@@ -167,7 +167,9 @@ field home.)*
 - **Envelope.** Every JSON response is one envelope: `{"status":"ok","data":…,"warnings":[…]}` or the
   error form (§4). `warnings[]` carries the *advisory-but-not-fatal* signals — unknown soft-enum
   values, a human-UI drift the reconciler self-healed (CC5), a stale cache read's visible age — that
-  must never be an error (DM1).
+  must never be an error (DM1). A **resumable** error (a mid-run `import` cut) also carries top-level
+  `warnings[]`, so a self-heal audit line from an already-completed record is not lost — it can't be
+  re-emitted on resume (the restored alias label makes the record skip the fast path).
 - **Issue standard on `file`** (issue-standard §1/§2/§4; `lib/backlog/issuefmt.py`). `file` emits the
   §1 title shape (prepends the `area:` prefix, idempotently) and **audits** the created issue against
   the §4 thresholds. Findings ride in a **separate** top-level `lint` field —

--- a/lib/backlog/cli.py
+++ b/lib/backlog/cli.py
@@ -806,6 +806,10 @@ def _emit(result: dict, *, json_mode: bool, usage: bool = False) -> int:
     else:
         err = result.get("error", {})
         print(f"error [{err.get('code')}]: {err.get('message')}", file=sys.stderr)
+        # A resumable error envelope (e.g. import) carries the audit warnings accrued
+        # before the cut; surface them like the ok path so they reach the operator.
+        for warning in result.get("warnings", []):
+            print(f"warning: {warning}", file=sys.stderr)
         if usage:
             print(_HELP, file=sys.stderr)
     return exit_code

--- a/lib/backlog/migrate.py
+++ b/lib/backlog/migrate.py
@@ -593,6 +593,11 @@ def import_items(
         result["error"]["details"].update(
             {"created": created, "skipped": skipped, "collisions": collisions, "resumable": True}
         )
+        # Carry the audit warnings accrued before the cut (checkpoint notes + per-record
+        # self-heal lines). A self-heal line from an already-completed record can't be
+        # re-emitted on resume — the restored label makes the record skip the fast path,
+        # never re-running the heal — so dropping it here loses it permanently.
+        result["warnings"] = warnings
         return result
     except (OSError, json.JSONDecodeError) as exc:  # ERR-6 — unexpected boundary
         _diag(f"unexpected transport failure on import: {type(exc).__name__}")

--- a/tests/test_backlog_cli.py
+++ b/tests/test_backlog_cli.py
@@ -105,6 +105,26 @@ class TestOutputDiscipline:
         assert "weird" in err  # warning narration on stderr
         assert "warning" not in out.lower()  # stdout stays clean
 
+    def test_error_envelope_warnings_reach_stderr(self, capsys):
+        # BKL-9V2W: a resumable error envelope (e.g. a mid-run import failure)
+        # carries the audit warnings accrued before the cut. The human error path
+        # must surface them like the ok path — else the carried audit line stays
+        # invisible to the operator running the migration.
+        result = {
+            "status": "error",
+            "error": {
+                "code": "unavailable",
+                "message": "backend failed",
+                "details": {"resumable": True},
+            },
+            "warnings": ["restored missing alias label id:DIS-0001 on octo/repo#4"],
+        }
+        code = cli._emit(result, json_mode=False)
+        err = capsys.readouterr().err
+        assert code != 0
+        assert "error [unavailable]" in err
+        assert "restored missing alias label" in err
+
 
 class TestExitClasses:
     """ERR-1 — each error code maps to a stable non-zero exit class."""

--- a/tests/test_backlog_migrate.py
+++ b/tests/test_backlog_migrate.py
@@ -387,6 +387,27 @@ class TestCheckpointLossRebuild:
 
 # --- CRASH-4: import resumable / idempotent ----------------------------------
 
+# Minimal open-only fixtures for the resumable-envelope warnings regression: a
+# subset (DIS-0001) and its superset (DIS-0001 + DIS-0002). A re-import of the
+# superset self-heals the first (a mutation) and then creates the second (the
+# mutation that fails), so a completed record's warning precedes the cut.
+_ONE_OPEN_ITEM = """# Backlog — mini
+
+## Open
+
+- **[DIS-0001]** Add the harbor map overlay
+  `effort: M · impact: L · area: ui · source: user · added: 2026-05-01 · status: open · stage: ready`
+
+  Players want a top-down harbor map.
+"""
+
+_TWO_OPEN_ITEMS = _ONE_OPEN_ITEM + """
+- **[DIS-0002]** Rate-limit the trade API
+  `effort: S · impact: M · area: backend · source: builder · added: 2026-05-02 · status: open · stage: ready`
+
+  Bursts of trades exceed the upstream cap.
+"""
+
 
 class TestImportResumable:
     def test_crash_mid_import_resumes_without_duplicates(self, fake, tmp_path):
@@ -426,6 +447,30 @@ class TestImportResumable:
         assert second["status"] == "ok"
         dis4 = _alias_issues(fake, "DIS-0004")[0]
         assert (dis4.get("state") or "open").lower() == "closed"  # resume converged
+
+    def test_resumable_error_carries_accrued_self_heal_warnings(self, fake):
+        # Regression (BKL-9V2W): an alias self-heal audit line emitted by an
+        # already-completed record must ride the resumable TransportError envelope.
+        # It cannot be recovered on resume — the restored id:PFX label makes the
+        # record skip the fast label path, so the heal never re-runs — so dropping
+        # it from the error envelope loses the audit line permanently.
+        _seed_labels(fake, _TWO_OPEN_ITEMS)
+        _import(fake, _ONE_OPEN_ITEM)  # DIS-0001 lands on GitHub
+        number = _alias_issues(fake, "DIS-0001")[0]["number"]
+
+        # A human deletes DIS-0001's id:PFX label; the block id_aliases survives.
+        fake.remove_label(OWNER, REPO, number, ids.alias_label("DIS-0001"))
+
+        # Re-import the superset: DIS-0001 self-heals (mutation 1 — restores the
+        # label, emitting the audit line), then DIS-0002's create (mutation 2) hits
+        # the injected failure and returns the resumable envelope.
+        fake.fail_at_mutation(2)
+        result = _import(fake, _TWO_OPEN_ITEMS)
+
+        assert result["status"] == "error"
+        assert result["error"]["details"]["resumable"] is True
+        assert result["error"]["details"]["skipped"]  # DIS-0001 healed before the cut
+        assert any("restored missing alias label" in w for w in result["warnings"])
 
 
 # --- BKL-4W7H: id:PFX alias self-heal (deleted label ↛ permanent duplicate) ---


### PR DESCRIPTION
Fixes **BKL-9V2W**. `migrate.import_items`' resumable mid-run error envelope (the
`TransportError` path) carried `created`/`skipped`/`collisions` but dropped the
accrued `warnings[]` — so an alias self-heal audit line emitted by an
already-completed record was lost, and **never re-emitted on resume** (the restored
`id:PFX` label makes the record skip the fast path, so the heal never re-runs). The
live-migration audit trail must not lose these.

## The fix — two layers

- **Data plane** (`lib/backlog/migrate.py`): the resumable error envelope now
  carries the accrued `warnings[]` at top level, matching the ok envelope
  (`core.ok(data, warnings)`).
- **CLI** (`lib/backlog/cli.py`): `_emit`'s human-mode *error* path now surfaces
  `warnings[]` like the ok path — a carried-but-unprinted warning would still be
  invisible to the operator running the migration.
- **Contract** (`documentation/backlog-service-api-contract.md` §3): notes a
  resumable error also carries top-level `warnings[]`.

## Scope

Deliberately scoped to `warnings[]`. Pre-cut **collisions** are *not* folded into
the error-path warnings (the Critic's lone NOTE) — collisions re-detect on resume
and stay in `error.details.collisions`, so nothing is permanently lost, unlike the
one-shot self-heal line.

Bonus: the exhausted-rate-limit path funnels through the same outer `except`, so
this fix also closes BKL-3K9N's known lost-audit-warning limitation.

## Tests & gates

| | |
|---|---|
| Regression tests | `test_resumable_error_carries_accrued_self_heal_warnings` (data plane) + `test_error_envelope_warnings_reach_stderr` (CLI emitter) |
| Suite | 2364 passed / 0 failed / 6 skipped |
| Cumulative-Critic | satisfied — 1 review fact + 1 free edge (docs), 0 unresolved blocking |
| Critic (`chunk`) | 0 blocking / 0 warning / 1 note (defensible, see Scope) |

Statusless change-log entry (this flips no chunk checkbox — Chunk 06 stays deferred,
BKL-6M4T). The `develop→main` release flips it to `status=shipped`.
