### PR TITLE
fix(observability): relay upgrades and consequential advisories to the person

### DIFF
--- a/.prawduct/artifacts/build-plan-upgrade-discovery.md
+++ b/.prawduct/artifacts/build-plan-upgrade-discovery.md
@@ -181,8 +181,9 @@ chunk alone.
 Context: Authored and built 2026-08-01 on `feature/upgrade-discovery-relay`, from a defect traced
 while preparing an owner acceptance exercise for the backlog migration — the owner asked why an
 auto-updating product would ever discover the migration, and the answer was that it would not.
-All three chunks are built and committed (`4c0dc44` + the Critic-resolution commit); the suite is
-green and both relays were verified against real rendered output. Unmerged and untagged: whether
+All three chunks are built and committed (`4c0dc44`, then `74cdef3` and `f2aeb56` resolving two
+rounds of Critic findings); the suite is green and both relays were verified against real rendered
+output. Unmerged and untagged: whether
 this rides in v3.2.3 or a follow-up is the owner's open call. **Chunks 01 and 02 must ship
 together** — the lift routes consuming repos toward an irreversible bulk write, and the relay is
 what puts a person in that loop.

--- a/.prawduct/artifacts/build-plan-upgrade-discovery.md
+++ b/.prawduct/artifacts/build-plan-upgrade-discovery.md
@@ -1,7 +1,30 @@
+---
+artifact: build-plan
+version: 2
+scope: upgrade-discovery
+governed_by:
+  - artifact: observability-strategy
+    dispositions:
+      - norm: "stdout is the agent-facing channel; stderr is the user-and-diagnostics channel"
+        disposition: applies
+        note: >-
+          The whole plan follows from this norm. It is not amended — it was correct;
+          what drifted was the description claiming the briefing answers the owner's
+          questions. Chunk 03 fixes the description, not the norm.
+      - norm: "Text emitted into a governed product names no prawduct-internal identifier"
+        disposition: applies
+        note: >-
+          Both relay directives are emitted text. Asserted by test, not just review.
+---
+
 # Build plan — Upgrade discovery: make a shipped capability reachable by the human
 
-**Critic mode:** cumulative-final
 **Branch:** `feature/upgrade-discovery-relay`
+
+<!-- No plan-level `Critic mode:` field: the reader looks for it inside a `## Chunk` section, and
+     the valid tokens are chunk/final/cumulative/verify-resolutions. A plan-level line naming a
+     chunk `Type:` value is silently ignored, which reads as configured while doing nothing. -->
+
 
 ## Problem
 
@@ -97,8 +120,19 @@ nagging, which trains the user to ignore the channel and costs more than it buys
 5. Tests, banner: directive present on a crossing; absent when `last == current`; absent on
    first-marker write; present alongside both headline-only and new-gate deltas.
 6. Tests, advisories: directive present with a `warn`; present with an `urgent`; absent on `info`-only;
-   absent with no active advisories; unaffected by the 5-item display cap (a `warn` ranked past the cap
-   still triggers it — the cap is a display limit, not a relevance filter).
+   absent with no active advisories; absent for a *resolved* `warn` (state decides, not priority);
+   and the display cap cannot hide a consequential advisory.
+
+   **Amended during build — the cap clause originally read "a `warn` ranked past the cap still
+   triggers the relay."** That state is unreachable: the priority sort ranks `urgent`/`warn` ahead
+   of `info`, so the only thing that can displace a `warn` from the visible five is an `urgent`,
+   itself relay-priority. A test of it passed identically against a correct implementation and one
+   keyed off the displayed slice — it asserted nothing. Replaced with the property that is real and
+   load-bearing: **the cap can never hide a consequential advisory**, which pins the *sort* (reorder
+   it to newest-first and a `warn` under six fresh `info`s would be relayed but not shown, telling
+   the person to look at something they cannot see). Verified by mutation that the replacement
+   fails when the priority sort is removed. The implementation still keys off the full active set —
+   not because the slice is wrong today, but so it stays right if the sort changes.
 7. Offline suite green.
 
 ## Chunk 02 — Lift the migration advisory hold
@@ -131,6 +165,15 @@ chunk alone.
 
 ## Status
 
-- [ ] Chunk 01 — Relay the upgrade to the human, from the banner
-- [ ] Chunk 02 — Lift the migration advisory hold
-- [ ] Chunk 03 — Make the observability strategy honest about audience
+- [ ] Chunk 01: Relay at both emission sites — built 2026-08-01, `[ ]` until release (derived — the release flips it from the change-log tag, so do not hand-check it)
+- [ ] Chunk 02: Lift the migration advisory hold — built 2026-08-01, `[ ]` until release
+- [ ] Chunk 03: Make the observability strategy honest about audience — built 2026-08-01, `[ ]` until release
+
+Context: Authored and built 2026-08-01 on `feature/upgrade-discovery-relay`, from a defect traced
+while preparing an owner acceptance exercise for the backlog migration — the owner asked why an
+auto-updating product would ever discover the migration, and the answer was that it would not.
+All three chunks are built and committed (`4c0dc44` + the Critic-resolution commit); the suite is
+green and both relays were verified against real rendered output. Unmerged and untagged: whether
+this rides in v3.2.3 or a follow-up is the owner's open call. **Chunks 01 and 02 must ship
+together** — the lift routes consuming repos toward an irreversible bulk write, and the relay is
+what puts a person in that loop.

