### PR TITLE
docs: requirements and design for coverage socket 1 (#249)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3,6 +3,34 @@
 <!-- Append new entries at the top. Each entry is a ## section.
      Historical entries (pre-2026-03-22) are in project-state.yaml under change_log_history. -->
 
+## 2026-09-10: the four-socket epic's missing first document lands
+
+<!-- prawduct: type=docs | scope=coverage-socket-1-docs -->
+
+The change-evidence contract is four sockets, and three of them — #618 blast radius, #619
+diff-scoped mutation, #620 API diff — have carried both a requirements and a design document on
+`develop` for weeks. Socket 1, #249, is the one the shared artifact calls the instrument for the
+most serious Python-specificity violation in the tree (`test-reference-verify` feeds
+`verify_coverage`, a BLOCKING Goal 1 check, and understands only `def`/`class`), and its two
+documents existed only on an unmerged remote branch. Every other commit from that branch is
+already on `develop` by sha; these two files were the residue.
+
+So this lands them unchanged: `documentation/issues/249-requirements.md` (CE1-1..CE1-10, the eight
+decisions, grounded against `develop` at `7583fb29`) and `249-design.md` (the `coverage_producer`
+key, `--executed-command` on `test-reference-verify`, the additive `uncovered_lines` field, and a
+nine-case test plan). Nothing is implemented by this change and nothing is meant to be — the epic
+gets its fourth pair of documents, which is what makes the set readable as a set.
+
+Re-checked against `develop` before landing rather than trusted from the branch's own date stamp:
+`coverage_producer` still exists nowhere, `"executed"` is still assigned as a `coverage_level` by
+no shipped code path, `KNOWN_KINDS` still has no coverage slot, `test-reference-verify` is still
+present and still the floor, and #249 and #556 are both still open. The documents' claims about
+what is *absent* are the load-bearing ones, and all of them still hold. What has drifted since
+2026-08-31 is line citations into `gates.py` — `verify_coverage`'s severity branch moved from
+`:1868` to `:1916` — which is the ordinary decay of a document that stamps the commit it was
+verified against. Rewriting them would restate a grounding pass rather than record one, so the
+stamp stands and the drift is named here instead.
+
 ## 2026-09-10: an audit of develop, and the three findings that could not wait for the cut
 
 <!-- prawduct: type=fix | scope=audit-followups -->

--- a/documentation/issues/249-design.md
+++ b/documentation/issues/249-design.md
@@ -1,0 +1,440 @@
+# Issue #249 — Coverage: The Coverage Floor Is Python-Only: Design
+
+`status: draft · stage: design · area: coverage · added: 2026-08-31 · source: scheduled backlog
+session · issue: https://github.com/brookstalley/prawduct/issues/249`
+
+Builds on `documentation/issues/249-requirements.md` (CE1-1 through CE1-10, Decisions 1–8). This
+document resolves the requirements doc's two design-stage deferrals — the exact verdict
+serialization (Decision 2's "left open to design" clause) and whether executed-level line data
+extends the existing F4a schema or lives in a separate shape (Decision 4) — and specifies
+file-by-file changes an implementation chunk can follow directly. It also settles, for socket 1,
+the cross-socket declaration-surface question `change-evidence-design.md`'s Open Questions left
+open, and retires that same artifact's "which real toolchains cannot emit any of the four formats"
+open question outright (both resolved in the two Decisions immediately below).
+
+Socket 1 of the four-socket change-evidence contract — the last of the four to reach design.
+Siblings #618 (socket 2), #619 (socket 3), #620 (socket 4) already have requirements and design
+merged. The shared contract itself (`.prawduct/artifacts/change-evidence-design.md`) is not
+restated here.
+
+## Summary of what ships
+
+1. **CE1-1, CE1-8** — one new `project-state.yaml` key: `coverage_producer` (opaque invocation,
+   optional — no new boolean; `coverage_required` is reused per requirements Decision 5).
+2. **CE1-2, CE1-3** — `bin/test-reference-verify` gains a new `--executed-command <cmd>` flag and a
+   new `_build_executed_evidence_fields()` function. When invoked with the flag, it runs the
+   declared producer instead of its own symbol-grep and writes `coverage_level: "executed"`. Its
+   existing symbol-grep path (the floor) is untouched — same file, same entry point, a second
+   branch.
+3. **CE1-4** — one new *optional*, additive F4a field: `uncovered_lines` (a list of `file:line`
+   strings). `changes_referenced`/`changes_unjudged`/`coverage_level` are populated exactly as
+   `verify_coverage` already reads them — **CE1-3's "no new gate logic" promise is kept literally:
+   `lib/gates.py` needs zero code changes.**
+4. `bin/prawduct-hook`'s existing `test-evidence record` overlay call (the one call site that
+   already invokes `test-reference-verify --merge-into`) reads the new key and passes
+   `--executed-command` through when declared. No new `prawduct-hook` subcommand.
+5. **CE1-9** — the Case-B caveat added at three doc sites: `test-reference-verify`'s module
+   docstring, `verify_coverage`'s docstring, and the new `project-state.yaml` key's comment block.
+6. `plugin/templates/project-state.yaml` documentation for the new key.
+
+## Decisions resolved
+
+### Decision — declaration surface (settles `change-evidence-design.md` Open Question #1, for
+socket 1; the cross-socket question in general)
+
+Requirements' Scope-out left this "not decided for socket 1 in isolation... no sibling design has
+settled it yet." It is now settled by precedent, not by waiting further: #618, #619, and #620 each
+independently declared their **own** dedicated key(s) — `reference_index_producer`,
+`mutation_producer`/`mutation_required`, `api_diff_producer`/`api_diff_required` — none of them
+introduced or reused a shared cross-socket key. Three-for-three is the pattern, not a coincidence
+to relitigate: each socket's producer contract is shaped differently (a `{base}` placeholder for
+socket 3, none for socket 4, none needed for socket 1 either), so a shared key would need to be the
+union of four incompatible shapes or force an artificial common envelope onto producers that don't
+need one. Socket 1 follows the same pattern: **one new key, `coverage_producer`, scoped to this
+socket alone.** This design closes `change-evidence-design.md` Open Question #1 for good — a future
+reader hitting that line in the artifact should treat it as answered by the accumulated precedent
+of all four sockets' designs, not still open.
+
+### Decision — the "which toolchains cannot emit LCOV/Cobertura/Clover/JaCoCo" open question is
+moot (retires `change-evidence-design.md`'s last open question)
+
+That question predates the issue's own 2026-08-07 Correction (requirements Grounding facts) and
+asked it because the pre-Correction plan had prawduct **parsing** one of those four report formats
+directly — so a toolchain unable to produce any of them would have had no path in. Under the
+corrected, already-ratified contract, prawduct parses **no** report format; it consumes an
+already-normalized verdict the product's own producer command prints (requirements Decision 1,
+CE1-1, CE1-8). This design's producer envelope (below) needs nothing more than "the changed lines
+that are not covered, and the changed files the producer could judge at all" — a shape any coverage
+signal can be squeezed into by a five-line wrapper script, regardless of whether the underlying
+tool speaks LCOV, Cobertura, a proprietary JSON, or nothing exportable at all (a wrapper can read a
+tool's terminal output and regex it, same as any CI script already does). No product is excluded by
+format. This design therefore treats the artifact's open question as **retired**, not merely
+deferred again. The proposed edit (Files touched, below) strikes the line and replaces it with a
+one-sentence pointer here: *"Retired — #249's design supplies a producer envelope no report format
+is required to pass through; see `documentation/issues/249-design.md` § Decision."*
+
+### Decision 2 (requirements) — the minimal verdict primitive, serialized
+
+The declared `coverage_producer` command prints one JSON object to **stdout**:
+
+```json
+{"schema": 1, "tracked": ["src/a.py", "src/b.py"], "uncovered": ["src/a.py:42", "src/a.py:57"]}
+```
+
+- `tracked` — every changed file the producer's underlying coverage report could judge at all
+  (instrumented, or otherwise assessable for the diff). This is the field the pre-Correction plan
+  never needed and the corrected contract does: without it, "zero uncovered lines for this file"
+  is ambiguous between "fully covered" and "not a source file the coverage tool tracks" (a
+  `README.md` in the diff, say) — the same ambiguity the floor resolves today via
+  `_is_python_file`, generalized to whatever universe the product's own tool defines instead of a
+  hardcoded suffix check.
+- `uncovered` — `file:line` pairs (requirements CE1-2, verbatim from the design artifact's own
+  stated primitive) for every tracked, changed line the report shows as not executed. Line is a
+  1-based integer following the `:`; `file` must appear in `tracked`.
+- `schema` — rejects a version this reader does not understand rather than misparsing it, the same
+  posture `api_diff_producer`'s envelope uses (#620 design, Decision 4) and `data-model.md`'s
+  forward-incompatibility rule requires (CE1-4).
+
+`changes_referenced` = changed files present in `tracked` with no `uncovered` entry.
+`changes_unjudged` = changed files absent from `tracked` (mirrors the floor's existing "outside the
+verifier's judgment" classification, generalized). `missing` (the actual gate population) is
+derived by `verify_coverage` exactly as today — changed, not referenced, not unjudged — because
+`changes_referenced`/`changes_unjudged` already encode the right answer; **no branch inside
+`verify_coverage` needs to know executed-level verdicts exist at all.**
+
+### Decision 4 (requirements) — schema extension, not a separate shape
+
+One new **optional** field, `uncovered_lines: list[str]` (`file:line`, verbatim from the producer's
+`uncovered`, filtered to changed files as a defensive measure — see §2), added to the merged
+`.test-evidence.json` record when `coverage_level: "executed"`. It is not added to
+`_EVIDENCE_REQUIRED_FIELDS` or `_EVIDENCE_COVERAGE_FIELDS` (`gates.py:56-69`) — `_validate_evidence_schema`
+only rejects a **missing** required field or a **wrong-typed present** one (`gates.py:349-389`); an
+extra key it was never told to expect is neither, so a record without `uncovered_lines` (every
+floor-level record ever written, and this socket's own error/fallback paths) continues to validate
+unchanged. This is what "additive-only field evolution" (Decision 4's own constraint) means
+concretely, and it is why `lib/gates.py` needs no code change (CE1-3): the field exists for a
+reader that wants it (a future `verify_coverage` enhancement citing exact lines in its BLOCKING
+message — noted as an Open item below, not required by this chunk) without the existing reader
+needing to know it exists. A parallel storage shape (a second file, or a new `evidence.py`
+`kind`) was rejected: it would need its own freshness/staleness story `test_status`/`verify_coverage`
+already solve for the one file that exists, for no benefit this field doesn't already provide.
+
+## Section 1 — `project-state.yaml` key (CE1-1, CE1-8)
+
+**Where:** `plugin/templates/project-state.yaml`, inside the existing "TEST EXECUTION" block,
+directly after the `tests_dirs:` comment (currently ending at line 372) and before the new
+`sentinel_command:` block that now follows it — same section family (coverage/test declaration
+surfaces), matching the "COVERAGE EVIDENCE" heading's own placement convention one block up.
+
+```yaml
+# coverage_producer: scripts/coverage-diff-verdict.sh
+#   Opaque, unwrapped shlex-split invocation, run from the repo root — same
+#   "declare it, don't wrap it" contract as test_command:/api_diff_producer:/
+#   mutation_producer:. Prints one JSON object to stdout:
+#     {"schema": 1, "tracked": [...changed files the coverage report could
+#      judge...], "uncovered": ["file:line", ...changed, tracked, not
+#      executed...]}
+#   prawduct validates no report format and ships no LCOV/Cobertura/Clover/
+#   JaCoCo parser — the product's own coverage tool plus an existing
+#   diff-coverage normalizer (or a hand-rolled wrapper) does that and prints
+#   this envelope. Declaring this activates coverage_level: "executed"
+#   evidence, read by the SAME coverage_required lever above — no separate
+#   opt-in. Unset: prawduct-hook test-evidence record falls back to the
+#   Python-only symbol-grep floor, unchanged. An "executed" verdict proves a
+#   changed line ran during a test; it does not prove any assertion
+#   constrained its behaviour (see change-evidence-design.md § Blind spots).
+#   See `.prawduct/artifacts/change-evidence-design.md` and
+#   `documentation/issues/249-design.md`.
+```
+
+**Compatibility:** additive and optional; a `project-state.yaml` predating this change reads as
+"not declared" (`read_str_yaml_key` returns `None`) and the existing floor path runs exactly as it
+does today — no migration, matching `api_diff_producer`/`reference_index_producer`/
+`mutation_producer`'s existing posture.
+
+## Section 2 — `bin/test-reference-verify`: `--executed-command` (CE1-2, CE1-3, CE1-4)
+
+**New argparse option**, alongside the existing `--merge-into` definition (`test-reference-verify:321-325`):
+
+```python
+parser.add_argument(
+    "--executed-command",
+    default=None,
+    help=(
+        "Opaque, shlex-split command emitting the executed-level verdict "
+        '{"schema": 1, "tracked": [...], "uncovered": ["file:line", ...]} on '
+        "stdout. When given, replaces the Python-only symbol-grep floor for "
+        "this run: coverage_level is written as executed (issue #249 design)."
+    ),
+)
+```
+
+**Dispatch** (`main()`, replacing the unconditional `fields = _build_evidence_fields(repo, base,
+tests_dirs)` call at `test-reference-verify:352-356`):
+
+```python
+try:
+    if args.executed_command:
+        fields = _build_executed_evidence_fields(repo, base, args.executed_command)
+    else:
+        fields = _build_evidence_fields(repo, base, tests_dirs)
+except RuntimeError as exc:
+    print(f"error: {exc}", file=sys.stderr)
+    return 2
+```
+
+The existing `except RuntimeError` branch is reused verbatim — a producer failure surfaces exactly
+like a git failure does today (exit 2, one stderr line), no new error-handling shape.
+
+**New function**, placed beside `_build_evidence_fields` (mirrors `api_diff_status`'s
+`_run_api_diff_producer` helper, #620 design §2, at the same level of abstraction — subprocess +
+JSON contract, timeout-guarded):
+
+```python
+_EXECUTED_PRODUCER_TIMEOUT_SECONDS = 60
+_EXECUTED_VERIFIER_NAME = "test-reference-verify (executed: declared producer)"
+
+
+def _build_executed_evidence_fields(cwd: Path, base: str, command: str) -> dict:
+    """Compute F4a fields from a declared executed-level producer's verdict.
+
+    Fixed name in ``verifier`` rather than embedding ``command`` verbatim —
+    the field is meant for a human scanning evidence, not for reproducing the
+    invocation (that lives in project-state.yaml, one place, not duplicated
+    into every record it produces).
+
+    Raises RuntimeError on any producer failure — timeout, non-zero exit,
+    invalid JSON, wrong schema, or a malformed tracked/uncovered shape —
+    which ``main()`` reports and turns into exit 2, identically to a git
+    failure. There is no silent-degrade path: an executed-level producer that
+    cannot be trusted must not write coverage_level: executed evidence for a
+    verdict it did not actually compute.
+    """
+    changed = set(_changed_files(cwd, base))
+    try:
+        argv = shlex.split(command)
+        result = subprocess.run(
+            argv, cwd=cwd, capture_output=True, text=True,
+            timeout=_EXECUTED_PRODUCER_TIMEOUT_SECONDS, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"coverage_producer failed to run: {exc}") from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"coverage_producer exited {result.returncode}: "
+            f"{result.stderr.strip() or '(no stderr)'}"
+        )
+    try:
+        verdict = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"coverage_producer emitted invalid JSON: {exc}") from exc
+    if not isinstance(verdict, dict) or verdict.get("schema") != 1:
+        raise RuntimeError("coverage_producer verdict missing schema: 1")
+    tracked = verdict.get("tracked")
+    uncovered = verdict.get("uncovered")
+    if not isinstance(tracked, list) or not isinstance(uncovered, list):
+        raise RuntimeError("coverage_producer verdict missing tracked/uncovered lists")
+
+    tracked_set = {str(t) for t in tracked}
+    uncovered_files = set()
+    uncovered_lines: list[str] = []
+    for entry in uncovered:
+        text = str(entry)
+        file_part, _, _line_part = text.rpartition(":")
+        if not file_part:
+            continue  # malformed entry, defensively dropped rather than raised on
+        uncovered_files.add(file_part)
+        if file_part in changed:
+            uncovered_lines.append(text)
+
+    referenced = sorted(f for f in changed if f in tracked_set and f not in uncovered_files)
+    unjudged = sorted(f for f in changed if f not in tracked_set)
+
+    return {
+        "verifier": _EXECUTED_VERIFIER_NAME,
+        "coverage_level": "executed",
+        "tests_executed": [],
+        "changes_referenced": referenced,
+        "changes_unjudged": unjudged,
+        "uncovered_lines": sorted(uncovered_lines),
+    }
+```
+
+`tests_executed: []` — the field means "test files discovered under the tests directory," a
+floor-specific concept (which test file textually mentions a symbol) with no executed-level
+analogue; an empty list is honest rather than a fabricated re-derivation. Nothing downstream reads
+it as a count of anything (`verify_coverage` never inspects `tests_executed`; it exists in the F4a
+schema for the pytest-half record `cmd_test_evidence` writes before the overlay, per
+`_EVIDENCE_REQUIRED_FIELDS`).
+
+**Module-level imports:** `shlex` is new (`subprocess`/`json` already imported at
+`test-reference-verify:52-55`).
+
+## Section 3 — `bin/prawduct-hook`: read the new key, pass the flag (CE1-1)
+
+**Where:** `cmd_test_evidence`'s existing overlay block (`prawduct-hook:3898-3922`) — the single
+call site that already invokes `test-reference-verify --merge-into`. Add one read and one
+conditional argument, touching no other line in the block:
+
+```python
+verifier = Path(_plugin_root()) / "bin" / "test-reference-verify"
+if verifier.is_file():
+    coverage_producer = read_str_yaml_key(
+        prawduct_dir / "project-state.yaml", "coverage_producer"
+    )
+    merge_cmd = [
+        sys.executable,
+        str(verifier),
+        "--merge-into",
+        str(evidence_path),
+        "--repo",
+        str(project_dir),
+    ]
+    for tests_dir in tests_dirs:
+        merge_cmd += ["--tests-dir", tests_dir]
+    if base:
+        merge_cmd += ["--base", base]
+    if coverage_producer:
+        merge_cmd += ["--executed-command", coverage_producer]
+    mp = subprocess.run(merge_cmd, check=False, capture_output=True, text=True)
+    ...  # unchanged below
+```
+
+`--tests-dir` is still passed even when `--executed-command` is given — harmless (the executed path
+never reads `tests_dirs`), and keeps the two call shapes from diverging for no reason. `prawduct_dir`
+is already in scope at this point in `cmd_test_evidence` — it is assigned near the top of the
+function (`prawduct-hook:3384`) and used again just above this block, at the atomic-write step
+(`prawduct_dir.mkdir(...)`, `:3879`) — so reading `coverage_producer` needs no new variable, only
+the one extra `read_str_yaml_key` call shown above.
+
+No new `prawduct-hook` subcommand, no dispatch-table change, no `_USAGE` edit: this rides the
+existing `test-evidence record` entry point exactly as the floor already does, which is what keeps
+`verify_coverage` (the actual gate) and the Critic's Symbol-coverage bullet (`goals-1-3.md:71`)
+untouched — they read `.test-evidence.json`, not the producer.
+
+## Section 4 — Case-B caveat at the sites that state the guarantee (CE1-9)
+
+Three edits, each one sentence, at the concrete places socket 1's guarantee is stated in running
+code/docs (the design artifact's own "Blind spots" section already carries the canonical statement
+this mirrors, `change-evidence-design.md:173-179`):
+
+1. **`test-reference-verify`'s module docstring** (`:2-24`) — the existing floor-level sentence
+   ("A referenced symbol does NOT prove a test exercises the code — only that some test mentions
+   it") gets an executed-level sibling directly after the `--executed-command` description added in
+   §2's usage text: *"An executed verdict proves a changed line ran during some test; it does not
+   prove any assertion constrained that line's behaviour (Case B — see
+   `change-evidence-design.md` § Blind spots)."*
+2. **`verify_coverage`'s docstring** (`gates.py:1754-1788`) — already discusses the
+   `referenced`/`executed` distinction generally (the "day one does" paragraph); append: *"Neither
+   level proves an assertion constrained the covered line's behaviour — `executed` proves execution,
+   not verification."*
+3. **The new `project-state.yaml` key's comment block** (§1 above) already carries the caveat inline
+   — it is the first place a product author reads before declaring the key, which is where CE1-9's
+   "wherever the guarantee is described" is most load-bearing (an author who never reads a docstring
+   still reads the key they are about to set).
+
+No edit to `plugin/skills/critic/goals-1-3.md:71` — its Symbol-coverage bullet already instructs
+"wording is `coverage_level`-scaled and must not be softened," which routes the Critic to whatever
+`verify_coverage` actually prints; adding the caveat there too would be a fourth restatement of the
+same sentence with nothing new to say.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `plugin/templates/project-state.yaml` | New `coverage_producer:` comment block in the existing TEST EXECUTION section (CE1-1, CE1-8) |
+| `plugin/bin/test-reference-verify` | New `--executed-command` flag; new `_build_executed_evidence_fields()`, `_EXECUTED_PRODUCER_TIMEOUT_SECONDS`, `_EXECUTED_VERIFIER_NAME`; `main()` branches on the flag; module docstring gains the Case-B sentence; `import shlex` |
+| `plugin/bin/prawduct-hook` | `cmd_test_evidence`'s overlay block reads `coverage_producer` and conditionally passes `--executed-command` |
+| `plugin/lib/gates.py` | **No change** (CE1-3 — `verify_coverage` already reads `changes_referenced`/`changes_unjudged`/`coverage_level` correctly; docstring gains the Case-B sentence, Section 4 item 2) |
+| `.prawduct/artifacts/change-evidence-design.md` | Open Questions: strike "which real toolchains cannot emit any of the four formats" as retired (Decision above); mark Open Question #1 answered by the four sockets' accumulated precedent |
+| `tests/test_reference_verify_executed.py` (new) | See test plan below |
+
+## Test plan (`tests/test_reference_verify_executed.py`)
+
+Following `tests/test_verify_coverage_gate.py`'s and #620's `tests/test_api_diff_gate.py`'s
+established style — real git repos, real subprocess invocation of `bin/test-reference-verify`, no
+mocking of git or the filesystem. Producer commands are small fixture scripts printing fixed JSON
+to stdout.
+
+1. **No `--executed-command`** — unchanged floor behavior, symbol-grep runs exactly as today
+   (regression guard: this flag must not perturb the existing default path).
+2. **Executed, clean** — producer prints `{"schema": 1, "tracked": ["a.py"], "uncovered": []}` for
+   a diff that only changes `a.py` → `coverage_level: "executed"`, `changes_referenced: ["a.py"]`,
+   `uncovered_lines: []`.
+3. **Executed, some lines uncovered** — producer prints one `uncovered` entry for the changed file
+   → that file is absent from `changes_referenced`, present in `uncovered_lines`; `verify_coverage`
+   run against the resulting record reports `missing-coverage` for it with `coverage_level:
+   executed` severity wording ("has no executing test"), unmodified from today's behavior —
+   confirms CE1-3's "no gate change" claim end-to-end, not just by code inspection.
+4. **Untracked changed file** — a changed file absent from `tracked` → lands in
+   `changes_unjudged`, not `changes_referenced` and not counted as `missing` — the ambiguity
+   Decision 2's `tracked` field exists to resolve.
+5. **Producer exits non-zero** — `--merge-into` run returns exit 2, one `error:` stderr line naming
+   the producer's own stderr; the pre-existing evidence file (if any) is left untouched (`_merge_into`
+   is never reached because the exception fires before it, per §2's dispatch).
+6. **Producer emits invalid JSON / wrong schema / missing `tracked` or `uncovered`** — each is its
+   own case, all raising the same `RuntimeError` shape, all exit 2.
+7. **Producer times out** — a fixture script sleeping past
+   `_EXECUTED_PRODUCER_TIMEOUT_SECONDS` (test overrides the constant to keep the suite fast) →
+   exit 2, same as case 5.
+8. **`uncovered` entry naming a file outside `changed`** — defensively dropped from
+   `uncovered_lines` (only changed files are recorded there) but still contributes to
+   `uncovered_files` for the referenced/unjudged split — a producer over-reporting relative to the
+   requested diff must not corrupt the record it writes, but also must not silently mark a stale
+   entry as covered.
+9. **`prawduct-hook test-evidence record` end-to-end** — `coverage_producer:` declared in
+   `project-state.yaml`, a real repo, real commit → the written `.test-evidence.json` carries
+   `coverage_level: "executed"` and `uncovered_lines`; `coverage_producer` absent → unchanged
+   `coverage_level: "referenced"` record, confirming Decision 6's fallback (demoted, not retired).
+
+## Open items for the build chunk (not resolved here)
+
+- Whether `verify_coverage`'s BLOCKING message should be enriched to cite exact `uncovered_lines`
+  per file when present, rather than only naming the file (as today). `uncovered_lines` is written
+  specifically to make this possible later without a schema change — but CE1-3 promises zero gate
+  logic change for this item, so it is explicitly deferred, not silently assumed.
+  Recommendation: a follow-up item, not this chunk.
+- Exact wording of the fixture producer scripts in the test plan (cosmetic).
+- Whether `_EXECUTED_PRODUCER_TIMEOUT_SECONDS` should be product-configurable — no knob proposed,
+  mirroring #620's identical call on `_API_DIFF_PRODUCER_TIMEOUT_SECONDS` (design §"Open items");
+  revisit only if real-world use proves 60s too tight for a large diff's coverage tool.
+
+## Acceptance (carried from requirements, now with an implementation path)
+
+- [ ] A non-Python product with `coverage_producer:` declared gets a `coverage_level: "executed"`
+      diff-coverage verdict without hand-rolling a verifier — pinned by test-plan cases 2–3, 9.
+- [ ] Prawduct ships no coverage-report parser — `_build_executed_evidence_fields` parses only the
+      two-field `{schema, tracked, uncovered}` envelope, never a tool-native report format
+      (confirmed moot for LCOV/Cobertura/Clover/JaCoCo specifically by the Decision above).
+- [ ] A missing producer reports *unchecked*, never *passed* — unchanged: no `coverage_producer`
+      means the existing floor runs exactly as today, whose `changes_unjudged` behavior is
+      untouched (case 1); a *declared* producer that fails is a loud `error:`, exit 2, never a
+      silent pass (cases 5–7).
+- [ ] The socket defaults to report-only; a blocking threshold is a product opt-in via the existing
+      `coverage_required` key, with no new key introduced for blocking (`verify_coverage` itself is
+      unmodified — CE1-3).
+- [ ] The Case-B limit (covered ≠ verified) is stated wherever the guarantee is stated — three doc
+      sites, Section 4.
+
+## Evidence / references
+
+- `documentation/issues/249-requirements.md` — CE1-1–10, Decisions 1–8, grounding facts.
+- `.prawduct/artifacts/change-evidence-design.md:104-125,171-179,303-318` — socket 1's design-doc
+  entry, the Blind spots / Case-B statement this design's Section 4 mirrors, and the two Open
+  Questions this design settles/retires.
+- `plugin/bin/test-reference-verify:210-277,291-376` — `_build_evidence_fields` (the floor,
+  unmodified), `main()`'s dispatch (the exact insertion point for the new branch), `_merge_into`
+  (reused as-is — the new function returns the same shape it already merges).
+- `plugin/lib/gates.py:56-69,349-389,1754-1881` — `_EVIDENCE_REQUIRED_FIELDS`/
+  `_EVIDENCE_COVERAGE_FIELDS`, `_validate_evidence_schema` (confirms `uncovered_lines` needs no
+  entry), `verify_coverage` (confirms it needs no code change).
+- `plugin/bin/prawduct-hook:3898-3922` — the exact overlay call site Section 3 extends.
+- `documentation/issues/620-design.md` §"Decision 4", §"Section 2" — the sibling precedent for a
+  producer-envelope `schema` field, a subprocess-with-timeout helper shape, and the exact
+  declaration-surface pattern (own key per socket) this design's opening Decision generalizes from.
+- `documentation/issues/618-design.md:20-21,86-88` — the sibling precedent for a producer key with
+  no paired `*_required` key (this item's own shape, since `coverage_required` predates the
+  four-socket design and is reused rather than duplicated).
+- `documentation/issues/619-design.md:17-18,174-179` — the sibling precedent for a mandatory
+  placeholder in a producer command (`{base}`); socket 1's producer needs none, noted for
+  completeness since design must show it considered the question, not merely omit it.

--- a/documentation/issues/249-requirements.md
+++ b/documentation/issues/249-requirements.md
@@ -1,0 +1,319 @@
+# Issue #249 — Coverage: The Coverage Floor Is Python-Only: Requirements
+
+`status: draft · stage: requirements · area: coverage · added: 2026-08-23 · revised: 2026-08-31 ·
+source: scheduled backlog session · issue: https://github.com/brookstalley/prawduct/issues/249`
+
+Related: siblings #618 (socket 2 — blast radius, requirements+design merged), #619 (socket 3 —
+diff-scoped mutation, requirements+design merged), #620 (socket 4 — API diff, requirements+design
+merged); GOV-2R8K, the single home of the shared four-socket contract
+(`.prawduct/artifacts/change-evidence-design.md`), which this document must not restate. Also
+related: #556 (a residual gap in the language-agnostic green-is-evidence trigger this item's
+producer partially closes as a side effect — see Grounding facts and Decision 7).
+
+## Problem
+
+The framework's only shipped answer to "is this change exercised at all?" is
+`plugin/bin/test-reference-verify`'s symbol-grep, which understands only Python `def`/`class`
+syntax. On a polyglot or non-Python repo the framework's "the tests actually referenced the
+changed code" guarantee does not exist — and because this mechanism feeds `verify_coverage`, a
+BLOCKING Goal 1 Critic check, `architecture.md` names it "the most serious instance found" of the
+Python-specificity norm's violation. Socket 1 is the instrument for exactly this gap: the
+product's own coverage tooling plus an existing diff-coverage normalizer, whose verdict prawduct
+consumes rather than re-derives. The design rationale, the four-socket contract shape, and the
+default report-only posture all live in `change-evidence-design.md` and are not re-derived here;
+this document grounds socket 1's five acceptance criteria against the current codebase and
+resolves the decisions that document deliberately left open where they are scoped to this socket
+alone.
+
+## Grounding facts
+
+Re-verified against `origin/develop` at commit `7583fb29` (2026-08-31), correcting an earlier pass
+(commit `f1d78cc5`, 2026-08-23) whose line citations had drifted and whose GOV-6X2N reference no
+longer matches the tree — both corrected below and flagged inline where they matter:
+
+- **The shipped floor's complete output shape is five fields, and `coverage_level` is a hardcoded
+  literal, never computed.** `_build_evidence_fields` (`plugin/bin/test-reference-verify:271-276`)
+  returns exactly `verifier`, `coverage_level` (always the string `"referenced"`), `tests_executed`,
+  `changes_referenced`, `changes_unjudged` — there is no sixth field, and no code path in this file
+  ever assigns `"executed"`. `VERIFIER_NAME` (`:58`) is `"test-reference-verify (floor:
+  symbol-grep)"`. Unchanged since the 2026-08-23 pass (`test-reference-verify` carries zero diff
+  against it in the current tree).
+- **The Python-specificity gate is a single, complete predicate.** `_is_python_file`
+  (`plugin/bin/test-reference-verify:142-145`) is `path.suffix == ".py" or _looks_like_python(path)`
+  (the latter checking for a Python shebang on extensionless scripts, `:126-140`); symbol extraction
+  is `_PY_SYMBOL_RE` (`:64-67`), matching only `def`/`async def`/`class` lines. Any file failing
+  `_is_python_file` is routed straight to `changes_unjudged` at the call site (`:239`) — never
+  silently passed, which is the mechanism's one already-correct property this item must not
+  regress.
+- **The `referenced` vs `executed` distinction the design doc invokes is real, ratified plumbing —
+  but only one side of it has ever been populated.** `_EVIDENCE_COVERAGE_LEVELS =
+  frozenset({"referenced", "executed"})` (`plugin/lib/gates.py:70`, unchanged) is a validated enum;
+  `verify_coverage`'s own docstring names the gap directly: *"The reasoning does not survive a
+  `coverage_level: executed` verifier, whose evidence is execution: no in-plugin writer emits that
+  level today, and the day one does is the day this needs to ask"* (`gates.py:1785-1787` — the
+  2026-08-23 pass cited `:1774-1776`; an unrelated verify-resolutions docstring edit earlier in the
+  file shifted every line below it by +11, corrected throughout this revision). A repo-wide search
+  confirms `"executed"` is never assigned as a `coverage_level` value anywhere in shipped code — it
+  exists only as the enum member, as prose telling product-authored verifiers what they *should*
+  emit, and as one dead conditional branch in `verify_coverage`'s severity wording
+  (`gates.py:1868-1869`: `if coverage_level == "executed": suffix = "has no executing test."`).
+  Socket 1 is precisely "the day one does."
+- **`verify_coverage`'s gating logic is fully report-only/blocking-switchable today, and the switch
+  is already the right one for this socket.** `coverage_required` (read via `read_bool_yaml_key`)
+  gates the entire check: false (the default) → `"skipped: coverage_required is false (default in
+  v1.4)"`, return 0, no enforcement at all (`gates.py:1792-1794`). When true, changed files split
+  three ways: `skipped` (unjudged or deleted, reported only — the list built at `:1844-1847`,
+  printed at `:1852-1857`), `missing` (changed, not referenced, not skipped — the actual gate
+  population, `:1848-1851`), and everything else passes (`:1858-1863`). Severity wording is already
+  `coverage_level`-scaled (`:1865-1874`). The full function runs `gates.py:1754-1881`. This is the
+  same file `changes_unjudged` mechanics used across sockets 2–4's "unchecked, never passed"
+  precedent, native to socket 1's own gate.
+- **No per-language or diff-coverage-tool declaration key exists anywhere in `project-state.yaml`,
+  template or live.** An exhaustive case-insensitive search for `diff-cover`, `diff-test-coverage`,
+  `lcov`, `cobertura`, `clover`, `jacoco` returns zero matches in either
+  `plugin/templates/project-state.yaml` or `.prawduct/project-state.yaml`. The only existing
+  declaration surface in the COVERAGE EVIDENCE / TEST EXECUTION blocks
+  (`plugin/templates/project-state.yaml:329-375` — shifted from the 2026-08-23 pass's `326-372` by
+  an unrelated `active_build_plan` comment edit earlier in the file; a further `sentinel_command:`
+  block for the unrelated `audit-learnings` sentinel-grading feature was also added just past this
+  range since that pass, and names no coverage tool) is `coverage_required`, `test_command`/
+  `test_commands`, and `tests_dirs` — none of which name a coverage tool or report format. Socket
+  1's producer declaration is greenfield, exactly like its siblings'.
+- **No LCOV/Cobertura/Clover/JaCoCo parser exists anywhere in the repo, confirming the issue's own
+  2026-08-07 Correction has not regressed.** The only files mentioning any of these formats are
+  `change-evidence-design.md` itself; `test-reference-verify`'s only parsing is its own Python
+  regex and plain-text substring matching — it ingests no external coverage-report format. This is
+  the concrete evidence behind the issue's own acceptance criterion "prawduct ships no
+  coverage-report parser."
+- **The evidence store's `kind` enum is fail-closed and has no slot for a coverage-specific fact,
+  same open state as every sibling.** `KNOWN_KINDS = frozenset({"review", "resolution",
+  "disposition", "guard-refusal"})` (`plugin/lib/evidence.py:84`, unchanged); `append_fact` rejects
+  any other kind outright (`:191-196`, unchanged — the 17 lines `evidence.py` gained since the
+  2026-08-23 pass are inside `_cmd_list`, well after this range, and do not touch it). `test-run` is
+  named reserved-but-unimplemented (`.prawduct/artifacts/data-model.md:26-27,57` — unchanged —
+  *"extending the store to subsume [test-run/PR-review evidence] is design direction, not yet a
+  ratified norm"*), and is not itself a coverage-specific kind. This is the identical open question
+  #618/#619/#620 already flag for their own sockets, not new to socket 1.
+- **A separate, already-partially-addressed governance consumer of the same root cause exists and
+  is out of this item's scope — correcting the 2026-08-23 pass's tracking reference.** That pass
+  named the residual gap "GOV-6X2N," an informal id that resolves to no filed issue (a repo-wide
+  search finds it nowhere). The code itself has since been corrected on exactly this point: the
+  comment above `_GREEN_IS_EVIDENCE_DIRECTIVE` (`plugin/bin/prawduct-hook:3001-3013`) now states
+  plainly that its own *predecessor* comment "previously said it was 'tracked separately' while
+  naming no item, which is how it stayed open long enough to be worth this warning: a tracking
+  reference that points at no id is not a tracking reference" — and names the real, filed successor
+  directly: **#556** (`brookstalley/prawduct#556`, cited at `:3007`), *"governance: green-is-evidence
+  is blind to unreferenced code"* — a Python file whose symbols no test mentions lands in neither
+  `changes_referenced` nor `changes_unjudged`, so `_GREEN_IS_EVIDENCE_DIRECTIVE` (`:3016-3029`,
+  which fires off `_evidence_changed_judged_code`, `:3031+`, reading the same `changes_referenced`
+  field) stays silent on it. #556 is itself `related: COV-4M2J` — this issue. The predecessor
+  limitation ("empty in every non-Python product") is separately closed (#348, unchanged). Once a
+  real executed-level producer exists for a language, #556's gap narrows for that language as a side
+  effect (an executed-level record still cannot see a wholly untested symbol, but the languages
+  where the directive can fire at all grows) — worth recording so design does not have to
+  rediscover it, but fixing `prawduct-hook`'s directive logic is not this item's work.
+- **`test-reference-verify` is explicitly named, by the ratified architecture norm itself, as the
+  socket this item must eventually retire toward — not delete outright.** `architecture.md:78`'s
+  Retroactivity paragraph (content unchanged since the 2026-08-23 pass; the file's only diff since
+  is a later addition to the same paragraph, about an unrelated site): *"Confirmed violating:
+  `plugin/bin/test-reference-verify` (`_PY_SYMBOL_RE`, `_is_python_file` — and it feeds
+  `verify-coverage`, a BLOCKING Goal 1 check that therefore passes silently on Swift/Rust/C#, the
+  most serious instance found)."* The design doc's own Open Questions name the retirement path as
+  unresolved: *"leaving it in place alongside a working socket would be two homes for one fact"*
+  (`change-evidence-design.md:308-310`, unchanged) — this item does not resolve that question, only
+  avoids worsening it.
+- **The current Critic protocol's citation points are unchanged since the 2026-08-23 pass** (a diff
+  check against the current tree confirms zero changes to `plugin/skills/critic/goals-1-3.md`).
+  Self-containment is `:3-4`, the "Before you review" checklist runs `:19-21` and ends with *"Run
+  `prawduct-hook test-status` and `prawduct-hook verify-coverage` (Goal 1). Nothing else executes"*
+  at `:21`, and the Symbol-coverage bullet reviewers actually follow is at `:71`, reading in full:
+  *"**Symbol coverage:** run `prawduct-hook verify-coverage`. Exit 1 with `missing-coverage:` stderr
+  lines → BLOCKING per missing file; quote each verbatim — wording is `coverage_level`-scaled and
+  must not be softened."* Socket 1's design pass can cite these directly.
+- **The precedent for "requirements numbers every decision, including the ones punted to design"
+  is established across all three sibling docs, and the declaration-surface-count question is
+  explicitly left for whichever socket's design lands first.** #620's own Scope-out states: *"cross-
+  socket, not decided for socket 4 in isolation; whichever socket's design lands first should
+  settle it, or it is settled directly on the design doc."* Socket 1 follows the identical shape
+  below rather than attempting to resolve that cross-socket question here — and, per the Acceptance
+  section below, this item's own design pass is now free to settle it, since no sibling design has.
+
+## Decisions
+
+Scoped to socket 1 alone — none of these reopen the shared four-socket contract, which stays owned
+by `change-evidence-design.md`.
+
+**1. A declared producer is an opaque invocation or result-artifact path that itself already emits
+a normalized diff-coverage verdict — prawduct validates no coverage-report format and ships no
+LCOV/Cobertura/Clover/JaCoCo parser.** This is the design doc's own corrected contract (the
+2026-08-07 Correction the issue's Evidence section records) and mirrors `test_command`'s "declare
+it — don't wrap it" precedent every sibling reuses. The product runs its native coverage tool plus
+an existing diff-coverage normalizer (`diff-cover`, `diff-test-coverage`, or any other); prawduct
+never touches the underlying report format's bytes.
+
+**2. The minimal verdict primitive is fixed by the design doc, not deferred: uncovered changed
+lines as `file:line` pairs.** Unlike socket 4 (whose primitive was explicitly left to design),
+socket 1's shape is already stated as the required contract, "not an afterthought"
+(`change-evidence-design.md`'s Socket 1 section) — this document requires it directly. Exact
+serialization (whether pairs are encoded as strings, tuples, or ranges) is left open to design.
+
+**3. A producer satisfying Decisions 1–2 populates `coverage_level: "executed"`, activating
+plumbing that already exists and is already dormant — no new enum value, and no change to
+`_EVIDENCE_COVERAGE_LEVELS` or `verify_coverage`'s existing severity-wording branch is needed.**
+`gates.py`'s own docstring names this exact moment ("the day one does is the day this needs to
+ask") as the trigger for re-examining the function's assumptions — this item is that trigger, and
+design must re-read that docstring's caveat before extending the function.
+
+**4. Whether the executed-level line data extends the existing F4a schema (`changes_referenced`/
+`changes_unjudged`, file-granularity) with new field(s), or is carried as a separate shape
+`verify_coverage` (or a successor) reads alongside it, is explicitly deferred to design.** The two
+shapes answer different-grained questions — "was this file referenced at all" vs. "which lines in
+it executed" — and design must pick one rather than assume the file-level fields can silently
+absorb line-level data. Whichever is chosen must respect additive-only field evolution and loud
+(never silent) handling of a schema-ahead or malformed record, per `data-model.md`'s existing
+forward-incompatibility rules — the same constraint every sibling states for its own storage
+question.
+
+**5. `coverage_required` remains the single activation/blocking lever for socket 1 — no new
+project-state.yaml boolean key is introduced.** Unlike sockets 2–4, which each need a brand-new
+opt-in key, socket 1's lever already exists: `verify_coverage` already reads `coverage_required`
+as exactly the report-only/blocking switch this socket needs. Reusing it, rather than adding a
+second key that would mean the same thing, is what "declare it, don't wrap it" implies once a
+lever already exists.
+
+**6. `test-reference-verify` is demoted to socket 1's fallback producer, unchanged in its own
+behavior, when no executed-level producer is declared — it is not retired by this item.** This is
+what preserves the Python-specificity norm's fail-open guarantee for every product that has not
+yet adopted a stronger producer, and is the design doc's own explicit adoption path (*"`test-
+reference-verify` is demoted, not deleted... it becomes socket 1's fallback producer when no
+better one is declared"*). `test-reference-verify`'s actual retirement is the design doc's own
+open question (`change-evidence-design.md:308-310`) and is not resolved here.
+
+**7. The #556 governance consumer of `changes_referenced` is not this item's work, but this item's
+producer narrows its blind spot for adopting languages as a side effect.** #556 is separately filed
+(correcting the earlier pass's untracked "GOV-6X2N" reference — see Grounding facts), its
+predecessor limitation is already closed (#348), and its residual gap (a symbol declared but never
+referenced by any test, in neither evidence list) narrows for any language that adopts an
+executed-level producer under this item — but fixing `prawduct-hook`'s directive logic itself is
+out of scope here.
+
+**8. Documentation must state the Case-B limit wherever socket 1's guarantee is described, exactly
+as the design doc requires.** An `executed` verdict proves the changed line ran during a test; it
+proves nothing about whether any assertion constrained that line's behavior. This item does not
+close that gap (socket 3 does) — it must not be described as if it does.
+
+## Requirements
+
+MUST unless marked SHOULD.
+
+- **CE1-1** A product declares its socket 1 producer as an opaque invocation or result-artifact
+  path; prawduct validates no coverage-report format name and ships no per-format parser or
+  allowlist (Decision 1).
+- **CE1-2** The verdict is uncovered changed lines as `file:line` pairs, matching the design doc's
+  stated primitive verbatim (Decision 2); exact serialization is out of this document's scope
+  (design-stage).
+- **CE1-3** A producer satisfying CE1-1/CE1-2 populates `coverage_level: "executed"` in the merged
+  evidence record — the enum value and `verify_coverage`'s severity branch for it already exist and
+  require no new gate logic (Decision 3).
+- **CE1-4** Whether executed-level line data extends the existing `changes_referenced`/
+  `changes_unjudged` schema or is carried in a separate shape is a design-stage decision, not
+  resolved here (Decision 4); whichever is chosen respects additive-only field evolution and loud
+  (never silent) handling of a schema-ahead record.
+- **CE1-5** `coverage_required` remains the sole activation/blocking lever for this socket; no new
+  project-state.yaml boolean key is introduced for it (Decision 5).
+- **CE1-6** `test-reference-verify` continues to serve as socket 1's fallback producer, emitting
+  `coverage_level: "referenced"` unchanged, whenever no executed-level producer is declared —
+  demoted, not retired, by this item (Decision 6).
+- **CE1-7** A changed file with neither a declared executed-level producer's verdict nor an
+  applicable `test-reference-verify` floor result continues to report `changes_unjudged`, never
+  coalesced with a passing verdict — the existing, already-correct behavior
+  (`gates.py:1844-1851`) this item must not regress.
+- **CE1-8** Prawduct's own code contains no LCOV/Cobertura/Clover/JaCoCo parser and no diff-coverage
+  engine of its own, confirmed absent today and required to stay that way; the verdict is consumed
+  from the product's own coverage tool plus an existing diff-coverage normalizer, never re-derived
+  (Decision 1).
+- **CE1-9** Documentation states, wherever socket 1's guarantee is described, that an `executed`
+  verdict proves the changed line ran during tests and never that any assertion constrained its
+  behavior (Case B) (Decision 8).
+- **CE1-10** Fixing #556's directive-silence gap is out of scope for this item, though its residual
+  narrows as a side effect once a language adopts an executed-level producer (Decision 7).
+
+## Acceptance
+
+Restated from the issue body, grounded against the current tree:
+
+- [ ] A non-Python product gets a diff-coverage verdict without hand-rolling a verifier.
+- [ ] Prawduct ships no coverage-report parser — the verdict is consumed, never re-derived.
+- [ ] A missing producer reports *unchecked*, never *passed* — inherited automatically once
+      `test-reference-verify` is the fallback (Decision 6) and its existing `changes_unjudged`
+      handling is preserved (CE1-7).
+- [ ] The socket defaults to report-only; a blocking threshold is a product opt-in via the existing
+      `coverage_required` key, with no new key introduced (CE1-5).
+- [ ] The Case-B limit (covered ≠ verified) is stated wherever the guarantee is stated (CE1-9).
+
+## Scope-out (this item)
+
+- The shared four-socket contract, its rationale, blind spots, and adoption/rollout mechanics —
+  `change-evidence-design.md`'s territory, per the issue's own scope-out.
+- Sockets 2–4 (#618, #619, #620) — sibling items with their own requirements passes, already
+  merged.
+- Whether all four sockets share one `project-state.yaml` declaration surface or four
+  (`change-evidence-design.md` Open Question #1) — cross-socket, not decided for socket 1 in
+  isolation; no sibling design has settled it yet, so socket 1's own design pass may settle it or
+  defer it again.
+- The exact declaration key name for the producer invocation, the verdict's exact serialization
+  format, whether the F4a schema is extended in place or replaced by a parallel shape (Decision 4),
+  and any persistence choice beyond `.test-evidence.json` — all design-stage deliverables.
+- Retiring `test-reference-verify` or otherwise resolving its Python-specificity violation in
+  general — tracked by the Python-specificity migration (LNG-5W8R) and the design doc's own
+  retirement open question (`change-evidence-design.md:308-310`); this item only adds a
+  stronger fallback-first producer alongside it.
+- Fixing #556 (`_GREEN_IS_EVIDENCE_DIRECTIVE`'s silence on unjudged changesets) — separately filed
+  and tracked (Decision 7).
+- Selecting or wiring a specific diff-coverage normalizer for any particular ecosystem — a
+  product's own declaration, per the socket contract.
+- Which real toolchains cannot produce any of LCOV/Cobertura/Clover/JaCoCo — the design doc's own
+  explicit Open Question, carried forward, not resolved here.
+
+## Evidence / references
+
+- `.prawduct/artifacts/change-evidence-design.md` — the shared four-socket design; §"Socket 1 —
+  Exercised? (diff coverage)", the defect table, Open Questions.
+- `plugin/bin/test-reference-verify:58,64-67,126-145,239,271-277` — `VERIFIER_NAME`,
+  `_PY_SYMBOL_RE`, `_looks_like_python`/`_is_python_file`, the `changes_unjudged` routing, and
+  `_build_evidence_fields`'s complete five-field output shape.
+- `plugin/lib/gates.py:70,1754-1881,1785-1787,1792-1794,1844-1863,1865-1874` —
+  `_EVIDENCE_COVERAGE_LEVELS`, `verify_coverage`'s full gating logic, its own docstring naming the
+  dormant `executed` case, the `coverage_required` report-only switch, and the
+  `skipped`/`missing`/severity-wording split. (Re-verified 2026-08-31; the 2026-08-23 pass's
+  citations for this function were `1743-1870`/`1774-1776`/`1781-1783`/`1833-1863`/`1857-1858` — an
+  unrelated verify-resolutions docstring edit earlier in the file shifted everything from
+  `verify_coverage` onward by +11 lines, corrected here.)
+- `plugin/templates/project-state.yaml:329-375` — the COVERAGE EVIDENCE / TEST EXECUTION blocks:
+  `coverage_required`, `test_command`/`test_commands`, `tests_dirs` — confirming no existing
+  per-format declaration key. (Shifted from `326-372` by an unrelated `active_build_plan` comment
+  edit earlier in the file; re-verified 2026-08-31.)
+- `plugin/lib/evidence.py:84,191-196` — `KNOWN_KINDS` and `append_fact`'s fail-closed rejection of
+  unregistered kinds. Unaffected by the 17-line addition this file gained since 2026-08-23 (inside
+  `_cmd_list`, well after this range).
+- `.prawduct/artifacts/data-model.md:26-27,57` — the reserved-but-unratified `test-run`/`pr-review`/
+  `promotion` kinds, the open question `change-evidence-design.md` inherits and this item does not
+  resolve.
+- `plugin/bin/prawduct-hook:3001-3013,3016-3029,3031` — the comment above
+  `_GREEN_IS_EVIDENCE_DIRECTIVE` explicitly correcting its own predecessor's untracked reference and
+  naming `brookstalley/prawduct#556` as the filed successor (re-verified 2026-08-31; the 2026-08-23
+  pass cited `2780-2803` and the informal, unfiled "GOV-6X2N" — both corrected here), the directive
+  constant itself, and `_evidence_changed_judged_code`.
+- `.prawduct/artifacts/architecture.md:78` — the Retroactivity paragraph naming
+  `test-reference-verify` a confirmed Python-specificity violation, "the most serious instance
+  found." (Content unchanged at this line since 2026-08-23; the paragraph gained an unrelated
+  addition about a different site.)
+- `plugin/skills/critic/goals-1-3.md:3-4,19-21,71` — the self-contained protocol, the "Before you
+  review" checklist ending in "nothing else executes," and the Symbol-coverage bullet. Confirmed
+  unchanged since the 2026-08-23 pass (zero diff against this file).
+- `brookstalley/prawduct#556` — "governance: green-is-evidence is blind to unreferenced code,"
+  `related: COV-4M2J` (this issue); the correctly-filed successor to the earlier pass's untracked
+  "GOV-6X2N" reference.
+- `documentation/issues/618-requirements.md`, `619-requirements.md`, `620-requirements.md` — the
+  sibling socket requirements passes this document follows in structure and mirrors for shared
+  open questions (declaration-surface count, evidence storage).


### PR DESCRIPTION
Lands `documentation/issues/249-requirements.md` and `249-design.md` — the socket-1 documents of the four-socket coverage set whose sockets 2–4 (#618/#619/#620) already have their docs on develop. Cherry-picked from the cloud-session draft (eaad0e99) and re-checked against develop before landing: every load-bearing absence claim still holds (`coverage_producer` exists nowhere, `"executed"` is assigned as a `coverage_level` by no shipped path, `KNOWN_KINDS` unchanged, `test-reference-verify` still present). Only `gates.py` line citations drifted; named in the change-log entry rather than restated.

Doc-only PR — review gates skipped per `check-pr-doc-only` (3 files, none judgeable). Change-log entry `scope=coverage-socket-1-docs`, no `release=`.

#249 stays open by design: the docs land, nothing is implemented. No backlog item closes at merge.