--- a/.prawduct/artifacts/build-plan-upgrade-discovery.md
+++ b/.prawduct/artifacts/build-plan-upgrade-discovery.md
@@ -1,0 +1,136 @@
+# Build plan — Upgrade discovery: make a shipped capability reachable by the human
+
+**Critic mode:** cumulative-final
+**Branch:** `feature/upgrade-discovery-relay`
+
+## Problem
+
+An auto-updating product never learns that a new prawduct capability exists. Traced end to end on
+`develop@ddb6dd1`:
+
+1. The update lands silently — no release page visited, no changelog read.
+2. On the next session the version-delta banner renders `↑ Prawduct updated: vA → vB` plus the
+   release headline and any newly-active gates — to **stdout**, which the ratified observability norm
+   defines as the *agent-facing* channel (`observability-strategy.md` § Direction).
+3. `write_marker()` runs immediately after, so the banner **never renders again**
+   (`plugin/hooks/banner.py`).
+4. **Nothing instructs the agent to pass it on.** No relay directive exists in either digest variant
+   or in the digest hook.
+5. The one advisory that would route an un-migrated repo to the backlog migration is registered as a
+   no-op (`_probe_migration_required_held`).
+
+Net: the capability is announced once, on a channel the human does not read, and then never again.
+The backlog service ships to a fleet that cannot discover it.
+
+**The narrow reading is wrong and must not be built.** "Migrate automatically" is a worse product —
+it writes 100–250 irreversible issues into a repo nobody asked to migrate. Requiring a human decision
+is correct. The defect is that *the decision is never offered*.
+
+## Success
+
+1. On the first session after a version crossing, the human is told what changed **in conversation** —
+   the one channel they reliably read.
+2. An un-migrated repo with a structured backlog surfaces the migration advisory, and it reaches the
+   human through (1) rather than dying in agent context.
+3. `observability-strategy.md` no longer claims the briefing answers the owner's questions on a
+   channel its own norm reserves for the agent — it states how the owner actually learns.
+
+## Out of scope
+
+- **Routing advisories to stderr by consequence.** Considered and deliberately not built: the relay
+  is the general mechanism and covers advisories, headlines and gate activations at once. A second
+  channel-level mechanism would be redundant until the relay is shown insufficient. Revisit if it is.
+- Any change to the auto-update mechanism itself.
+- A notification surface outside the conversation.
+- Migrating anything. This plan makes migration *discoverable*, never automatic.
+
+## Requirements confidence
+
+**High** on the problem — every link in the chain was read, not inferred, and the file/function for
+each is named above. **High** on success criteria 1 and 3. **Medium** on criterion 2's blast radius:
+lifting the advisory executes a recorded owner ruling (2026-07-24) whose two stated conditions are
+both discharged, but it is the first release in which any consuming repo is routed toward an
+irreversible bulk write. The relay is what makes that safe — it is the reason the two ship together,
+and neither should land without the other.
+
+---
+
+## Chunk 01 — Relay at both emission sites
+
+**Two sites, because one does not cover the case.** The version banner fires **once, ever** — the
+marker advances immediately after it renders. A standing advisory fires **every session** until it
+resolves. Relaying only the banner would mean that if the agent fails to pass on the news during the
+single session where the upgrade landed, the capability is unreachable forever, while the advisory
+that exists precisely to nudge it goes on firing into agent context unread. Criterion 2 of this plan
+is false unless both sites relay.
+
+**Design decision — why not the session digest.** The digest was the obvious home and is the wrong
+one, on grounds that are not about budget:
+
+- Both directives fire **only when there is something to say** — a version crossing, or an active
+  consequential advisory. A digest block is re-read on every session forever to cover the minority
+  that have news.
+- Each sits **immediately next to the content it refers to**, so the agent reads the headline (or the
+  advisory) and the instruction to pass it on in one breath, rather than matching a general rule from
+  session start against a block further down.
+- It is the same principle as this release's own headline — *deliver the rule where it applies, not
+  in a file to be read later*. A relay directive parked in the digest is the exact pattern that
+  headline exists to retire.
+
+The digest's 44 characters of remaining inline headroom (9,956 of 10,000, measured) is what prompted
+the re-examination, but it is **not** the reason: the owner offered to raise the limit and the design
+did not move. Recorded so the next reader does not "fix" this by consolidating into the digest once
+the budget looks roomy.
+
+**Proportionality — `warn`/`urgent` only.** The advisory relay fires only when an active advisory
+carries `warn` or `urgent` priority. `info` advisories are FYI and relaying them every session is
+nagging, which trains the user to ignore the channel and costs more than it buys.
+
+**Done when:**
+1. `render_delta()` emits a trailing directive telling the agent to surface the change to the user in
+   conversation, and stating why (the user does not see this channel).
+2. The banner directive appears **only** when there is a delta — never on a same-version session,
+   never on first contact where the marker is being written for the first time.
+3. The briefing's advisory block emits a directive when any active advisory is `warn`/`urgent`; no
+   directive on an `info`-only set, and none when there are no active advisories.
+4. Neither directive names a prawduct-internal identifier (§ Direction, emitted-text norm).
+5. Tests, banner: directive present on a crossing; absent when `last == current`; absent on
+   first-marker write; present alongside both headline-only and new-gate deltas.
+6. Tests, advisories: directive present with a `warn`; present with an `urgent`; absent on `info`-only;
+   absent with no active advisories; unaffected by the 5-item display cap (a `warn` ranked past the cap
+   still triggers it — the cap is a display limit, not a relevance filter).
+7. Offline suite green.
+
+## Chunk 02 — Lift the migration advisory hold
+
+**Depends on:** Chunk 01. The relay is the precondition, not a nicety: without it the advisory routes
+the *agent* toward an irreversible bulk write with no human necessarily informed. Do not land this
+chunk alone.
+
+**Done when:**
+1. `register()` wires `probe_migration_required` into the live roster in place of
+   `_probe_migration_required_held`; the held wrapper and its explanatory comment are removed rather
+   than left as dead code.
+2. `test_held_out_of_live_roster` is replaced by its inverse — a structured, un-migrated backlog
+   surfaces the advisory *through the live roster*, with the recommended action intact.
+3. The lift is recorded as a decision (owner ruling 2026-07-24; both stated conditions discharged),
+   not left to read as a default flip.
+4. Offline suite green.
+
+## Chunk 03 — Make the observability strategy honest about audience
+
+**Done when:**
+1. § What You Get no longer implies the owner reads the briefing directly; it names the relay as how
+   a material change reaches them, and the briefing as the agent's state surface.
+2. The § Direction channel norm is unchanged — it was right; the description was what drifted
+   (norms bind, descriptions track).
+3. The rejected alternative (stderr routing by consequence) is recorded with its reasoning, so the
+   next reader does not re-litigate it from scratch.
+
+---
+
+## Status
+
+- [ ] Chunk 01 — Relay the upgrade to the human, from the banner
+- [ ] Chunk 02 — Lift the migration advisory hold
+- [ ] Chunk 03 — Make the observability strategy honest about audience

--- a/.prawduct/artifacts/build-plan-upgrade-discovery.md
+++ b/.prawduct/artifacts/build-plan-upgrade-discovery.md
@@ -174,9 +174,9 @@ chunk alone.
 
 ## Status
 
-- [ ] Chunk 01: Relay at both emission sites — built 2026-08-01, `[ ]` until release (derived — the release flips it from the change-log tag, so do not hand-check it)
-- [ ] Chunk 02: Lift the migration advisory hold — built 2026-08-01, `[ ]` until release
-- [ ] Chunk 03: Make the observability strategy honest about audience — built 2026-08-01, `[ ]` until release
+- [x] Chunk 01: Relay at both emission sites — built 2026-08-01, `[ ]` until release (derived — the release flips it from the change-log tag, so do not hand-check it)
+- [x] Chunk 02: Lift the migration advisory hold — built 2026-08-01, `[ ]` until release
+- [x] Chunk 03: Make the observability strategy honest about audience — built 2026-08-01, `[ ]` until release
 
 Context: Authored and built 2026-08-01 on `feature/upgrade-discovery-relay`, from a defect traced
 while preparing an owner acceptance exercise for the backlog migration — the owner asked why an

--- a/.prawduct/artifacts/build-plan-upgrade-discovery.md
+++ b/.prawduct/artifacts/build-plan-upgrade-discovery.md
@@ -15,6 +15,15 @@ governed_by:
         disposition: applies
         note: >-
           Both relay directives are emitted text. Asserted by test, not just review.
+      - norm: "The governance ledger has a single writer (the `ledger-append` helper);
+          agents never hand-author it"
+        disposition: inapplicable
+        note: >-
+          Recorded rather than omitted: an absent entry reads as unconsidered, and
+          "inapplicable, because —" is a disposition. This plan touches no ledger
+          write path — the relay directives are session-start stdout, and the probe
+          registration changes which function the advisory roster calls. Nothing
+          here appends a ledger event by any route, hand-authored or otherwise.
 ---
 
 # Build plan — Upgrade discovery: make a shipped capability reachable by the human

--- a/.prawduct/artifacts/observability-strategy.md
+++ b/.prawduct/artifacts/observability-strategy.md
@@ -19,8 +19,10 @@ last_validated: null
 
 The scenarios this design must make answerable:
 
-1. **"What state is my repo in right now?"** → the SessionStart briefing renders it at the top of
-   every session (branch, active work, advisories, stale artifacts, size warnings).
+1. **"What state is my repo in right now?"** → the SessionStart briefing assembles it at the top of
+   every session (branch, active work, advisories, stale artifacts, size warnings) — for the *agent*,
+   on stdout. The owner learns the parts that matter **by relay**: the agent is directed to surface
+   consequential advisories and version changes in conversation (see § How the owner actually learns).
 2. **"Is my prawduct install healthy?"** → `/prawduct:doctor` reports **healthy** or **degraded**
    with the specific reason.
 3. **"Why did a gate block me?"** → the block message names the gate and the remedy inline; nothing
@@ -28,10 +30,42 @@ The scenarios this design must make answerable:
 4. **"Is review costing too much?"** → `review-stats` aggregates the governance ledger into
    wall-clock, run-count, and finding-yield numbers (this is how the P0 wall-clock budget in
    `nonfunctional-requirements.md` is actually watched).
-5. **"What nudges am I ignoring?"** → the advisory list shows post-sync advisories and their state.
+5. **"What nudges am I ignoring?"** → `/prawduct:advisory list` on demand; and for `warn`/`urgent`,
+   the relay raises them unasked, so ignoring one is a choice rather than an accident.
 
 If those five are answerable from the terminal and the committed/local state, observability has
 done its job.
+
+### How the owner actually learns
+
+The channel norm below is deliberate and correct: stdout is the agent's, stderr is the person's. The
+consequence is easy to miss and was missed for several releases — **almost everything prawduct says
+about itself is said to the model.** The briefing, its advisory block, and the version-delta banner
+all print to stdout. The banner compounds it: it renders once at a version crossing, then advances
+its marker and never renders again.
+
+So a capability could ship, be announced, and reach nobody. That is not hypothetical — it is how the
+backlog service shipped: announced at the crossing, on the agent's channel, with the one advisory
+that would have nudged it registered as a no-op.
+
+The mechanism that closes it is a **relay directive** at each emission site — `banner.RELAY_MARKER`
+for a version crossing, `briefing.ADVISORY_RELAY_TEXT` for an active `warn`/`urgent` advisory. Each
+instructs the agent to surface the news in conversation, which is the one channel the owner reliably
+reads. Two properties are load-bearing:
+
+- **At the emission site, not in the session digest.** A directive fires only when there is something
+  to say; a digest rule is re-read every session to cover the minority that have news, and sits far
+  from the content it governs. This mirrors the same release's learnings change — deliver the rule
+  where it applies rather than parking it in a file to be read later.
+- **`warn`/`urgent` only.** Relaying `info` every session is nagging, and a channel that nags gets
+  tuned out — which would cost the `warn` case the audience it exists for.
+
+**Rejected: routing advisories to stderr by consequence.** Tempting, since the norm already provides
+the split and stderr is the person's channel. Rejected because the relay covers advisories,
+headlines, and gate activations through one mechanism, whereas channel-routing would solve only the
+advisory third and add a second way for the same signal to reach the same person. Revisit if the
+relay proves unreliable in practice — the evidence to watch for is an owner surprised by a `warn`
+they were never told about.
 
 ## Direction
 

--- a/.prawduct/artifacts/release-plan-v3.2.3.md
+++ b/.prawduct/artifacts/release-plan-v3.2.3.md
@@ -12,10 +12,19 @@ patch bump, not a minor-per-feature.*
 **Recorded because a minor is arguable here and was not taken.** This release carries the largest
 consumer-visible code delta since v3.2.0 — `audit_learnings_cmd.py` (+428), `backlog/migrate.py`
 (+234), `critic_consolidate.py` (+175), `views.py` (+130) — and it adds a genuinely new capability
-(`superseded-by=` retirement in `audit-learnings`). It stays a patch because **nothing goes live and
-no persisted format or gate semantic breaks**: `superseded-by=` is an additive metadata key that
-fails closed on every ambiguity, the two new delivery sites *print* rather than gate, and the
-backlog service remains opt-in per repo. No behaviour an adopter depends on changes shape.
+(`superseded-by=` retirement in `audit-learnings`). It stays a patch because **no persisted format
+or gate semantic breaks**: `superseded-by=` is an additive metadata key that fails closed on every
+ambiguity, and every new delivery site *prints* rather than gates. No behaviour an adopter depends
+on changes shape.
+
+**Corrected 2026-08-01 — the original rationale said "nothing goes live," and the
+`upgrade-discovery` scope falsifies it.** That scope's Chunk 02 lifts the
+`backlog-service-migration-required` hold, so the advisory now fires at `warn` in every un-migrated
+repo with a structured backlog; the backlog service is still opt-in to *adopt*, but the nudge toward
+it is no longer opt-in to *see*. Patch remains correct under the conservative-versioning norm — the
+advisory prints and recommends, it does not gate, and nothing an adopter depends on changes shape —
+but the reason is now "it prints rather than gates," not "nothing goes live." Re-recorded rather
+than left standing, because a false premise in a version decision is worse than an arguable one.
 
 ## Release classification
 
@@ -25,6 +34,7 @@ backlog service remains opt-in per repo. No behaviour an adopter depends on chan
 | learnings-firing | ships | |
 | backlog-service-v1 | ships | |
 | record-mechanization | ships | |
+| upgrade-discovery | ships | |
 
 `K withheld = 0` → **whole-develop promotion** (runbook Phase 2 steps 14–20), not the pruned path.
 The v3.1.2 pruning does not carry forward: v3.2.0 promoted whole-develop and re-established
@@ -45,6 +55,19 @@ frozen history and blocker liveness is no longer readable from it. It did not fi
 worth recording: **the gate reads blocker liveness only for rows that name a blocker, and no row
 here does.** Every scope ships, so there is no withholding decision whose premise could have expired
 and nothing for the frozen backlog to be consulted about.
+
+**Re-measured 2026-08-01, after `upgrade-discovery` joined the release.** The measurement above was
+taken before the Phase 1 prep commit (`ddb6dd1`) stamped the first four scopes, and before a fifth
+existed; it is kept as the historical record rather than overwritten. Current state:
+
+```
+releasable: no release-pending scopes — nothing to classify
+  (227 change-log entries scanned, 206 tagged, 5 scope(s) already tagged release=v3.2.3).
+```
+
+Per `cut-and-publish-a-plugin-release.md` step 0, `no release-pending scopes — nothing to classify`
+takes the **same whole-develop promotion path** as `K withheld = 0`. The reasoning above still holds
+for the same reason: no row names a blocker.
 
 So the by-hand blocker check the runbook asks a cut-over repo for is **vacuous by construction here**,
 not skipped. The distinction matters a release later, when "there was nothing to check" and "I did
@@ -112,6 +135,18 @@ stranded, `verify-migration` exit 0. Consumer-visible portion is the hardening t
    completeness, not performance*: for every supported scenario, no functional requirement is
    broken, unproven against the real API, or silently wrong. `BKL-2K8V` (pick latency) is an NFR and
    explicitly does **not** gate.
+3. **Added 2026-08-01 with the `upgrade-discovery` scope — decide whether the migration advisory
+   goes fleet-wide with `BKL-8W2M` unbuilt.** The lift itself is settled: owner ruling 2026-07-24,
+   and `BKL-7D3V` explicitly scopes out re-litigating it. What is *not* settled is an interaction
+   that post-dates that ruling. `BKL-7D3V` recorded the accepted risk as "a repo that will never
+   host on GitHub gets an unresolvable `warn` every session… `BKL-8W2M` is what makes the lift
+   survivable" — and `BKL-8W2M` (#197) is still open at `stage:requirements`, i.e. unbuilt and
+   unscoped. That risk was accepted when the advisory reached only the **agent**. Chunk 01 of this
+   scope relays every `warn` to the **person, in conversation, every session**, which is strictly
+   worse than what was accepted and is the exact failure the relay's own `info`-exclusion note
+   guards against ("a channel that nags gets tuned out, which would cost the `warn` case its
+   audience"). Publishing is the irreversible step; merging to `develop` was not. Either land
+   `BKL-8W2M` before Phase 2, or record an explicit second acceptance of the amplified version.
 
 **Status at time of writing: PENDING.** Owner elected to hold at the Phase 1 checkpoint —
 `origin/develop` fully prepped, nothing published. Record the result in

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,51 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-08-01: Everything prawduct says about itself, it says to the model — so a shipped capability reached nobody
+
+<!-- prawduct: type=fix | scope=upgrade-discovery | chunks=01,02,03 | status=open -->
+
+**The question that found it.** Preparing an owner acceptance exercise for the backlog migration, the
+owner asked why the script read as if a human would run the migration commands by hand. Three rounds
+of that question, each one level up, ended at: *"prawduct is set to auto-update, this version lands,
+the user continues working — this doesn't feel like migration will happen unless the user knows to
+ask?"* It doesn't, and the reason generalises past migration.
+
+**The chain, read rather than inferred.** The update lands silently. The version-delta banner renders
+`↑ Prawduct updated: vA → vB` plus the release headline — to **stdout**, which this project's own
+ratified norm defines as the *agent-facing* channel. `write_marker()` then advances the marker, so the
+banner never renders again. Nothing instructed the agent to pass any of it on. And the one advisory
+that would have nudged an un-migrated repo toward the backlog service was registered as a no-op. Net:
+the capability was announced once, on a channel the owner does not read, and then never again.
+
+**The fix is delivery, not authoring — the same diagnosis this release already applied to learnings.**
+A **relay directive** now sits at each emission site: the banner's delta block closes by telling the
+agent to surface what changed in conversation, and the briefing's advisory block does the same for any
+active `warn`/`urgent`. Both fire only when there is news, and both sit next to the content they refer
+to. The session digest was the obvious home and is the wrong one: a rule read at session start,
+competing with everything else in context, is precisely the delivery failure being fixed. (It also had
+44 characters of inline headroom left, measured — but the owner offered to raise the limit and the
+design did not move, which is the honest record of why.)
+
+**`info` is deliberately excluded.** A channel that nags gets tuned out, which would cost the `warn`
+case the audience it exists for.
+
+**The migration advisory is live.** Its recorded lift conditions — three runbook safety fixes plus one
+proven end-to-end migration — were all discharged, and an owner ruling made it live rather than
+leaving the probe's default to decide by silence. It had been shipping held *by silence* anyway,
+because no chunk implemented the ruling. **The relay is what makes the lift safe**: this advisory
+routes toward an irreversible bulk write of 100–250 real GitHub issues, and until now it could have
+routed the *model* there with nobody informed. It is a `warn`, so it relays, and the migration becomes
+the owner's call — the only form in which it was ever meant to be offered. The two ship together; the
+lift should not land without the relay.
+
+**Also corrected: the strategy artifact claimed what the code did not do.** § What You Get sold the
+briefing as answering *"What state is my repo in right now?"* and the advisory list as *"What nudges
+am I ignoring?"* — both framed as the owner's questions, both delivered on the channel its own norm
+reserves for the agent. The norm was right; the description had drifted. It now states how the owner
+actually learns, and records the rejected alternative (routing advisories to stderr by consequence)
+with its reasoning.
+
 ## 2026-08-01: prawduct's backlog is on GitHub Issues — 371 items, 0 stranded, and the tripwire that fired at the cutover was re-aimed rather than silenced
 
 <!-- prawduct: type=feature | scope=v3.2.0-golive | chunks=06 | release=v3.2.3 | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -5,7 +5,7 @@
 
 ## 2026-08-01: Everything prawduct says about itself, it says to the model — so a shipped capability reached nobody
 
-<!-- prawduct: type=fix | scope=upgrade-discovery | chunks=01,02,03 -->
+<!-- prawduct: type=fix | scope=upgrade-discovery | chunks=01,02,03 | release=v3.2.3 | status=shipped -->
 
 **The question that found it.** Preparing an owner acceptance exercise for the backlog migration, the
 owner asked why the script read as if a human would run the migration commands by hand. Three rounds

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -5,7 +5,7 @@
 
 ## 2026-08-01: Everything prawduct says about itself, it says to the model — so a shipped capability reached nobody
 
-<!-- prawduct: type=fix | scope=upgrade-discovery | chunks=01,02,03 | status=open -->
+<!-- prawduct: type=fix | scope=upgrade-discovery | chunks=01,02,03 -->
 
 **The question that found it.** Preparing an owner acceptance exercise for the backlog migration, the
 owner asked why the script read as if a human would run the migration commands by hand. Three rounds

--- a/.prawduct/learnings.md
+++ b/.prawduct/learnings.md
@@ -27,6 +27,8 @@ dropping them.
 
 ## The fix for a review finding needs the same adversarial pass as the original work — dispatch a delta review of the fix commit, because "I am correcting a known defect" feels like lower-risk work than writing new code and the verification reflex relaxes exactly where the last round proved it shouldn't
 
+## A finding of the form "A is pinned, B is not" is discharged by PINNING B, never by changing B — changing shipped behaviour to satisfy the letter of such a finding relocates the asymmetry from the code to the test layer, where the next review finds it again and charges you another round against a P0 wall-clock budget. Generalise it: the fix commit carries the cheap check that closes the loop it opens — the test beside the moved behaviour, the parser run before a hand-authored machine-parsed record — because a check deferred to the review that follows costs a whole review run to deliver
+
 ## A governance change cannot supply its own authority — when an agent amends a binding norm mid-build, land the owner's confirmation somewhere the amendment isn't, because a change that is its own only witness is indistinguishable from laundering however sound the substance
 
 ## When you "correct" an inherited number, recount the SET and not just the count — re-measuring inside the frame you inherited reproduces the frame's error while feeling exactly like verification

--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -670,6 +670,9 @@ scope_rollups:
   test-evidence-single-run:
     chunks: ["01", "02", "03"]
     releases: ["v2.2.3"]
+  upgrade-discovery:
+    chunks: ["01", "02", "03"]
+    releases: ["v3.2.3"]
   upstream-bug-reporting:
     chunks: ["01", "02"]
     releases: ["v2.1.6"]

--- a/.prawduct/project-state.yaml
+++ b/.prawduct/project-state.yaml
@@ -351,15 +351,20 @@ views_enabled: true
 # field holds only the current in-progress plan (absent/empty -> the gates
 # fall back to artifacts/build-plan.md).
 
-# Repointed 2026-08-01 (v3.2.0 Chunk 06). It read
-# `artifacts/build-plan-record-mechanization.md` while this branch built the
-# golive plan's Chunk 06 — so record-lint graded the wrong plan and reported
-# `chunk-ref-missing unchecked`, and the golive plan's own Context prose
-# ("active_build_plan now points here") was false. That is CRT-4V8P /
-# GOV-3K7M observed on this very branch: the pointer is single-slot
-# (BLD-7W2J), record-mechanization is legitimately still in progress, and
-# nothing checks that the pointer agrees with the plan under review.
-active_build_plan: artifacts/build-plan-v3.2.0-golive.md
+# Repoint this whenever the plan under active build changes. The slot is
+# single-valued and nothing checks that it agrees with the plan actually being
+# built, so a stale pointer sends record-lint, the stop-hook gate, regen-views
+# and Critic mode inference at the wrong plan — silently, since each of them
+# reports confidently about whichever plan it was handed.
+#
+# It has now gone stale twice on consecutive branches: once pointing at
+# record-mechanization while the golive plan was being built (record-lint graded
+# the wrong plan; the golive plan's own "active_build_plan now points here" prose
+# was false), and once pointing at the golive plan while the upgrade-discovery
+# plan was being built (Critic mode inference misfired off it). The recurrence is
+# the argument that a reminder in a comment is not the fix — the check that the
+# pointer agrees with the plan under review is.
+active_build_plan: artifacts/build-plan-upgrade-discovery.md
 
 # =============================================================================
 # BUILD-PLAN REF ROOT (opt-in)

--- a/.prawduct/release-notes.md
+++ b/.prawduct/release-notes.md
@@ -7,6 +7,12 @@
 
 ## v3.2.3
 
+### upgrade-discovery
+
+**Entry:** 2026-08-01: Everything prawduct says about itself, it says to the model — so a shipped capability reached nobody
+
+**Chunks shipped:** 01, 02, 03
+
 ### v3.2.0-golive
 
 **Entry:** 2026-08-01: prawduct's backlog is on GitHub Issues — 371 items, 0 stranded, and the tripwire that fired at the cutover was re-aimed rather than silenced

--- a/documentation/backlog-service-requirements.md
+++ b/documentation/backlog-service-requirements.md
@@ -305,8 +305,11 @@ state; it remains the interim supported path until the GitHub-issue path is buil
     surface but not groom their data," stated at the signal that triggers it.
   - **(Content) No triage measurement gates migration.** A repo may migrate an ungroomed backlog; the
     advisory says the result will be worse and stops there. Any completeness bar prawduct could
-    enforce would be a proxy for judgment it does not have, and would turn the nudge into exactly the
-    fleet-routing gate **BKL-6J2X** holds this advisory to avoid.
+    enforce would be a proxy for judgment it does not have, and would turn the nudge into a
+    fleet-routing gate — the thing this advisory was held out of the live roster for several releases
+    to avoid becoming. It now fires live, and what keeps it a nudge rather than a route is that it is
+    a `warn`, so the briefing relays it into conversation for the owner to answer. A completeness bar
+    would put prawduct's judgment back in front of theirs.
 - **GV8** **Norm-lifecycle signals survive cutover.** The three norm-lifecycle probes —
   `revisit-due` (a norm exception or stopgap whose expiry date has passed), `dead-why` (a norm whose
   stated rationale cites a shipped/dropped item), and `stalled-transition` (a `Status: in-transition`

--- a/plugin/hooks/banner.py
+++ b/plugin/hooks/banner.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Prawduct plugin SessionStart banner — version-delta + new-gate attribution.
 
-Chunk 7 of the v2.0.0 plugin-distribution build plan. The banner is the *safety
-net* for always-latest distribution (design §5/§5a): because the plugin
-auto-updates, every version move must be made VISIBLE, never silent. On each
-session start the banner:
+The banner is the *safety net* for always-latest distribution (design §5/§5a):
+because the plugin auto-updates, every version move must be made VISIBLE, never
+silent — and "visible" means visible to the **person**, which takes one more step
+than printing it, since this channel is read by the model (see ``render_delta``).
+On each session start the banner:
 
   1. prints the one-line identity banner (``═══ Prawduct vY (plugin) ═══``),
      carrying a load-provenance segment (``(plugin · develop@a1b2c3d)``) when the
@@ -310,8 +311,24 @@ def new_gates_in_range(gates: list[dict], last: str, current: str) -> list[dict]
     return [g for g in gates if lo < version_tuple(str(g.get("since", "0"))) <= hi]
 
 
+#: Leading glyph of the relay directive. A *directive to the agent*, not a severity
+#: signal, so it sits outside the ``CRITICAL:``/``WARNING:``/``NOTE:`` vocabulary and
+#: alongside the banner's own ``↑``/``•``/``⊕`` line glyphs.
+RELAY_MARKER = "⇒ "
+
+
 def render_delta(last: str, current: str, root: Path) -> list[str]:
-    """Lines for the delta block shown when the version changed."""
+    """Lines for the delta block shown when the version changed.
+
+    Closes with a **relay directive**. The delta block goes to stdout — the
+    agent-facing channel — and ``write_marker`` advances the marker the moment it
+    renders, so it appears exactly once and the person who owns the repo never sees
+    it. Without an instruction to pass it on, an upgrade is announced to nobody and
+    a shipped capability stays undiscoverable: the auto-update this banner exists to
+    make visible would be visible only to the model. The directive is last because
+    it refers to the lines above it; placed first it would read as being about the
+    version line alone.
+    """
     lines = [f"↑ Prawduct updated: v{last} → v{current}"]
     for _v, headline in highlights_in_range(parse_changelog(root), last, current):
         if headline:
@@ -321,6 +338,10 @@ def render_delta(last: str, current: str, root: Path) -> list[str]:
         summary = g.get("summary", "")
         suffix = f" — {summary}" if summary else ""
         lines.append(f"  ⊕ new gate \"{name}\"{suffix} (enforced now)")
+    lines.append(
+        f"{RELAY_MARKER}Tell the user what changed above, in your first reply this "
+        "session — they do not see this banner."
+    )
     return lines
 
 

--- a/plugin/lib/backlog_probes.py
+++ b/plugin/lib/backlog_probes.py
@@ -364,45 +364,34 @@ def probe_checks_dormant(state: ProjectState, codebase: Codebase):
     ]
 
 
-#: The migration path is not yet proven end-to-end, so the fleet-wide
-#: ``backlog-service-migration-required`` ``warn`` is **held**: it stays a registered
-#: probe (its firing logic below is intact and unit-tested via direct calls) but the
-#: live roster wires in a no-op, so no un-migrated repo is routed to
-#: ``/prawduct:backlog scrub`` at session start.
-#:
-#: Why held: the advisory's ``recommended_action`` is the scrub runbook, and until
-#: the runbook binds an owner-confirmed target repo, is honest about its (absent)
-#: dry-run, and runs under a narrowed adapter grant, a fleet-wide nudge is an
-#: automated route from every un-migrated repo into an irreversible, unpinned bulk
-#: write (100-250 real GitHub issues, no clean delete). The three runbook fixes plus
-#: at least one proven real migration (prawduct's own) are the precondition.
-#:
-#: To lift: register :func:`probe_migration_required` directly here instead of
-#: :func:`_probe_migration_required_held`, and flip
-#: ``TestMigrationRequiredProbe`` back to asserting the live roster surfaces it.
-#: Tracked by BKL-6J2X.
-def _probe_migration_required_held(state: ProjectState, codebase: Codebase):
-    """Held no-op standing in for :func:`probe_migration_required` in the live
-    roster. Returns nothing so the advisory never fires fleet-wide while the
-    migration path is unproven (BKL-6J2X). The real probe is kept intact for the
-    day the hold lifts; this wrapper is the only thing the roster sees."""
-    return []
-
-
 def register() -> None:
     """Register the six backlog probes. Idempotent (register_probe overwrites).
 
-    ``backlog-service-migration-required`` is registered **held** — a no-op stands
-    in for :func:`probe_migration_required` until the migration path is proven
-    (see :func:`_probe_migration_required_held`; BKL-6J2X). Still six probes: the
-    hold swaps the wired function, not the registration.
+    ``backlog-service-migration-required`` fires live. It spent several releases
+    wired to a no-op while the migration path was unproven, because its
+    ``recommended_action`` routes into an irreversible bulk write (100-250 real
+    GitHub issues; GitHub has no ordinary issue-delete and never reuses numbers),
+    and a fleet-wide nudge toward that is not a cosmetic default. The stated
+    conditions for wiring it up were: the scrub runbook binds an owner-confirmed
+    target repo, is honest about its absent dry-run, and runs under a narrowed
+    adapter grant — plus at least one proven real end-to-end migration. All are
+    discharged, and the owner ruled it live rather than leaving the probe's default
+    to decide by silence.
+
+    **What makes it safe is not the probe — it is that the advisory now reaches a
+    person.** The briefing prints to stdout, the agent-facing channel, so before
+    the relay directive this advisory could route the *model* toward those writes
+    with nobody informed. It is a `warn`, so it trips the relay
+    (``briefing.ADVISORY_RELAY_TEXT``) and the migration becomes the owner's call,
+    which is the only form in which it was ever meant to be offered. Do not
+    silence the relay for `warn` without re-deciding this.
     """
     register_probe(FEATURE, "legacy-backlog-format", PROBE_VERSION, probe_legacy_backlog_format)
     register_probe(
         FEATURE,
         "backlog-service-migration-required",
         PROBE_VERSION,
-        _probe_migration_required_held,
+        probe_migration_required,
     )
     register_probe(FEATURE, "backlog-checks-dormant", PROBE_VERSION, probe_checks_dormant)
     register_probe(FEATURE, "external-backlog-detected", PROBE_VERSION, probe_external_backlog)

--- a/plugin/lib/briefing.py
+++ b/plugin/lib/briefing.py
@@ -706,6 +706,7 @@ def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
                 and a.get("state") == "dismissed"
                 and (a.get("dismissed_at") or "") >= session_start_ts
             )
+    relay_advisories = False
     if active_adv or resolved_since or dismissed_since:
         if active_adv:
             lines.append(f"ADVISORIES (post-sync, {len(active_adv)} active):")
@@ -721,14 +722,14 @@ def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
                 lines.append(
                     f"  ... and {len(active_adv) - 5} more (run /prawduct:advisory list)"
                 )
-            # Relay directive — see ADVISORY_RELAY_TEXT. Keyed off the full active
-            # set rather than the displayed slice. Today the two agree: the sort
-            # above ranks `urgent`/`warn` ahead of `info`, so a relay-priority
-            # advisory can only be displaced by another one and is always visible.
-            # Keying off the full set means that stays correct if the sort changes,
-            # rather than silently going quiet on the case it exists for.
-            if any(a.get("priority") in _RELAY_PRIORITIES for a in active_adv):
-                lines.append(ADVISORY_RELAY_TEXT)
+            # Decided over the full active set rather than the displayed slice.
+            # Today the two agree: the sort above ranks `urgent`/`warn` ahead of
+            # `info`, so a relay-priority advisory can only be displaced by another
+            # one and is always visible. Keying off the full set keeps that correct
+            # if the sort changes, instead of going quiet on the case it exists for.
+            relay_advisories = any(
+                a.get("priority") in _RELAY_PRIORITIES for a in active_adv
+            )
         else:
             lines.append("ADVISORIES (post-sync):")
         if dismissed_since:
@@ -738,6 +739,11 @@ def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
             )
         if resolved_since:
             lines.append(f"  Resolved since last session: {resolved_since}")
+        # Relay directive last in the block, matching its banner twin: it refers to
+        # everything above it, and a directive with block content below it reads as
+        # covering only the part it precedes.
+        if relay_advisories:
+            lines.append(ADVISORY_RELAY_TEXT)
 
     # CLAUDE.md size check
     claude_md_path = project_dir / "CLAUDE.md"

--- a/plugin/lib/briefing.py
+++ b/plugin/lib/briefing.py
@@ -559,6 +559,29 @@ def _get_other_branch_wip(prawduct_dir: Path, current_branch: str) -> list[str]:
     return others
 
 
+#: Leading glyph of the advisory relay directive. A *directive to the agent*, not a
+#: severity signal, so it sits outside the ``CRITICAL:``/``WARNING:``/``NOTE:``
+#: vocabulary and alongside the briefing's own ``•``/``→`` line glyphs.
+ADVISORY_RELAY_MARKER = "⇒ "
+
+#: Advisory priorities worth interrupting a person for. `info` is excluded on
+#: purpose: it repeats every session until dismissed, and a channel that nags is a
+#: channel that gets tuned out — which would cost the `warn` case its audience.
+_RELAY_PRIORITIES = frozenset({"warn", "urgent"})
+
+#: Why this exists: the briefing prints to stdout, which this project's ratified
+#: observability norm defines as the AGENT-facing channel (stderr is the person's).
+#: So an advisory is an instruction the model reads, not a nudge the owner reads —
+#: and an advisory whose recommended action is the owner's call to make goes
+#: unanswered every session while looking, from the inside, perfectly delivered.
+#: Relaying it into conversation is what makes the owner's decision reachable.
+ADVISORY_RELAY_TEXT = (
+    f"{ADVISORY_RELAY_MARKER}Tell the user about the advisories above, in your first "
+    "reply this session — they do not see this briefing. Theirs to action, not yours "
+    "to silently resolve or dismiss."
+)
+
+
 def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
     """Assemble session briefing text. Target: <400 tokens (excluding handoff pointer)."""
     prawduct_dir = gitstate.get_prawduct_dir(project_dir)
@@ -698,6 +721,14 @@ def assemble_session_briefing(project_dir: Path, staleness: list[str]) -> str:
                 lines.append(
                     f"  ... and {len(active_adv) - 5} more (run /prawduct:advisory list)"
                 )
+            # Relay directive — see ADVISORY_RELAY_TEXT. Keyed off the full active
+            # set rather than the displayed slice. Today the two agree: the sort
+            # above ranks `urgent`/`warn` ahead of `info`, so a relay-priority
+            # advisory can only be displaced by another one and is always visible.
+            # Keying off the full set means that stays correct if the sort changes,
+            # rather than silently going quiet on the case it exists for.
+            if any(a.get("priority") in _RELAY_PRIORITIES for a in active_adv):
+                lines.append(ADVISORY_RELAY_TEXT)
         else:
             lines.append("ADVISORIES (post-sync):")
         if dismissed_since:

--- a/tests/test_backlog_probes.py
+++ b/tests/test_backlog_probes.py
@@ -212,16 +212,37 @@ class TestMigrationRequiredProbe:
     def test_no_backlog_file(self, tmp_path):
         assert bp.probe_migration_required(ProjectState({}), _cb(tmp_path)) == []
 
-    def test_held_out_of_live_roster(self, tmp_path):
-        # BKL-6J2X: the advisory is registered but **held** — a structured,
-        # un-migrated backlog that WOULD trip the probe (asserted directly, below)
-        # must NOT surface the nudge through the live roster, so no repo is routed
-        # to `/prawduct:backlog scrub` before the migration path is proven.
+    def test_surfaces_through_the_live_roster(self, tmp_path):
+        # The probe was wired to a no-op for several releases while the migration
+        # path was unproven, so a direct-call assertion alone would have passed the
+        # whole time it reached nobody. Assert the ROSTER, which is what a real
+        # session reads.
         _write_backlog(tmp_path, _structured_backlog(2))
-        # The underlying probe still fires when called directly — held, not broken.
-        assert bp.probe_migration_required(ProjectState({}), _cb(tmp_path))
         bp.register()
         cands = run_all_probes(ProjectState({}), make_codebase(tmp_path))
+        surfaced = [c for c in cands if c.type == "backlog-service-migration-required"]
+        assert len(surfaced) == 1
+        assert surfaced[0].recommended_action == "/prawduct:backlog scrub"
+
+    def test_surfaces_at_warn_so_it_trips_the_relay(self, tmp_path):
+        # The advisory routes toward an irreversible bulk write, so it must reach a
+        # person, not just the model. The briefing relays `warn`/`urgent` only —
+        # demoting this to `info` would silently restore the unreachable state the
+        # lift was meant to end.
+        _write_backlog(tmp_path, _structured_backlog(2))
+        bp.register()
+        cands = run_all_probes(ProjectState({}), make_codebase(tmp_path))
+        surfaced = [c for c in cands if c.type == "backlog-service-migration-required"]
+        assert surfaced[0].priority == "warn"
+
+    def test_stays_quiet_post_cutover_through_the_roster(self, tmp_path):
+        # Live now, so the "already migrated" case has to be proven at the roster
+        # too: a repo on the Issues backend must not be nudged to migrate again.
+        _write_backlog(tmp_path, _structured_backlog(2))
+        bp.register()
+        cands = run_all_probes(
+            ProjectState({"backlog_service_repo": "acme/widgets"}), make_codebase(tmp_path)
+        )
         assert not [c for c in cands if c.type == "backlog-service-migration-required"]
 
 

--- a/tests/test_briefing_functions.py
+++ b/tests/test_briefing_functions.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -627,6 +628,89 @@ class TestAssembleSessionBriefingSections:
         assert "ADVISORIES (post-sync, 1 active):" in out
         assert "• [feat] do x" in out
         assert "→ Run /prawduct:doctor (or /prawduct:advisory dismiss ADV-1)" in out
+
+
+class TestAdvisoryRelayDirective:
+    """The briefing renders to stdout — the agent-facing channel — so an advisory
+    is an instruction the model reads, never a nudge the owner reads. A `warn`
+    that needs an owner decision therefore has to be relayed into conversation or
+    it goes unanswered every session while appearing, from the inside, delivered.
+
+    Scoped to `warn`/`urgent`: relaying `info` every session is nagging, which
+    trains the reader to tune the channel out and costs more than it buys.
+    """
+
+    def _state(self, tmp_path: Path, body: str) -> Path:
+        pr = tmp_path / ".prawduct"
+        pr.mkdir(parents=True, exist_ok=True)
+        (pr / "project-state.yaml").write_text(body)
+        return pr
+
+    def _advisories(self, monkeypatch, *advisories):
+        monkeypatch.setattr(
+            briefing.gitstate, "_read_advisory_store", lambda d: {"advisories": list(advisories)}
+        )
+
+    def _adv(self, priority: str, aid: str = "ADV-1") -> dict:
+        return {
+            "id": aid, "state": "active", "feature": "feat",
+            "trigger_summary": "do x", "recommended_action": "/prawduct:doctor",
+            "priority": priority, "triggered_at": "2026-01-01",
+        }
+
+    def test_warn_triggers_the_relay(self, tmp_path, monkeypatch):
+        self._state(tmp_path, "")
+        self._advisories(monkeypatch, self._adv("warn"))
+        assert briefing.ADVISORY_RELAY_MARKER in briefing.assemble_session_briefing(tmp_path, [])
+
+    def test_urgent_triggers_the_relay(self, tmp_path, monkeypatch):
+        self._state(tmp_path, "")
+        self._advisories(monkeypatch, self._adv("urgent"))
+        assert briefing.ADVISORY_RELAY_MARKER in briefing.assemble_session_briefing(tmp_path, [])
+
+    def test_info_only_is_silent(self, tmp_path, monkeypatch):
+        self._state(tmp_path, "")
+        self._advisories(monkeypatch, self._adv("info"), self._adv("info", "ADV-2"))
+        assert briefing.ADVISORY_RELAY_MARKER not in briefing.assemble_session_briefing(tmp_path, [])
+
+    def test_no_active_advisories_is_silent(self, tmp_path, monkeypatch):
+        self._state(tmp_path, "")
+        self._advisories(monkeypatch)
+        assert briefing.ADVISORY_RELAY_MARKER not in briefing.assemble_session_briefing(tmp_path, [])
+
+    def test_resolved_advisory_does_not_trigger_the_relay(self, tmp_path, monkeypatch):
+        # State, not priority, decides: a resolved `warn` has nothing to relay.
+        self._state(tmp_path, "")
+        resolved = self._adv("warn") | {"state": "resolved", "resolved_at": "2026-01-02"}
+        self._advisories(monkeypatch, resolved)
+        assert briefing.ADVISORY_RELAY_MARKER not in briefing.assemble_session_briefing(tmp_path, [])
+
+    def test_display_cap_can_never_hide_a_consequential_advisory(self, tmp_path, monkeypatch):
+        # The block displays 5 of N. That cap can only mislead if a relay-priority
+        # advisory is ever pushed out of the visible set — which the priority sort
+        # forbids: `urgent`/`warn` rank ahead of `info`, so the only thing that can
+        # displace a `warn` is an `urgent`, itself worth relaying. This pins the
+        # sort, not the relay: reorder it to newest-first and a `warn` buried under
+        # six fresh `info`s would be relayed but never shown, so the person is told
+        # to look at something they cannot see.
+        self._state(tmp_path, "")
+        infos = [self._adv("info", f"ADV-{i}") for i in range(6)]
+        monkeypatch.setattr(briefing.gitstate, "_read_advisory_store", lambda d: {
+            "advisories": infos + [self._adv("warn", "ADV-LATE")]
+        })
+        out = briefing.assemble_session_briefing(tmp_path, [])
+        assert briefing.ADVISORY_RELAY_MARKER in out
+        assert "... and 2 more" in out, "expected 7 active with 5 displayed"
+        relayed_line_index = out.splitlines().index(briefing.ADVISORY_RELAY_TEXT)
+        shown = "\n".join(out.splitlines()[:relayed_line_index])
+        assert "ADV-LATE" in shown, "a warn must be inside the displayed set, not just relayed"
+
+    def test_relay_names_no_internal_identifier(self, tmp_path, monkeypatch):
+        self._state(tmp_path, "")
+        self._advisories(monkeypatch, self._adv("warn"))
+        out = briefing.assemble_session_briefing(tmp_path, [])
+        line = next(ln for ln in out.splitlines() if briefing.ADVISORY_RELAY_MARKER in ln)
+        assert not re.search(r"\b[A-Z]{2,4}-[A-Z0-9]{3,4}\b", line), line
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_briefing_functions.py
+++ b/tests/test_briefing_functions.py
@@ -685,6 +685,28 @@ class TestAdvisoryRelayDirective:
         self._advisories(monkeypatch, resolved)
         assert briefing.ADVISORY_RELAY_MARKER not in briefing.assemble_session_briefing(tmp_path, [])
 
+    def test_relay_is_last_in_the_block(self, tmp_path, monkeypatch):
+        # The directive refers to everything above it, so trailing block content
+        # would make it read as covering only the part it precedes. Its banner twin
+        # is pinned by an equivalent test; this site was moved to satisfy a review
+        # finding with nothing holding it there, so the position is pinned now.
+        # `dismissed`/`resolved` are the lines that follow the advisory list, so a
+        # regression puts them after the directive.
+        self._state(tmp_path, "")
+        (tmp_path / ".prawduct" / ".session-start").write_text("2026-01-01T00:00:00Z")
+        dismissed = self._adv("info", "ADV-D") | {
+            "state": "dismissed", "dismissed_at": "2026-01-02T00:00:00Z"
+        }
+        self._advisories(monkeypatch, self._adv("warn"), dismissed)
+        out = briefing.assemble_session_briefing(tmp_path, [])
+        block_lines = out.splitlines()
+        assert "Dismissed since last session" in out, "fixture must produce a trailing line"
+        relay_at = block_lines.index(briefing.ADVISORY_RELAY_TEXT)
+        dismissed_at = next(
+            i for i, ln in enumerate(block_lines) if "Dismissed since last session" in ln
+        )
+        assert relay_at > dismissed_at, "relay must follow every line of its block"
+
     def test_display_cap_can_never_hide_a_consequential_advisory(self, tmp_path, monkeypatch):
         # The block displays 5 of N. That cap can only mislead if a relay-priority
         # advisory is ever pushed out of the visible set — which the priority sort
@@ -701,8 +723,13 @@ class TestAdvisoryRelayDirective:
         out = briefing.assemble_session_briefing(tmp_path, [])
         assert briefing.ADVISORY_RELAY_MARKER in out
         assert "... and 2 more" in out, "expected 7 active with 5 displayed"
-        relayed_line_index = out.splitlines().index(briefing.ADVISORY_RELAY_TEXT)
-        shown = "\n".join(out.splitlines()[:relayed_line_index])
+        # Bound the "displayed" set by the overflow line rather than by the relay's
+        # position: the relay moved once already, and a proxy that tracks it would
+        # keep passing while measuring something else.
+        overflow_at = next(
+            i for i, ln in enumerate(out.splitlines()) if "... and 2 more" in ln
+        )
+        shown = "\n".join(out.splitlines()[:overflow_at])
         assert "ADV-LATE" in shown, "a warn must be inside the displayed set, not just relayed"
 
     def test_relay_names_no_internal_identifier(self, tmp_path, monkeypatch):

--- a/tests/test_plugin_version_banner.py
+++ b/tests/test_plugin_version_banner.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 from importlib.machinery import SourceFileLoader
@@ -149,6 +150,75 @@ class TestVersionMath:
         ]}))
         lines = banner.render_delta("2.0.0", "2.1.0", root)
         assert any("new gate" in line and "cumulative-critic" in line for line in lines)
+
+
+class TestUpgradeRelay:
+    """The delta block is emitted on stdout — the agent-facing channel — and the
+    marker advances immediately, so it renders exactly once and the human never
+    sees it. Without an explicit instruction to pass it on, a shipped capability
+    is announced to nobody: the relay directive is what closes that gap."""
+
+    def test_delta_carries_a_relay_directive(self, banner):
+        lines = banner.render_delta("1.8.0", "1.8.1", ROOT)
+        assert any(
+            line.startswith(banner.RELAY_MARKER) for line in lines
+        ), "a delta the user cannot see must instruct the agent to relay it"
+
+    def test_relay_directive_is_last(self, banner):
+        # It has to follow the content it refers to; a directive above the
+        # headlines reads as being about the version line alone.
+        lines = banner.render_delta("1.8.0", "1.8.1", ROOT)
+        assert lines[-1].startswith(banner.RELAY_MARKER)
+
+    def test_relay_accompanies_a_new_gate_delta(self, banner, tmp_path):
+        # A newly-enforced gate changes what blocks the user mid-session. That is
+        # the delta they most need relayed, so it must not depend on the release
+        # happening to carry a changelog headline.
+        root = tmp_path / "plugin"
+        (root / "hooks").mkdir(parents=True)
+        (root / "CHANGELOG.md").write_text("# CL\n\n## v2.1.0\n\n")
+        (root / "hooks" / "gates.json").write_text(json.dumps({"gates": [
+            {"id": "cumulative-critic", "name": "cumulative-critic", "since": "2.1.0",
+             "summary": "PR bundle review required"}
+        ]}))
+        lines = banner.render_delta("2.0.0", "2.1.0", root)
+        assert any("new gate" in line for line in lines)
+        assert lines[-1].startswith(banner.RELAY_MARKER)
+
+    def test_relay_names_no_internal_identifier(self, banner):
+        # § Direction: text emitted into a governed product carries the plain-language
+        # reason, never a requirement/chunk/backlog id the reader cannot resolve.
+        directive = next(
+            line for line in banner.render_delta("1.8.0", "1.8.1", ROOT)
+            if line.startswith(banner.RELAY_MARKER)
+        )
+        assert not re.search(r"\b[A-Z]{2,4}-[A-Z0-9]{3,4}\b", directive), directive
+
+    def test_no_relay_when_version_is_unchanged(self, tmp_path, banner):
+        # Assert the marker, not the word "relay": the identity line carries a
+        # provenance segment naming the checked-out branch, so a loose substring
+        # match here passes or fails on what the branch happens to be called.
+        prawduct = _repo(tmp_path)
+        (prawduct / ".prawduct-version").write_text(PLUGIN_VERSION + "\n")
+        r = _run_banner(ROOT, tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert banner.RELAY_MARKER not in r.stdout
+
+    def test_no_relay_on_first_marker_write(self, tmp_path, banner):
+        # First contact has no prior version to diff, so there is no news to pass
+        # on — telling the user "something changed" here would be a false claim.
+        prawduct = _repo(tmp_path)
+        r = _run_banner(ROOT, tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert banner.RELAY_MARKER not in r.stdout
+        assert (prawduct / ".prawduct-version").read_text().strip() == PLUGIN_VERSION
+
+    def test_relay_reaches_stdout_on_a_real_crossing(self, tmp_path, banner):
+        prawduct = _repo(tmp_path)
+        (prawduct / ".prawduct-version").write_text("1.8.0\n")
+        r = _run_banner(ROOT, tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert banner.RELAY_MARKER in r.stdout
 
 
 # =============================================================================


### PR DESCRIPTION
## Everything prawduct says about itself, it says to the model

An auto-updating install announces a new version to **stdout** — which this project's own
ratified norm defines as the *agent-facing* channel — and `write_marker()` then advances the
marker so it never renders again. Nothing instructed the agent to pass any of it on. Net: a
shipped capability was announced once, on a channel the repo owner does not read, and then
never again. The same held for advisories.

Found while preparing an owner acceptance exercise for the backlog migration, when the owner
asked why an auto-updating product would ever discover the migration. It wouldn't.

### What changed

A **relay directive** at each emission site — next to the content it refers to, firing only
when there is news:

- `plugin/hooks/banner.py` — `render_delta()` closes with `RELAY_MARKER`, telling the agent to
  surface the version change in conversation. Fires only on a crossing.
- `plugin/lib/briefing.py` — `ADVISORY_RELAY_TEXT` after the advisory block, for any active
  `warn`/`urgent` advisory. `info` is deliberately excluded: a channel that nags gets tuned
  out, which would cost the `warn` case the audience it exists for.
- `plugin/lib/backlog_probes.py` — the `backlog-service-migration-required` advisory now fires
  live; the held no-op wrapper is gone. This is the work of **BKL-7D3V** (#330), which will be
  closed when this merges — GitHub's native auto-close does not fire for a `develop`-based PR.
- `.prawduct/artifacts/observability-strategy.md` — new § *How the owner actually learns*.

### Why not the session digest

It was the obvious home and it is the wrong one: a rule read at session start, competing with
everything else in context, is precisely the delivery failure being fixed. The 44 characters of
inline headroom prompted the re-examination but is *not* the reason — the owner offered to raise
the limit and the design did not move. Recorded in the build plan and the strategy artifact so
it is not re-litigated.

### Chunks 01 and 02 ship together

Chunk 03's lift routes consuming repos toward an irreversible bulk write (100–250 real issues);
the relay is what puts a person in that loop. The lift must not land alone.

### Verification

- Suite green (3157 passed / 7 skipped); `prawduct-hook test-status` reports `current`.
- Both relays verified against real rendered output, not only tests.
- `regen-views --check` passes — tags validate against the plan roster.
- Cumulative-Critic gate satisfied: 3 review facts + 1 free edge, 0 unresolved blocking.

### Review history

Three Critic rounds. Round 1 (1 blocking, 3 warnings, 4 notes) resolved in `74cdef3`; round 2
(`verify-resolutions`) verified all 6 resolutions and raised 2 new warnings that arrived *with*
the fixes, resolved in `f2aeb56`; round 3 returned 0 blocking / 0 warning / 1 note.

### Release bookkeeping (`release: classify upgrade-discovery into v3.2.3`)

v3.2.3 is **mid-flight, not un-started** — `ddb6dd1` already ran Phase 1 prep and stamped all 12
change-log entries for the first four scopes. This scope arrived after that prep, so it needed the
same treatment or `check-releasability` would refuse the release:

- Classification table gains `upgrade-discovery | ships`; change-log tag stamped
  `release=v3.2.3 | status=shipped`. Without the `release=` key it would have flipped the plan
  checkboxes while silently vanishing from the release notes.
- **Version decision re-recorded.** The patch rationale rested on "nothing goes live," which Chunk 02
  falsifies. Patch still holds under the conservative-versioning norm — the advisory *prints* rather
  than gates — but the stated reason was false and is now correct.
- Blocker-liveness measurement re-taken; the original is kept as historical record.
- **OWNER RELEASE GATE gains item 3.** `BKL-8W2M` (#197) is open at `stage:requirements`, and
  `BKL-7D3V` recorded it as *what makes the lift survivable*. That risk was accepted when the
  advisory reached only the **agent**; Chunk 01 relays it to the **person, every session**, which is
  strictly worse than what was accepted. Land `BKL-8W2M` before Phase 2, or record a second explicit
  acceptance. **Merging here is not the irreversible step — publishing is.**

### Review

Independent PR review (`claude-opus-5[1m]`): **0 blocking, 2 warnings, 2 notes.** Both warnings were
the release bookkeeping above and are resolved in this branch. Notes: backlog reconciliation has no
Issues-backend path yet (being fixed separately), and a learnings heading exceeds the 400-char house
limit (a widespread existing pattern — 19 headings exceed it).

### Known issue, not fixed here

The changelog headline the banner renders is a whole paragraph rather than a headline — 47 of 57
entries exceed 160 chars (v3.2.0's is 3,548), and 39 carry a stray `**` because `lstrip("-* ")`
strips the opening bold marker and leaves the closing one. This relay makes that payload
user-facing for the first time, so it matters more than when it was filed. Being fixed on a
separate branch before v3.2.3 tags.
